### PR TITLE
feat: fe sidebar restructure

### DIFF
--- a/Client/src/Components/Sidebar/index.jsx
+++ b/Client/src/Components/Sidebar/index.jsx
@@ -47,15 +47,9 @@ import Folder from "../../assets/icons/folder.svg?react";
 import "./index.css";
 
 const menu = [
-	{
-		name: "Dashboard",
-		icon: <Dashboard />,
-		nested: [
-			{ name: "Monitors", path: "monitors", icon: <Monitors /> },
-			{ name: "Pagespeed", path: "pagespeed", icon: <PageSpeed /> },
-			{ name: "Infrastructure", path: "infrastructure", icon: <Integrations /> },
-		],
-	},
+	{ name: "Monitors", path: "monitors", icon: <Monitors /> },
+	{ name: "Pagespeed", path: "pagespeed", icon: <PageSpeed /> },
+	{ name: "Infrastructure", path: "infrastructure", icon: <Integrations /> },
 	{ name: "Incidents", path: "incidents", icon: <Incidents /> },
 	// { name: "Status pages", path: "status", icon: <StatusPages /> },
 	{ name: "Maintenance", path: "maintenance", icon: <Maintenance /> },

--- a/Client/src/Pages/PageSpeed/index.jsx
+++ b/Client/src/Pages/PageSpeed/index.jsx
@@ -8,7 +8,6 @@ import "./index.css";
 import { useNavigate } from "react-router";
 import PropTypes from "prop-types";
 import Breadcrumbs from "../../Components/Breadcrumbs";
-import Greeting from "../../Utils/greeting";
 import SkeletonLayout from "./skeleton";
 import Card from "./card";
 import { networkService } from "../../main";
@@ -82,11 +81,10 @@ const PageSpeed = ({ isAdmin }) => {
 						<Breadcrumbs list={[{ name: `pagespeed`, path: "/pagespeed" }]} />
 						<Stack
 							direction="row"
-							justifyContent="space-between"
+							justifyContent="end"
 							alignItems="center"
 							mt={theme.spacing(5)}
 						>
-							<Greeting type="pagespeed" />
 							{isAdmin && (
 								<Button
 									variant="contained"


### PR DESCRIPTION
This PR removes the "Dashboards" top level menu item and moves the previous submenus Monitors, Pagespeed, and Infrastructure to the top level of the menu. 

- [x] Remove Dashboard menu item
  - [x] Move Dashboard submenus to top level
- [x] Remove greeting from PageSpeed page 