### PR TITLE
feat: Edit infrastructure monitor page

### DIFF
--- a/Client/src/App.jsx
+++ b/Client/src/App.jsx
@@ -41,6 +41,8 @@ import { logger } from "./Utils/Logger"; // Import the logger
 import { networkService } from "./main";
 import { Infrastructure } from "./Pages/Infrastructure";
 import InfrastructureDetails from "./Pages/Infrastructure/Details";
+import ConfigureInfrastructureMonitor from "./Pages/Infrastructure/Configure";
+
 function App() {
 	const AdminCheckedRegister = withAdminCheck(Register);
 	const MonitorsWithAdminProp = withAdminProp(Monitors);
@@ -137,6 +139,10 @@ function App() {
 					<Route
 						path="infrastructure/:monitorId"
 						element={<ProtectedRoute Component={InfrastructureDetailsWithAdminProp} />}
+					/>
+					<Route
+						path="infrastructure/configure/:monitorId"
+						element={<ProtectedRoute Component={ConfigureInfrastructureMonitor} />}
 					/>
 
 					<Route

--- a/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -388,6 +388,7 @@ const infrastructureMonitorsSlice = createSlice({
 				state.isLoading = false;
 				state.success = action.payload.success;
 				state.msg = action.payload.msg;
+				state.selectedInfraMonitor = action.payload.data;
 			})
 			.addCase(pauseInfrastructureMonitor.rejected, (state, action) => {
 				state.isLoading = false;

--- a/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -246,6 +246,7 @@ const infrastructureMonitorsSlice = createSlice({
 
 			.addCase(getInfrastructureMonitorsByTeamId.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(getInfrastructureMonitorsByTeamId.fulfilled, (state, action) => {
 				state.isLoading = false;
@@ -265,6 +266,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// *****************************************************
 			.addCase(createInfrastructureMonitor.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(createInfrastructureMonitor.fulfilled, (state, action) => {
 				state.isLoading = false;
@@ -283,6 +285,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// *****************************************************
 			.addCase(checkInfrastructureEndpointResolution.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(checkInfrastructureEndpointResolution.fulfilled, (state, action) => {
 				state.isLoading = false;
@@ -301,6 +304,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// *****************************************************
 			.addCase(getInfrastructureMonitorById.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(getInfrastructureMonitorById.fulfilled, (state, action) => {
 				state.isLoading = false;
@@ -320,6 +324,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// *****************************************************
 			.addCase(updateInfrastructureMonitor.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(updateInfrastructureMonitor.fulfilled, (state, action) => {
 				state.isLoading = false;
@@ -339,6 +344,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// *****************************************************
 			.addCase(deleteInfrastructureMonitor.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(deleteInfrastructureMonitor.fulfilled, (state, action) => {
 				state.isLoading = false;
@@ -357,6 +363,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// *****************************************************
 			.addCase(deleteInfrastructureMonitorChecksByTeamId.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(deleteInfrastructureMonitorChecksByTeamId.fulfilled, (state, action) => {
 				state.isLoading = false;
@@ -375,6 +382,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// *****************************************************
 			.addCase(pauseInfrastructureMonitor.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(pauseInfrastructureMonitor.fulfilled, (state, action) => {
 				state.isLoading = false;
@@ -393,6 +401,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// *****************************************************
 			.addCase(deleteAllInfrastructureMonitors.pending, (state) => {
 				state.isLoading = true;
+				state.success = false;
 			})
 			.addCase(deleteAllInfrastructureMonitors.fulfilled, (state, action) => {
 				state.isLoading = false;

--- a/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -1,12 +1,21 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { jwtDecode } from "jwt-decode";
 import { networkService } from "../../main";
+
+export const CurrentAction = Object.freeze({
+	NONE: "none",
+	DELETE: "delete",
+	UPDATE: "update",
+	GET: "get",
+});
+
 const initialState = {
 	isLoading: false,
 	monitorsSummary: [],
 	success: null,
 	msg: null,
 	selectedInfraMonitor: null,
+	currentAction: CurrentAction.NONE,
 };
 
 export const createInfrastructureMonitor = createAsyncThunk(
@@ -303,6 +312,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// Get Monitor By Id
 			// *****************************************************
 			.addCase(getInfrastructureMonitorById.pending, (state) => {
+				state.currentAction = CurrentAction.GET;
 				state.isLoading = true;
 				state.success = false;
 			})
@@ -343,6 +353,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// Delete Monitor
 			// *****************************************************
 			.addCase(deleteInfrastructureMonitor.pending, (state) => {
+				state.currentAction = CurrentAction.DELETE;
 				state.isLoading = true;
 				state.success = false;
 			})

--- a/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -6,6 +6,7 @@ const initialState = {
 	monitorsSummary: [],
 	success: null,
 	msg: null,
+	selectedInfraMonitor: null,
 };
 
 export const createInfrastructureMonitor = createAsyncThunk(
@@ -304,7 +305,7 @@ const infrastructureMonitorsSlice = createSlice({
 			.addCase(getInfrastructureMonitorById.fulfilled, (state, action) => {
 				state.isLoading = false;
 				state.success = action.payload.success;
-				state.msg = action.payload.msg;
+				state.selectedInfraMonitor = action.payload.data;
 			})
 			.addCase(getInfrastructureMonitorById.rejected, (state, action) => {
 				state.isLoading = false;

--- a/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -305,6 +305,7 @@ const infrastructureMonitorsSlice = createSlice({
 			.addCase(getInfrastructureMonitorById.fulfilled, (state, action) => {
 				state.isLoading = false;
 				state.success = action.payload.success;
+				state.msg = action.payload.msg;
 				state.selectedInfraMonitor = action.payload.data;
 			})
 			.addCase(getInfrastructureMonitorById.rejected, (state, action) => {

--- a/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -149,10 +149,10 @@ export const deleteInfrastructureMonitor = createAsyncThunk(
 	"infrastructureMonitors/deleteMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
+			const { authToken, monitorId } = data;
 			const res = await networkService.deleteMonitorById({
 				authToken: authToken,
-				monitorId: monitor._id,
+				monitorId: monitorId,
 			});
 			return res.data;
 		} catch (error) {

--- a/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/Client/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -2,7 +2,7 @@ import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import { jwtDecode } from "jwt-decode";
 import { networkService } from "../../main";
 
-export const CurrentAction = Object.freeze({
+export const FormAction = Object.freeze({
 	NONE: "none",
 	DELETE: "delete",
 	UPDATE: "update",
@@ -15,7 +15,7 @@ const initialState = {
 	success: null,
 	msg: null,
 	selectedInfraMonitor: null,
-	currentAction: CurrentAction.NONE,
+	formAction: FormAction.NONE,
 };
 
 export const createInfrastructureMonitor = createAsyncThunk(
@@ -246,6 +246,9 @@ const infrastructureMonitorsSlice = createSlice({
 			state.success = null;
 			state.msg = null;
 		},
+		resetInfrastructureMonitorFormAction: (state) => {
+			state.formAction = initialState.formAction;
+		},
 	},
 	extraReducers: (builder) => {
 		builder
@@ -312,7 +315,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// Get Monitor By Id
 			// *****************************************************
 			.addCase(getInfrastructureMonitorById.pending, (state) => {
-				state.currentAction = CurrentAction.GET;
+				state.formAction = FormAction.GET;
 				state.isLoading = true;
 				state.success = false;
 			})
@@ -353,7 +356,7 @@ const infrastructureMonitorsSlice = createSlice({
 			// Delete Monitor
 			// *****************************************************
 			.addCase(deleteInfrastructureMonitor.pending, (state) => {
-				state.currentAction = CurrentAction.DELETE;
+				state.formAction = FormAction.DELETE;
 				state.isLoading = true;
 				state.success = false;
 			})
@@ -428,7 +431,7 @@ const infrastructureMonitorsSlice = createSlice({
 	},
 });
 
-export const { setInfrastructureMonitors, clearInfrastructureMonitorState } =
+export const { clearInfrastructureMonitorState, resetInfrastructureMonitorFormAction } =
 	infrastructureMonitorsSlice.actions;
 
 export default infrastructureMonitorsSlice.reducer;

--- a/Client/src/Pages/Infrastructure/Configure/index.jsx
+++ b/Client/src/Pages/Infrastructure/Configure/index.jsx
@@ -50,12 +50,14 @@ const ConfigureInfrastructureMonitor = () => {
 	).length;
 
 	useEffect(() => {
-		dispatch(getInfrastructureMonitorById({ authToken, monitorId }));
+		if (!infrastructureMonitor) {
+			dispatch(getInfrastructureMonitorById({ authToken, monitorId }));
+		}
 	}, [monitorId, authToken]);
 
 	useEffect(() => {
-		if (!success) navigate("/not-found", { replace: true });
-	}, [success, navigate]);
+		if (!isLoading && success === false) navigate("/not-found", { replace: true });
+	}, [success, isLoading, navigate]);
 
 	useEffect(() => {
 		setInfrastructureMonitor(selectedInfraMonitor);
@@ -479,7 +481,7 @@ const ConfigureInfrastructureMonitor = () => {
 							<Select
 								id="interval"
 								label="Check frequency"
-								value={infrastructureMonitor.interval || 15}
+								value={infrastructureMonitor.interval / MS_PER_MINUTE || 0.25}
 								onChange={(e) => handleChange(e, "interval")}
 								onBlur={(e) => handleBlur(e, "interval")}
 								items={frequencies}

--- a/Client/src/Pages/Infrastructure/Configure/index.jsx
+++ b/Client/src/Pages/Infrastructure/Configure/index.jsx
@@ -8,6 +8,7 @@ import {
 	createInfrastructureMonitor,
 	checkInfrastructureEndpointResolution,
 	getInfrastructureMonitorById,
+	pauseInfrastructureMonitor,
 } from "../../../Features/InfrastructureMonitors/infrastructureMonitorsSlice";
 import { useNavigate, useParams } from "react-router-dom";
 import { useTheme } from "@emotion/react";
@@ -62,6 +63,10 @@ const ConfigureInfrastructureMonitor = () => {
 	useEffect(() => {
 		setInfrastructureMonitor(selectedInfraMonitor);
 	}, [selectedInfraMonitor]);
+
+	const handlePause = () => {
+		dispatch(pauseInfrastructureMonitor({ authToken, monitorId }));
+	};
 
 	const handleCustomAlertCheckChange = (event) => {
 		const { value, id } = event.target;
@@ -165,6 +170,7 @@ const ConfigureInfrastructureMonitor = () => {
 		};
 		return form;
 	};
+
 	const handleCreateInfrastructureMonitor = async (event) => {
 		event.preventDefault();
 		let form = {
@@ -323,7 +329,7 @@ const ConfigureInfrastructureMonitor = () => {
 										},
 									},
 								}}
-								onClick={() => console.log("handle pause")}
+								onClick={handlePause}
 							>
 								{infrastructureMonitor?.isActive ? (
 									<>

--- a/Client/src/Pages/Infrastructure/Configure/index.jsx
+++ b/Client/src/Pages/Infrastructure/Configure/index.jsx
@@ -504,7 +504,7 @@ const ConfigureInfrastructureMonitor = () => {
 							onClick={handleCreateInfrastructureMonitor}
 							loading={isLoading}
 						>
-							Create infrastructure monitor
+							Save
 						</LoadingButton>
 					</Stack>
 				</Stack>

--- a/Client/src/Pages/Infrastructure/Configure/index.jsx
+++ b/Client/src/Pages/Infrastructure/Configure/index.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const ConfigureInfrastructureMonitor = () => {
+	return <div>Configure Infrastructure Monitor Page</div>;
+};
+
+export default ConfigureInfrastructureMonitor;

--- a/Client/src/Pages/Infrastructure/Configure/index.jsx
+++ b/Client/src/Pages/Infrastructure/Configure/index.jsx
@@ -32,7 +32,7 @@ const ConfigureInfrastructureMonitor = () => {
 	const HARDWARE_MONITOR_TYPES = ["cpu", "memory", "disk", "temperature"];
 	const { user, authToken } = useSelector((state) => state.auth);
 	const { monitorId } = useParams();
-	const { isLoading, selectedInfraMonitor, msg } = useSelector(
+	const { isLoading, selectedInfraMonitor, success } = useSelector(
 		(state) => state.infrastructureMonitors
 	);
 	const [infrastructureMonitor, setInfrastructureMonitor] = useState(null);
@@ -54,8 +54,8 @@ const ConfigureInfrastructureMonitor = () => {
 	}, [monitorId, authToken]);
 
 	useEffect(() => {
-		if (msg) navigate("/not-found", { replace: true });
-	}, [msg, navigate]);
+		if (!success) navigate("/not-found", { replace: true });
+	}, [success, navigate]);
 
 	useEffect(() => {
 		setInfrastructureMonitor(selectedInfraMonitor);

--- a/Client/src/Pages/Infrastructure/Configure/index.jsx
+++ b/Client/src/Pages/Infrastructure/Configure/index.jsx
@@ -1,7 +1,415 @@
-import React from "react";
+import { useEffect, useState } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+import LoadingButton from "@mui/lab/LoadingButton";
+import { useSelector, useDispatch } from "react-redux";
+import { infrastructureMonitorValidation } from "../../../Validation/validation";
+import { parseDomainName } from "../../../Utils/monitorUtils";
+import {
+	createInfrastructureMonitor,
+	checkInfrastructureEndpointResolution,
+	getInfrastructureMonitorById,
+} from "../../../Features/InfrastructureMonitors/infrastructureMonitorsSlice";
+import { useNavigate, useParams } from "react-router-dom";
+import { useTheme } from "@emotion/react";
+import { createToast } from "../../../Utils/toastUtils";
+import Link from "../../../Components/Link";
+import { ConfigBox } from "../../Monitors/styled";
+import TextInput from "../../../Components/Inputs/TextInput";
+import Select from "../../../Components/Inputs/Select";
+import Checkbox from "../../../Components/Inputs/Checkbox";
+import Breadcrumbs from "../../../Components/Breadcrumbs";
+import { buildErrors, hasValidationErrors } from "../../../Validation/error";
+import { capitalizeFirstLetter } from "../../../Utils/stringUtils";
+import { CustomThreshold } from "../CreateMonitor/CustomThreshold";
 
 const ConfigureInfrastructureMonitor = () => {
-	return <div>Configure Infrastructure Monitor Page</div>;
+	const [infrastructureMonitor, setInfrastructureMonitor] = useState({
+		url: "",
+		name: "",
+		notifications: [],
+		interval: 0.25,
+		cpu: false,
+		usage_cpu: "",
+		memory: false,
+		usage_memory: "",
+		disk: false,
+		usage_disk: "",
+		temperature: false,
+		usage_temperature: "",
+		secret: "",
+	});
+
+	const MS_PER_MINUTE = 60000;
+	const THRESHOLD_FIELD_PREFIX = "usage_";
+	const HARDWARE_MONITOR_TYPES = ["cpu", "memory", "disk", "temperature"];
+	const { user, authToken } = useSelector((state) => state.auth);
+	const { monitorId } = useParams();
+	const { isLoading, selectedInfraMonitor, msg } = useSelector(
+		(state) => state.infrastructureMonitors
+	);
+	const dispatch = useDispatch();
+	const navigate = useNavigate();
+	const theme = useTheme();
+
+	const idMap = {
+		"notify-email-default": "notification-email",
+	};
+
+	const [errors, setErrors] = useState({});
+
+	const alertErrKeyLen = Object.keys(errors).filter((k) =>
+		k.startsWith(THRESHOLD_FIELD_PREFIX)
+	).length;
+
+	useEffect(() => {
+		dispatch(getInfrastructureMonitorById({ authToken, monitorId }));
+	}, [monitorId, authToken]);
+
+	useEffect(() => {
+		if (msg) navigate("/not-found", { replace: true });
+	}, [msg, navigate]);
+
+	const handleCustomAlertCheckChange = (event) => {
+		const { value, id } = event.target;
+		setInfrastructureMonitor((prev) => {
+			const newState = {
+				[id]: prev[id] == undefined && value == "on" ? true : !prev[id],
+			};
+			return {
+				...prev,
+				...newState,
+				[THRESHOLD_FIELD_PREFIX + id]: newState[id]
+					? prev[THRESHOLD_FIELD_PREFIX + id]
+					: "",
+			};
+		});
+		// Remove the error if unchecked
+		setErrors((prev) => {
+			return buildErrors(prev, [THRESHOLD_FIELD_PREFIX + id]);
+		});
+	};
+
+	const handleBlur = (event, appendID) => {
+		event.preventDefault();
+		const { value, id } = event.target;
+
+		let name = idMap[id] ?? id;
+		if (name === "url" && infrastructureMonitor.name === "") {
+			setInfrastructureMonitor((prev) => ({
+				...prev,
+				name: parseDomainName(value),
+			}));
+		}
+
+		if (id?.startsWith("notify-email-")) return;
+		const { error } = infrastructureMonitorValidation.validate(
+			{ [id ?? appendID]: value },
+			{
+				abortEarly: false,
+			}
+		);
+		setErrors((prev) => {
+			return buildErrors(prev, id ?? appendID, error);
+		});
+	};
+
+	const handleChange = (event, appendedId) => {
+		event.preventDefault();
+		const { value, id } = event.target;
+		let name = appendedId ?? idMap[id] ?? id;
+		if (name.includes("notification-")) {
+			name = name.replace("notification-", "");
+			let hasNotif = infrastructureMonitor.notifications.some(
+				(notification) => notification.type === name
+			);
+			setInfrastructureMonitor((prev) => {
+				const notifs = [...prev.notifications];
+				if (hasNotif) {
+					return {
+						...prev,
+						notifications: notifs.filter((notif) => notif.type !== name),
+					};
+				} else {
+					return {
+						...prev,
+						notifications: [
+							...notifs,
+							name === "email"
+								? { type: name, address: value }
+								: // TODO - phone number
+									{ type: name, phone: value },
+						],
+					};
+				}
+			});
+		} else {
+			setInfrastructureMonitor((prev) => ({
+				...prev,
+				[name]: value,
+			}));
+		}
+	};
+
+	const generatePayload = (form) => {
+		let thresholds = {};
+		Object.keys(form)
+			.filter((k) => k.startsWith(THRESHOLD_FIELD_PREFIX))
+			.map((k) => {
+				if (form[k]) thresholds[k] = form[k] / 100;
+				delete form[k];
+				delete form[k.substring(THRESHOLD_FIELD_PREFIX.length)];
+			});
+
+		form = {
+			...form,
+			description: form.name,
+			teamId: user.teamId,
+			userId: user._id,
+			type: "hardware",
+			notifications: infrastructureMonitor.notifications,
+			thresholds,
+		};
+		return form;
+	};
+	const handleCreateInfrastructureMonitor = async (event) => {
+		event.preventDefault();
+		let form = {
+			...infrastructureMonitor,
+			name:
+				infrastructureMonitor.name === ""
+					? infrastructureMonitor.url
+					: infrastructureMonitor.name,
+			interval: infrastructureMonitor.interval * MS_PER_MINUTE,
+		};
+
+		delete form.notifications;
+		if (hasValidationErrors(form, infrastructureMonitorValidation, setErrors)) {
+			return;
+		} else {
+			const checkEndpointAction = await dispatch(
+				checkInfrastructureEndpointResolution({ authToken, monitorURL: form.url })
+			);
+			if (checkEndpointAction.meta.requestStatus === "rejected") {
+				createToast({
+					body: "The endpoint you entered doesn't resolve. Check the URL again.",
+				});
+				setErrors({ url: "The entered URL is not reachable." });
+				return;
+			}
+			const action = await dispatch(
+				createInfrastructureMonitor({ authToken, monitor: generatePayload(form) })
+			);
+			if (action.meta.requestStatus === "fulfilled") {
+				createToast({ body: "Infrastructure monitor created successfully!" });
+				navigate("/infrastructure");
+			} else {
+				createToast({ body: "Failed to create monitor." });
+			}
+		}
+	};
+
+	//select values
+	const frequencies = [
+		{ _id: 0.25, name: "15 seconds" },
+		{ _id: 0.5, name: "30 seconds" },
+		{ _id: 1, name: "1 minute" },
+		{ _id: 2, name: "2 minutes" },
+		{ _id: 5, name: "5 minutes" },
+		{ _id: 10, name: "10 minutes" },
+	];
+
+	return (
+		<Box className="create-infrastructure-monitor">
+			<Breadcrumbs
+				list={[
+					{ name: "Infrastructure monitors", path: "/infrastructure" },
+					{ name: "details", path: `/infrastructure/${monitorId}` },
+					{ name: "configure", path: `/infrastructure/configure/${monitorId}` },
+				]}
+			/>
+			<Stack
+				component="form"
+				className="create-infrastructure-monitor-form"
+				onSubmit={handleCreateInfrastructureMonitor}
+				noValidate
+				spellCheck="false"
+				gap={theme.spacing(12)}
+				mt={theme.spacing(6)}
+			>
+				<Typography
+					component="h1"
+					variant="h1"
+				>
+					<Typography
+						component="span"
+						fontSize="inherit"
+					>
+						Create your{" "}
+					</Typography>
+					<Typography
+						component="span"
+						variant="h2"
+						fontSize="inherit"
+						fontWeight="inherit"
+					>
+						infrastructure monitor
+					</Typography>
+				</Typography>
+				<ConfigBox>
+					<Box>
+						<Stack gap={theme.spacing(6)}>
+							<Typography component="h2">General settings</Typography>
+							<Typography component="p">
+								Here you can select the URL of the host, together with the friendly name
+								and authorization secret to connect to the server agent.
+							</Typography>
+							<Typography component="p">
+								The server you are monitoring must be running the{" "}
+								<Link
+									level="primary"
+									url="https://github.com/bluewave-labs/checkmate-agent"
+									label="Checkmate Monitoring Agent"
+								/>
+							</Typography>
+						</Stack>
+					</Box>
+					<Stack gap={theme.spacing(15)}>
+						<TextInput
+							type="text"
+							id="url"
+							label="Server URL"
+							placeholder="https://"
+							value={infrastructureMonitor.url}
+							onBlur={handleBlur}
+							onChange={handleChange}
+							error={errors["url"] ? true : false}
+							helperText={errors["url"]}
+						/>
+						<TextInput
+							type="text"
+							id="name"
+							label="Display name"
+							placeholder="Google"
+							isOptional={true}
+							value={infrastructureMonitor.name}
+							onBlur={handleBlur}
+							onChange={handleChange}
+							error={errors["name"]}
+						/>
+						<TextInput
+							type="text"
+							id="secret"
+							label="Authorization secret"
+							value={infrastructureMonitor.secret}
+							onBlur={handleBlur}
+							onChange={handleChange}
+							error={errors["secret"] ? true : false}
+							helperText={errors["secret"]}
+						/>
+					</Stack>
+				</ConfigBox>
+				<ConfigBox>
+					<Box>
+						<Typography component="h2">Incident notifications</Typography>
+						<Typography component="p">
+							When there is an incident, notify users.
+						</Typography>
+					</Box>
+					<Stack gap={theme.spacing(6)}>
+						<Typography component="p">When there is a new incident,</Typography>
+						<Checkbox
+							id="notify-email-default"
+							label={`Notify via email (to ${user.email})`}
+							isChecked={infrastructureMonitor.notifications.some(
+								(notification) => notification.type === "email"
+							)}
+							value={user?.email}
+							onChange={(e) => handleChange(e)}
+							onBlur={handleBlur}
+						/>
+					</Stack>
+				</ConfigBox>
+
+				<ConfigBox>
+					<Box>
+						<Typography component="h2">Customize alerts</Typography>
+						<Typography component="p">
+							Send a notification to user(s) when thresholds exceed a specified
+							percentage.
+						</Typography>
+					</Box>
+					<Stack gap={theme.spacing(6)}>
+						{HARDWARE_MONITOR_TYPES.map((type, idx) => (
+							<CustomThreshold
+								key={idx}
+								checkboxId={type}
+								checkboxLabel={
+									type !== "cpu" ? capitalizeFirstLetter(type) : type.toUpperCase()
+								}
+								onCheckboxChange={handleCustomAlertCheckChange}
+								fieldId={THRESHOLD_FIELD_PREFIX + type}
+								fieldValue={infrastructureMonitor[THRESHOLD_FIELD_PREFIX + type] ?? ""}
+								onFieldChange={handleChange}
+								onFieldBlur={handleBlur}
+								// TODO: need BE, maybe in another PR
+								alertUnit={type == "temperature" ? "°C" : "%"}
+								infrastructureMonitor={infrastructureMonitor}
+								errors={errors}
+							/>
+						))}
+						{alertErrKeyLen > 0 && (
+							<Typography
+								component="span"
+								className="input-error"
+								color={theme.palette.error.main}
+								mt={theme.spacing(2)}
+								sx={{
+									opacity: 0.8,
+								}}
+							>
+								{
+									errors[
+										THRESHOLD_FIELD_PREFIX +
+											HARDWARE_MONITOR_TYPES.filter(
+												(type) => errors[THRESHOLD_FIELD_PREFIX + type]
+											)[0]
+									]
+								}
+							</Typography>
+						)}
+					</Stack>
+				</ConfigBox>
+				<ConfigBox>
+					<Box>
+						<Typography component="h2">Advanced settings</Typography>
+					</Box>
+					<Stack gap={theme.spacing(12)}>
+						<Select
+							id="interval"
+							label="Check frequency"
+							value={infrastructureMonitor.interval || 15}
+							onChange={(e) => handleChange(e, "interval")}
+							onBlur={(e) => handleBlur(e, "interval")}
+							items={frequencies}
+						/>
+					</Stack>
+				</ConfigBox>
+				<Stack
+					direction="row"
+					justifyContent="flex-end"
+				>
+					<LoadingButton
+						variant="contained"
+						color="primary"
+						onClick={handleCreateInfrastructureMonitor}
+						loading={isLoading}
+					>
+						Create infrastructure monitor
+					</LoadingButton>
+				</Stack>
+			</Stack>
+		</Box>
+	);
 };
 
 export default ConfigureInfrastructureMonitor;

--- a/Client/src/Pages/Infrastructure/Configure/index.jsx
+++ b/Client/src/Pages/Infrastructure/Configure/index.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Box, Stack, Typography } from "@mui/material";
+import { Box, Stack, Tooltip, Typography } from "@mui/material";
 import LoadingButton from "@mui/lab/LoadingButton";
 import { useSelector, useDispatch } from "react-redux";
 import { infrastructureMonitorValidation } from "../../../Validation/validation";
@@ -21,6 +21,10 @@ import Breadcrumbs from "../../../Components/Breadcrumbs";
 import { buildErrors, hasValidationErrors } from "../../../Validation/error";
 import { capitalizeFirstLetter } from "../../../Utils/stringUtils";
 import { CustomThreshold } from "../CreateMonitor/CustomThreshold";
+import useUtils from "../../Monitors/utils";
+import PulseDot from "../../../Components/Animated/PulseDot";
+import PauseIcon from "../../../assets/icons/pause-icon.svg?react";
+import ResumeIcon from "../../../assets/icons/resume-icon.svg?react";
 
 const ConfigureInfrastructureMonitor = () => {
 	const MS_PER_MINUTE = 60000;
@@ -32,6 +36,7 @@ const ConfigureInfrastructureMonitor = () => {
 		(state) => state.infrastructureMonitors
 	);
 	const [infrastructureMonitor, setInfrastructureMonitor] = useState(null);
+	const { statusColor, statusMsg, determineState } = useUtils();
 	const [errors, setErrors] = useState({});
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
@@ -217,32 +222,130 @@ const ConfigureInfrastructureMonitor = () => {
 				/>
 				<Stack
 					component="form"
-					className="create-infrastructure-monitor-form"
 					onSubmit={handleCreateInfrastructureMonitor}
 					noValidate
 					spellCheck="false"
 					gap={theme.spacing(12)}
 					mt={theme.spacing(6)}
 				>
-					<Typography
-						component="h1"
-						variant="h1"
+					<Stack
+						direction="row"
+						gap={theme.spacing(2)}
 					>
-						<Typography
-							component="span"
-							fontSize="inherit"
+						<Box>
+							<Typography
+								component="h1"
+								variant="h1"
+							>
+								{infrastructureMonitor.name}
+							</Typography>
+							<Stack
+								direction="row"
+								alignItems="center"
+								height="fit-content"
+								gap={theme.spacing(2)}
+							>
+								<Tooltip
+									title={statusMsg[determineState(infrastructureMonitor)]}
+									disableInteractive
+									slotProps={{
+										popper: {
+											modifiers: [
+												{
+													name: "offset",
+													options: {
+														offset: [0, -8],
+													},
+												},
+											],
+										},
+									}}
+								>
+									<Box>
+										<PulseDot
+											color={statusColor[determineState(infrastructureMonitor)]}
+										/>
+									</Box>
+								</Tooltip>
+								<Typography
+									component="h2"
+									variant="h2"
+								>
+									{infrastructureMonitor.url?.replace(/^https?:\/\//, "") || "..."}
+								</Typography>
+								<Typography
+									position="relative"
+									variant="body2"
+									ml={theme.spacing(6)}
+									mt={theme.spacing(1)}
+									sx={{
+										"&:before": {
+											position: "absolute",
+											content: `""`,
+											width: 4,
+											height: 4,
+											borderRadius: "50%",
+											backgroundColor: theme.palette.text.tertiary,
+											opacity: 0.8,
+											left: -10,
+											top: "50%",
+											transform: "translateY(-50%)",
+										},
+									}}
+								>
+									Editting...
+								</Typography>
+							</Stack>
+						</Box>
+						<Box
+							sx={{
+								alignSelf: "flex-end",
+								ml: "auto",
+							}}
 						>
-							Create your{" "}
-						</Typography>
-						<Typography
-							component="span"
-							variant="h2"
-							fontSize="inherit"
-							fontWeight="inherit"
-						>
-							infrastructure monitor
-						</Typography>
-					</Typography>
+							<LoadingButton
+								variant="contained"
+								color="secondary"
+								loading={isLoading}
+								sx={{
+									pl: theme.spacing(4),
+									pr: theme.spacing(6),
+									mr: theme.spacing(6),
+									"& svg": {
+										mr: theme.spacing(2),
+										width: 22,
+										height: 22,
+										"& path": {
+											stroke: theme.palette.text.tertiary,
+											strokeWidth: 1.7,
+										},
+									},
+								}}
+								onClick={() => console.log("handle pause")}
+							>
+								{infrastructureMonitor?.isActive ? (
+									<>
+										<PauseIcon />
+										Pause
+									</>
+								) : (
+									<>
+										<ResumeIcon />
+										Resume
+									</>
+								)}
+							</LoadingButton>
+							<LoadingButton
+								loading={isLoading}
+								variant="contained"
+								color="error"
+								sx={{ px: theme.spacing(8) }}
+								onClick={() => setIsOpen(true)}
+							>
+								Remove
+							</LoadingButton>
+						</Box>
+					</Stack>
 					<ConfigBox>
 						<Box>
 							<Stack gap={theme.spacing(6)}>

--- a/Client/src/Pages/Infrastructure/Configure/index.jsx
+++ b/Client/src/Pages/Infrastructure/Configure/index.jsx
@@ -8,7 +8,7 @@ import {
 	getInfrastructureMonitorById,
 	pauseInfrastructureMonitor,
 	deleteInfrastructureMonitor,
-	CurrentAction,
+	FormAction,
 } from "../../../Features/InfrastructureMonitors/infrastructureMonitorsSlice";
 import { useNavigate, useParams } from "react-router-dom";
 import { useTheme } from "@emotion/react";
@@ -33,7 +33,7 @@ import { HARDWARE_MONITOR_TYPES, THRESHOLD_FIELD_PREFIX } from "../constants";
 const ConfigureInfrastructureMonitor = () => {
 	const { user, authToken } = useSelector((state) => state.auth);
 	const { monitorId } = useParams();
-	const { isLoading, selectedInfraMonitor, success, currentAction } = useSelector(
+	const { isLoading, selectedInfraMonitor, success, formAction } = useSelector(
 		(state) => state.infrastructureMonitors
 	);
 	const [infrastructureMonitor, setInfrastructureMonitor] = useState(null);
@@ -58,23 +58,25 @@ const ConfigureInfrastructureMonitor = () => {
 	}, [monitorId, authToken, dispatch]);
 
 	useEffect(() => {
-		if (currentAction === CurrentAction.GET && !isLoading && success === false)
+		if (formAction === FormAction.GET && !isLoading && success === false)
 			navigate("/not-found", { replace: true });
 	}, [success, isLoading, navigate]);
 
 	useEffect(() => {
-		setInfrastructureMonitor(selectedInfraMonitor);
+		if (selectedInfraMonitor) {
+			setInfrastructureMonitor(selectedInfraMonitor);
+		}
 	}, [selectedInfraMonitor]);
 
 	useEffect(() => {
-		if (currentAction === CurrentAction.DELETE && !isLoading) {
+		if (formAction === FormAction.DELETE && !isLoading) {
 			if (success) {
-				navigate("/infrastructure");
+				navigate("/infrastructure", { replace: true });
 			} else {
 				createToast({ body: "Failed to delete monitor." });
 			}
 		}
-	}, [currentAction, isLoading, success, navigate]);
+	}, [formAction, isLoading, success, navigate]);
 
 	const handlePause = () => {
 		dispatch(pauseInfrastructureMonitor({ authToken, monitorId }));

--- a/Client/src/Pages/Infrastructure/Details/index.jsx
+++ b/Client/src/Pages/Infrastructure/Details/index.jsx
@@ -1,7 +1,7 @@
 import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import Breadcrumbs from "../../../Components/Breadcrumbs";
-import { Stack, Box, Typography } from "@mui/material";
+import { Stack, Box, Typography, Tooltip, Button } from "@mui/material";
 import { useTheme } from "@emotion/react";
 import CustomGauge from "../../../Components/Charts/CustomGauge";
 import AreaChart from "../../../Components/Charts/AreaChart";
@@ -12,7 +12,7 @@ import useUtils from "../../Monitors/utils";
 import { useNavigate } from "react-router-dom";
 import Empty from "./empty";
 import { logger } from "../../../Utils/Logger";
-import { formatDurationRounded, formatDurationSplit } from "../../../Utils/timeUtils";
+import { formatDurationRounded } from "../../../Utils/timeUtils";
 import {
 	TzTick,
 	PercentTick,
@@ -20,6 +20,7 @@ import {
 	TemperatureTooltip,
 } from "../../../Components/Charts/Utils/chartUtils";
 import PropTypes from "prop-types";
+import SettingsIcon from "../../../assets/icons/settings-bold.svg?react";
 
 const BASE_BOX_PADDING_VERTICAL = 4;
 const BASE_BOX_PADDING_HORIZONTAL = 8;
@@ -182,7 +183,7 @@ GaugeBox.propTypes = {
  * Renders the infrastructure details page
  * @returns {React.ReactElement} Infrastructure details page component
  */
-const InfrastructureDetails = () => {
+const InfrastructureDetails = ({ isAdmin }) => {
 	const navigate = useNavigate();
 	const theme = useTheme();
 	const { monitorId } = useParams();
@@ -193,7 +194,7 @@ const InfrastructureDetails = () => {
 	const [monitor, setMonitor] = useState(null);
 	const { authToken } = useSelector((state) => state.auth);
 	const [dateRange, setDateRange] = useState("all");
-	const { statusColor, determineState } = useUtils();
+	const { statusColor, statusMsg, determineState } = useUtils();
 	// These calculations are needed because ResponsiveContainer
 	// doesn't take padding of parent/siblings into account
 	// when calculating height.
@@ -482,26 +483,90 @@ const InfrastructureDetails = () => {
 					<Stack
 						direction="row"
 						gap={theme.spacing(8)}
+						justifyContent="space-between"
+						alignItems="flex-start"
 					>
 						<Box>
-							<PulseDot color={statusColor[determineState(monitor)]} />
+							<Typography
+								component="h1"
+								variant="h1"
+							>
+								{monitor.name}
+							</Typography>
+							<Stack
+								direction="row"
+								alignItems="center"
+								height="fit-content"
+								gap={theme.spacing(2)}
+							>
+								<Tooltip
+									title={statusMsg[determineState(monitor)]}
+									disableInteractive
+									slotProps={{
+										popper: {
+											modifiers: [
+												{
+													name: "offset",
+													options: {
+														offset: [0, -8],
+													},
+												},
+											],
+										},
+									}}
+								>
+									<Box>
+										<PulseDot color={statusColor[determineState(monitor)]} />
+									</Box>
+								</Tooltip>
+								<Typography
+									component="h2"
+									variant="h2"
+								>
+									{monitor.url?.replace(/^https?:\/\//, "") || "..."}
+								</Typography>
+								<Typography
+									position="relative"
+									variant="body2"
+									mt={theme.spacing(1)}
+									ml={theme.spacing(6)}
+									sx={{
+										"&:before": {
+											position: "absolute",
+											content: `""`,
+											width: 4,
+											height: 4,
+											borderRadius: "50%",
+											backgroundColor: theme.palette.text.tertiary,
+											opacity: 0.8,
+											left: -9,
+											top: "50%",
+											transform: "translateY(-50%)",
+										},
+									}}
+								>
+									Checking every {formatDurationRounded(monitor?.interval)}.
+								</Typography>
+							</Stack>
 						</Box>
-						<Typography
-							alignSelf="end"
-							component="h1"
-							variant="h1"
-						>
-							{monitor.name}
-						</Typography>
-						<Typography alignSelf="end">{monitor.url || "..."}</Typography>
-						<Box sx={{ flexGrow: 1 }} />
-						<Typography alignSelf="end">
-							Checking every {formatDurationRounded(monitor?.interval)}
-						</Typography>
-						<Typography alignSelf="end">
-							Last checked {formatDurationSplit(monitor?.lastChecked).time}{" "}
-							{formatDurationSplit(monitor?.lastChecked).format} ago
-						</Typography>
+						{isAdmin && (
+							<Button
+								variant="contained"
+								color="secondary"
+								onClick={() => navigate(`/monitors`)}
+								sx={{
+									px: theme.spacing(5),
+									"& svg": {
+										mr: theme.spacing(3),
+										"& path": {
+											stroke: theme.palette.text.tertiary,
+										},
+									},
+								}}
+							>
+								<SettingsIcon /> Configure
+							</Button>
+						)}
 					</Stack>
 					<Stack
 						direction="row"

--- a/Client/src/Pages/Infrastructure/Details/index.jsx
+++ b/Client/src/Pages/Infrastructure/Details/index.jsx
@@ -553,7 +553,7 @@ const InfrastructureDetails = ({ isAdmin }) => {
 							<Button
 								variant="contained"
 								color="secondary"
-								onClick={() => navigate(`/monitors`)}
+								onClick={() => navigate(`/infrastructure/configure/${monitorId}`)}
 								sx={{
 									px: theme.spacing(5),
 									"& svg": {

--- a/Client/src/Pages/Infrastructure/constants.js
+++ b/Client/src/Pages/Infrastructure/constants.js
@@ -1,0 +1,2 @@
+export const THRESHOLD_FIELD_PREFIX = "usage_";
+export const HARDWARE_MONITOR_TYPES = ["cpu", "memory", "disk", "temperature"];

--- a/Client/src/Pages/Infrastructure/index.jsx
+++ b/Client/src/Pages/Infrastructure/index.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { /* useDispatch, */ useSelector } from "react-redux";
+import { /* useDispatch, */ useDispatch, useSelector } from "react-redux";
 import { useTheme } from "@emotion/react";
 import useUtils from "../Monitors/utils";
 import { jwtDecode } from "jwt-decode";
@@ -31,6 +31,7 @@ import CustomGauge from "../../Components/Charts/CustomGauge/index.jsx";
 import Host from "../Monitors/Home/host.jsx";
 import { useIsAdmin } from "../../Hooks/useIsAdmin.js";
 import { InfrastructureMenu } from "./components/Menu";
+import { resetInfrastructureMonitorFormAction } from "../../Features/InfrastructureMonitors/infrastructureMonitorsSlice.js";
 
 const columns = [
 	{ label: "Host" },
@@ -81,6 +82,7 @@ function Infrastructure() {
 	const theme = useTheme();
 	const [isLoading, setIsLoading] = useState(true);
 
+	const dispatch = useDispatch();
 	const navigate = useNavigate();
 	const navigateToCreate = () => navigate("/infrastructure/create");
 
@@ -128,6 +130,10 @@ function Infrastructure() {
 	useEffect(() => {
 		fetchMonitors();
 	}, [page, rowsPerPage]);
+
+	useEffect(() => {
+		dispatch(resetInfrastructureMonitorFormAction());
+	}, []);
 
 	const { determineState } = useUtils();
 	const { monitors, total: totalMonitors } = monitorState;


### PR DESCRIPTION
### Summary
This PR adds the "Configure" button at the infrastructure details page to edit the selected infrastructure.

### Changes Made
- Added **Infrastructure configure page**
- Added **Configure Button** at the top right of the _Infrastructure details page_ which redirects to the _Infrastructure configure page_
- Auto populate fields when editing infrastructure
- Added **Pause/Resume Infrastructure monitor** functionality
- Added **Delete Infrastructure monitor** functionality

### Related Issue/s
Fixes #1277 

### Screenshots / Demo Video
https://github.com/user-attachments/assets/e58e7b9d-4aad-44b5-af5c-278882139f1e

### Additional Context/s
- **Edit** functionality not yet working. We can create another PR for it
- Noticed that the **pulse dot** which indicates if the infra monitor is active or not doesn't go back to **green** when resumed
- Auto populating the **Customized Alerts** not yet working. We can create another PR for it
- Copy pasted the code in the _Pagespeed configure page_ and made adjustment from there. We can create a PR to refactor redundant codes and do some cleanup

