### PR TITLE
fix: Fix API url

### DIFF
--- a/Docker/prod/docker-compose.yaml
+++ b/Docker/prod/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   client:
     image: uptime_client:latest
     environment:
-      UPTIME_APP_API_BASE_URL: "https://uptime-demo.bluewavelabs.ca/api/v1"
+      UPTIME_APP_API_BASE_URL: "https://checkmate-demo.bluewavelabs.ca/api/v1"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
This PR updates the API base URL for the production server.  This is needed because of the recent DNS change