### PR TITLE
fix: FE loading button on login page, resolves #1122

### DIFF
--- a/Client/src/Pages/Auth/Login.jsx
+++ b/Client/src/Pages/Auth/Login.jsx
@@ -390,8 +390,6 @@ const Login = () => {
 	const [errors, setErrors] = useState({});
 	const [step, setStep] = useState(0);
 
-	useEffect(() => {}, [authState.isLoading]);
-
 	useEffect(() => {
 		if (authToken) {
 			navigate("/monitors");

--- a/Client/src/Pages/Auth/Login.jsx
+++ b/Client/src/Pages/Auth/Login.jsx
@@ -4,6 +4,7 @@ import { Box, Button, Stack, Typography } from "@mui/material";
 import { useTheme } from "@emotion/react";
 import { credentials } from "../../Validation/validation";
 import { login } from "../../Features/Auth/authSlice";
+import LoadingButton from "@mui/lab/LoadingButton";
 import { useDispatch, useSelector } from "react-redux";
 import { createToast } from "../../Utils/toastUtils";
 import { networkService } from "../../main";
@@ -231,6 +232,7 @@ const StepTwo = ({ form, errors, onSubmit, onChange, onBack }) => {
 	const theme = useTheme();
 	const navigate = useNavigate();
 	const inputRef = useRef(null);
+	const authState = useSelector((state) => state.auth);
 
 	useEffect(() => {
 		if (inputRef.current) {
@@ -302,10 +304,11 @@ const StepTwo = ({ form, errors, onSubmit, onChange, onBack }) => {
 							<ArrowBackRoundedIcon />
 							Back
 						</Button>
-						<Button
+						{/* <LoadingButton
 							variant="contained"
 							color="primary"
 							type="submit"
+							loading={authState.isLoading}
 							disabled={errors.password && true}
 							sx={{
 								width: "30%",
@@ -317,7 +320,15 @@ const StepTwo = ({ form, errors, onSubmit, onChange, onBack }) => {
 							}}
 						>
 							Continue
-						</Button>
+						</LoadingButton> */}
+						<LoadingButton
+							type="submit"
+							variant="contained"
+							color="primary"
+							loading={authState.isLoading}
+						>
+							{"Continue"}
+						</LoadingButton>
 					</Stack>
 				</Box>
 				<Box
@@ -378,6 +389,8 @@ const Login = () => {
 	});
 	const [errors, setErrors] = useState({});
 	const [step, setStep] = useState(0);
+
+	useEffect(() => {}, [authState.isLoading]);
 
 	useEffect(() => {
 		if (authToken) {

--- a/Client/src/Pages/Auth/Login.jsx
+++ b/Client/src/Pages/Auth/Login.jsx
@@ -304,7 +304,7 @@ const StepTwo = ({ form, errors, onSubmit, onChange, onBack }) => {
 							<ArrowBackRoundedIcon />
 							Back
 						</Button>
-						{/* <LoadingButton
+						<LoadingButton
 							variant="contained"
 							color="primary"
 							type="submit"
@@ -320,14 +320,6 @@ const StepTwo = ({ form, errors, onSubmit, onChange, onBack }) => {
 							}}
 						>
 							Continue
-						</LoadingButton> */}
-						<LoadingButton
-							type="submit"
-							variant="contained"
-							color="primary"
-							loading={authState.isLoading}
-						>
-							{"Continue"}
 						</LoadingButton>
 					</Stack>
 				</Box>

--- a/Client/src/Utils/Theme/globalTheme.js
+++ b/Client/src/Utils/Theme/globalTheme.js
@@ -81,7 +81,13 @@ const baseTheme = (palette) => ({
 							},
 						},
 						{
-							props: (props) => props.variant === "contained" && props.disabled,
+							props: (props) => {
+								return (
+									props.variant === "contained" &&
+									props.disabled &&
+									props.classes.loadingIndicator === undefined // Do not apply to loading button
+								);
+							},
 							style: {
 								backgroundColor: `${theme.palette.secondary.main} !important`,
 								color: `${theme.palette.secondary.contrastText} !important`,
@@ -101,6 +107,7 @@ const baseTheme = (palette) => ({
 				}),
 			},
 		},
+
 		MuiIconButton: {
 			styleOverrides: {
 				root: ({ theme }) => ({


### PR DESCRIPTION
This PR replaces the regular button on the login page with a `LoadingButton` to indicate loading is in progress.

- [x] Replace `Button` with `LoadingButton`
  - [x] Use auth slice's loading state with the `LoadingButton` to indicate loading 
- [x] Update theme to selectively apply button styling, ignore loading button


[Screencast from 2024-11-27 13-58-56.webm](https://github.com/user-attachments/assets/01cfcc9e-fa6b-433d-bdff-1136ebaae8b9)
