### PR TITLE
feat #1275: design corrected  : Current Password Field BG color

### DIFF
--- a/Client/src/Utils/Theme/globalTheme.js
+++ b/Client/src/Utils/Theme/globalTheme.js
@@ -237,6 +237,11 @@ const baseTheme = (palette) => ({
 							WebkitTextFillColor: "unset",
 						},
 					},
+					"& .MuiInputBase-input:-webkit-autofill": {
+						transition: "background-color 5000s ease-in-out 0s", // Long transition to override autofill background
+						WebkitBoxShadow: `0 0 0px 1000px ${theme.palette.background.main} inset`, // Match your theme's background color
+						WebkitTextFillColor: theme.palette.text.primary, // Match text color
+					},
 					"& .MuiInputBase-input.MuiOutlinedInput-input": {
 						padding: "0 var(--env-var-spacing-1-minus) !important",
 					},

--- a/Client/src/Utils/Theme/globalTheme.js
+++ b/Client/src/Utils/Theme/globalTheme.js
@@ -238,9 +238,9 @@ const baseTheme = (palette) => ({
 						},
 					},
 					"& .MuiInputBase-input:-webkit-autofill": {
-						transition: "background-color 5000s ease-in-out 0s", // Long transition to override autofill background
-						WebkitBoxShadow: `0 0 0px 1000px ${theme.palette.background.main} inset`, // Match your theme's background color
-						WebkitTextFillColor: theme.palette.text.primary, // Match text color
+						transition: "background-color 5000s ease-in-out 0s", 
+						WebkitBoxShadow: `0 0 0px 1000px ${theme.palette.background.main} inset`, 
+						WebkitTextFillColor: theme.palette.text.primary,
 					},
 					"& .MuiInputBase-input.MuiOutlinedInput-input": {
 						padding: "0 var(--env-var-spacing-1-minus) !important",


### PR DESCRIPTION
This PR addresses issue #1275, where the "Current Password" field in the Password page displayed a white background when using the dark theme. The issue was identified as being linked to Chrome's autofill feature, which applies a default white background to input fields when auto filling saved credentials.

Changes: 
Just added a few lines of code under _globalTheme.js_:
![image](https://github.com/user-attachments/assets/41396f6d-3d3b-4fc5-aed5-d9b41ef47ad9)

Testing:
1. Reproduced the issue using saved passwords in Chrome.
2. Applied the fix and tested in multiple scenarios:
3. Dark theme with autofill.
4. Dark theme without autofill.
5. Light theme.
6. Incognito mode and cleared cache.

Attached before-and-after screenshots for reference.
Before:
![image](https://github.com/user-attachments/assets/0abef9d5-295b-46ee-9d01-4b12011da254)
After:
![image](https://github.com/user-attachments/assets/d0491e94-9a81-413c-b792-8d844545b2bd)

Let me know if there are any additional checks or refinements needed! 
