### PR TITLE
feat: create monitor display name, resovles #992

### DIFF
--- a/Client/src/Pages/Infrastructure/CreateMonitor/index.jsx
+++ b/Client/src/Pages/Infrastructure/CreateMonitor/index.jsx
@@ -3,6 +3,7 @@ import { Box, Stack, Typography } from "@mui/material";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { useSelector, useDispatch } from "react-redux";
 import { infrastructureMonitorValidation } from "../../../Validation/validation";
+import { parseDomainName } from "../../../Utils/monitorUtils";
 import {
 	createInfrastructureMonitor,
 	checkInfrastructureEndpointResolution,
@@ -80,6 +81,15 @@ const CreateInfrastructureMonitor = () => {
 	const handleBlur = (event, appendID) => {
 		event.preventDefault();
 		const { value, id } = event.target;
+
+		let name = idMap[id] ?? id;
+		if (name === "url" && infrastructureMonitor.name === "") {
+			setInfrastructureMonitor((prev) => ({
+				...prev,
+				name: parseDomainName(value),
+			}));
+		}
+
 		if (id?.startsWith("notify-email-")) return;
 		const { error } = infrastructureMonitorValidation.validate(
 			{ [id ?? appendID]: value },

--- a/Client/src/Pages/Monitors/CreateMonitor/index.jsx
+++ b/Client/src/Pages/Monitors/CreateMonitor/index.jsx
@@ -17,6 +17,7 @@ import Checkbox from "../../../Components/Inputs/Checkbox";
 import Breadcrumbs from "../../../Components/Breadcrumbs";
 import { getUptimeMonitorById } from "../../../Features/UptimeMonitors/uptimeMonitorsSlice";
 import "./index.css";
+import { parseDomainName } from "../../../Utils/monitorUtils";
 
 const CreateMonitor = () => {
 	const MS_PER_MINUTE = 60000;
@@ -90,7 +91,7 @@ const CreateMonitor = () => {
 			}
 		};
 		fetchMonitor();
-	}, [monitorId, authToken, monitors]);
+	}, [monitorId, authToken, monitors, dispatch, navigate]);
 
 	const handleChange = (event, name) => {
 		const { value, id } = event.target;
@@ -137,6 +138,16 @@ const CreateMonitor = () => {
 				else delete updatedErrors[name];
 				return updatedErrors;
 			});
+		}
+	};
+
+	const onUrlBlur = (event) => {
+		const { value } = event.target;
+		if (monitor.name === "") {
+			setMonitor((prev) => ({
+				...prev,
+				name: parseDomainName(value),
+			}));
 		}
 	};
 
@@ -257,6 +268,7 @@ const CreateMonitor = () => {
 							placeholder={monitorTypeMaps[monitor.type].placeholder || ""}
 							value={monitor.url}
 							onChange={handleChange}
+							onBlur={onUrlBlur}
 							error={errors["url"]}
 						/>
 						<Field

--- a/Client/src/Pages/PageSpeed/CreatePageSpeed/index.jsx
+++ b/Client/src/Pages/PageSpeed/CreatePageSpeed/index.jsx
@@ -17,6 +17,7 @@ import Field from "../../../Components/Inputs/Field";
 import Select from "../../../Components/Inputs/Select";
 import Checkbox from "../../../Components/Inputs/Checkbox";
 import Breadcrumbs from "../../../Components/Breadcrumbs";
+import { parseDomainName } from "../../../Utils/monitorUtils";
 import "./index.css";
 
 const CreatePageSpeed = () => {
@@ -91,6 +92,16 @@ const CreatePageSpeed = () => {
 				else delete updatedErrors[name];
 				return updatedErrors;
 			});
+		}
+	};
+
+	const onUrlBlur = (event) => {
+		const { value } = event.target;
+		if (monitor.name === "") {
+			setMonitor((prev) => ({
+				...prev,
+				name: parseDomainName(value),
+			}));
 		}
 	};
 
@@ -213,6 +224,7 @@ const CreatePageSpeed = () => {
 							placeholder="google.com"
 							value={monitor.url}
 							onChange={handleChange}
+							onBlur={onUrlBlur}
 							error={errors["url"]}
 						/>
 						<Field

--- a/Client/src/Utils/monitorUtils.js
+++ b/Client/src/Utils/monitorUtils.js
@@ -15,3 +15,28 @@ export const getLastChecked = (checks, duration = true) => {
 	}
 	return new Date() - new Date(checks[0].createdAt);
 };
+
+export const parseDomainName = (url) => {
+	url = url.replace(/^https?:\/\//, "");
+	// Remove leading/trailing dots
+	url = url.replace(/^\.+|\.+$/g, "");
+	// Split by dots
+	const parts = url.split(".");
+	// Remove common prefixes and empty parts
+	const cleanParts = parts.filter((part) => part !== "www" && part !== "");
+	if (cleanParts.length > 2) {
+		// Don't know how to parse this, return URL
+		return url;
+	}
+	// If there's more than one part, take the second to last
+	const domainPart =
+		cleanParts.length > 1
+			? cleanParts[cleanParts.length - 2]
+			: cleanParts[cleanParts.length - 1];
+
+	if (domainPart) {
+		return domainPart.charAt(0).toUpperCase() + domainPart.slice(1).toLowerCase();
+	}
+
+	return url;
+};


### PR DESCRIPTION
This PR implements adding a name to a monitor when a URL is entered

Parsing a domain from a URL is non-trivial, so this is a pretty simple version.  It tries to figure out what the domain is, and if it can't, it just returns the original URL.

www.google.com -> Google
www.test.google.com -> www.test.google.com
123.123.123 -> 123.123.123
www.google -> Google
www.google. -> Google
.www.google.com -> Google
...google.com... -> Google

There are _many_ edge cases, so if anyone wants to spend time coming up with a better algorithm by all means, please do :joy: