### PR TITLE
fix: fixing button color text on dark mode

### DIFF
--- a/Client/src/Pages/Account/index.jsx
+++ b/Client/src/Pages/Account/index.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import PropTypes from "prop-types";
 import { useNavigate } from "react-router";
 import { useSelector } from "react-redux";

--- a/Client/src/Utils/Theme/constants.js
+++ b/Client/src/Utils/Theme/constants.js
@@ -206,12 +206,14 @@ const semanticColors = {
 		light: {
 			light: paletteColors.gray200,
 			dark: paletteColors.gray800,
+			/* TODO this should live in a different key (border.disabled.light and .dark) */
 			disabled: paletteColors.gray150,
 		},
 		dark: {
 			light: paletteColors.gray200,
 			dark: paletteColors.gray750,
-			disabled: paletteColors.gray800,
+			/* TODO this should live in a different key (border.disabled.light and .dark) */
+			disabled: paletteColors.gray150,
 		},
 	},
 	unresolved: {

--- a/Client/src/Utils/Theme/globalTheme.js
+++ b/Client/src/Utils/Theme/globalTheme.js
@@ -93,9 +93,19 @@ const baseTheme = (palette) => ({
 					"&:hover": {
 						boxShadow: "none",
 					},
-					"&.MuiLoadingButton-root:disabled": {
-						backgroundColor: theme.palette.secondary.main,
-						color: theme.palette.text.primary,
+					"&.MuiLoadingButton-root": {
+						"&:disabled": {
+							backgroundColor: theme.palette.secondary.main,
+							color: theme.palette.text.primary,
+						},
+					},
+					"&.MuiLoadingButton-loading": {
+						"& .MuiLoadingButton-label": {
+							color: "transparent",
+						},
+						"& .MuiLoadingButton-loadingIndicator": {
+							color: "inherit",
+						},
 					},
 				}),
 			},

--- a/Client/src/Utils/Theme/globalTheme.js
+++ b/Client/src/Utils/Theme/globalTheme.js
@@ -93,6 +93,10 @@ const baseTheme = (palette) => ({
 					"&:hover": {
 						boxShadow: "none",
 					},
+					"&.MuiLoadingButton-root:disabled": {
+						backgroundColor: theme.palette.secondary.main,
+						color: theme.palette.text.primary,
+					},
 				}),
 			},
 		},

--- a/Client/src/Utils/Theme/lightTheme.js
+++ b/Client/src/Utils/Theme/lightTheme.js
@@ -28,6 +28,7 @@ const {
 } = colors;
 
 const palette = {
+	/* TODO check if we need the addition of a new color gray150 for this. Also, this color would probably fit for primary contrastText */
 	action: {
 		disabled: border.light.disabled,
 	},


### PR DESCRIPTION
Fixes: https://github.com/bluewave-labs/checkmate/issues/1242

![Screenshot 2024-12-02 191615](https://github.com/user-attachments/assets/201f5b73-4c84-4375-8096-d3fd6ec05df2)
![Screenshot 2024-12-02 191553](https://github.com/user-attachments/assets/c5779e37-7bfb-4e71-a6cb-888d3bc9e8dc)
