### PR TITLE
fix: Infrastructure page content width

### DIFF
--- a/Client/src/Pages/Infrastructure/index.jsx
+++ b/Client/src/Pages/Infrastructure/index.jsx
@@ -166,10 +166,7 @@ function Infrastructure() {
 	});
 
 	return (
-		<Stack
-			component="main"
-			style={{ width: "100%", gap: "1rem" }}
-		>
+		<Stack gap={theme.spacing(8)}>
 			<Breadcrumbs list={BREADCRUMBS} />
 			<Stack
 				direction="row"


### PR DESCRIPTION
### Summary
This PR fixes the issue of the page content width of the **Infrastructure Page**, the route is `/infrastructure`, wherein its page content width is wider than the other pages; resulting also in making the sidebar width smaller.

### Changes Made
- Updated the **Infrastructure Page** to use `div` element instead of the `main` element as the main container for the page content

### Related Issues/s
Closes #1241 

### Screenshots
**Before:**
![issue1241-before](https://github.com/user-attachments/assets/97ad2aea-0879-4006-ad23-eb7efc0cedae)

**After:**
![issue1241-after](https://github.com/user-attachments/assets/88922ef7-b781-4294-bb2a-f1c93251ac29)

### Additional Context
N/A
