### PR TITLE
fix: remove start adornment from non-http type monitors

### DIFF
--- a/Client/src/Pages/Monitors/CreateMonitor/index.jsx
+++ b/Client/src/Pages/Monitors/CreateMonitor/index.jsx
@@ -214,7 +214,7 @@ const CreateMonitor = () => {
 		{ _id: 4, name: "4 minutes" },
 		{ _id: 5, name: "5 minutes" },
 	];
-
+	console.log(monitor.type);
 	return (
 		<Box className="create-monitor">
 			<Breadcrumbs
@@ -262,7 +262,9 @@ const CreateMonitor = () => {
 						<TextInput
 							type={monitor.type === "http" ? "url" : "text"}
 							id="monitor-url"
-							startAdornment={<HttpAdornment https={https} />}
+							startAdornment={
+								monitor.type === "http" ? <HttpAdornment https={https} /> : null
+							}
 							label={monitorTypeMaps[monitor.type].label || "URL to monitor"}
 							https={https}
 							placeholder={monitorTypeMaps[monitor.type].placeholder || ""}

--- a/Client/src/Pages/Monitors/CreateMonitor/index.jsx
+++ b/Client/src/Pages/Monitors/CreateMonitor/index.jsx
@@ -35,6 +35,24 @@ const CreateMonitor = () => {
 		{ _id: 5, name: "5 minutes" },
 	];
 
+	const monitorTypeMaps = {
+		http: {
+			label: "URL to monitor",
+			placeholder: "google.com",
+			namePlaceholder: "Google",
+		},
+		ping: {
+			label: "IP address to monitor",
+			placeholder: "1.1.1.1",
+			namePlaceholder: "Google",
+		},
+		docker: {
+			label: "Container ID",
+			placeholder: "abc123",
+			namePlaceholder: "My Container",
+		},
+	};
+
 	const { user, authToken } = useSelector((state) => state.auth);
 	const { monitors, isLoading } = useSelector((state) => state.uptimeMonitors);
 	const dispatch = useDispatch();
@@ -155,8 +173,6 @@ const CreateMonitor = () => {
 			notifications,
 		}));
 	};
-
-
 
 	useEffect(() => {
 		const fetchMonitor = async () => {


### PR DESCRIPTION
This PR resolves a bug wherein the http/https start adornment was shown on the monitor URL field even if a non http type monitor is selected

- [x] return `null` for start adornment if monitor type is not `http`