### PR TITLE
fix: Update error message in Password panel, confirm new password field

### DIFF
--- a/Client/src/Validation/validation.js
+++ b/Client/src/Validation/validation.js
@@ -82,7 +82,7 @@ const credentials = joi.object({
 			return value;
 		})
 		.messages({
-			"string.empty": "empty",
+			"string.empty": "This field can't be empty",
 			different: "Passwords do not match",
 		}),
 	role: joi.array(),


### PR DESCRIPTION
### Summary
This PR fixes the issue of the error message under `Confirm new password` field in the Password Panel.

### Changes Made
- Changed the error message from `empty -> This field can't be empty`

### Related Issue/s
Fixes #1206 

### Screenshot
**Before**
![image](https://github.com/user-attachments/assets/bd09017d-6802-4797-971f-07734a2c520d)

**After**
![image](https://github.com/user-attachments/assets/f0cadff6-5301-4897-a42d-a1ad41309448)

### Additional Context
N/A