### PR TITLE
fix: fe/create monitor refactor

### DIFF
--- a/Client/src/Components/Inputs/Radio/index.jsx
+++ b/Client/src/Components/Inputs/Radio/index.jsx
@@ -37,13 +37,6 @@ const Radio = (props) => {
 					id={props.id}
 					size={props.size}
 					checkedIcon={<RadioChecked />}
-					sx={{
-						color: "transparent",
-						width: 16,
-						height: 16,
-						boxShadow: `inset 0 0 0 1px ${theme.palette.secondary.main}`,
-						mt: theme.spacing(0.5),
-					}}
 				/>
 			}
 			onChange={props.onChange}
@@ -60,19 +53,7 @@ const Radio = (props) => {
 				</>
 			}
 			labelPlacement="end"
-			sx={{
-				alignItems: "flex-start",
-				p: theme.spacing(2.5),
-				m: theme.spacing(-2.5),
-				borderRadius: theme.shape.borderRadius,
-				"&:hover": {
-					backgroundColor: theme.palette.background.accent,
-				},
-				"& .MuiButtonBase-root": {
-					p: 0,
-					mr: theme.spacing(6),
-				},
-			}}
+			sx={{}}
 		/>
 	);
 };
@@ -81,6 +62,9 @@ Radio.propTypes = {
 	title: PropTypes.string.isRequired,
 	desc: PropTypes.string,
 	size: PropTypes.string,
+	checked: PropTypes.bool,
+	value: PropTypes.string,
+	onChange: PropTypes.func,
 };
 
 export default Radio;

--- a/Client/src/Utils/Theme/globalTheme.js
+++ b/Client/src/Utils/Theme/globalTheme.js
@@ -244,6 +244,36 @@ const baseTheme = (palette) => ({
 				}),
 			},
 		},
+		MuiRadio: {
+			styleOverrides: {
+				root: ({ theme }) => ({
+					color: "transparent",
+					width: 16,
+					height: 16,
+					boxShadow: `inset 0 0 0 1px ${theme.palette.secondary.main}`,
+					mt: theme.spacing(0.5),
+				}),
+			},
+		},
+		MuiFormControlLabel: {
+			styleOverrides: {
+				root: ({ theme }) => {
+					return {
+						alignItems: "flex-start",
+						borderRadius: theme.shape.borderRadius,
+						padding: theme.spacing(2.5),
+
+						"& .MuiButtonBase-root": {
+							padding: 0,
+							marginRight: theme.spacing(6),
+						},
+						"&:hover": {
+							backgroundColor: theme.palette.background.accent,
+						},
+					};
+				},
+			},
+		},
 	},
 	shape: {
 		borderRadius: 2,


### PR DESCRIPTION
This PR refactors the Create Monitor page.  There was a considerable amount of unnecessary mapping between IDs and form names.  This has all been removed and shoudl be much easier to read and maintain

- [x] Remove mapping between field IDs and form names
  - [x] Pass the relevant form field name to the `handleChange` method in order to update the correct fields
- [x] Organize imports and constants for clarity

This can also be applied to other "Create" pages to remove unnecessary complexity