### PR TITLE
add deleteHardwareChecksByMonitorId

### DIFF
--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -332,6 +332,7 @@ const deleteMonitor = async (req, res, next) => {
 			await req.db.deleteChecks(monitor._id);
 			await req.db.deletePageSpeedChecksByMonitorId(monitor._id);
 			await req.db.deleteNotificationsByMonitorId(monitor._id);
+			await req.db.deleteHardwareChecksByMonitorId(monitor._id);
 		} catch (error) {
 			logger.error({
 				message: `Error deleting associated records for monitor ${monitor._id} with name ${monitor.name}`,

--- a/Server/db/mongo/MongoDB.js
+++ b/Server/db/mongo/MongoDB.js
@@ -124,7 +124,10 @@ import {
 //****************************************
 // Hardware Checks
 //****************************************
-import { createHardwareCheck } from "./modules/hardwareCheckModule.js";
+import {
+	createHardwareCheck,
+	deleteHardwareChecksByMonitorId,
+} from "./modules/hardwareCheckModule.js";
 
 //****************************************
 // Checks
@@ -213,6 +216,7 @@ export default {
 	createPageSpeedCheck,
 	deletePageSpeedChecksByMonitorId,
 	createHardwareCheck,
+	deleteHardwareChecksByMonitorId,
 	createMaintenanceWindow,
 	getMaintenanceWindowsByTeamId,
 	getMaintenanceWindowById,

--- a/Server/db/mongo/modules/hardwareCheckModule.js
+++ b/Server/db/mongo/modules/hardwareCheckModule.js
@@ -37,4 +37,16 @@ const createHardwareCheck = async (hardwareCheckData) => {
 	}
 };
 
-export { createHardwareCheck };
+const deleteHardwareChecksByMonitorId = async (monitorId) => {
+	try {
+		const result = await HardwareCheck.deleteMany({ monitorId });
+		console.log("deleted hardware checks", result);
+		return result.deletedCount;
+	} catch (error) {
+		error.service = SERVICE_NAME;
+		error.method = "deleteHardwareChecksByMonitorId";
+		throw error;
+	}
+};
+
+export { createHardwareCheck, deleteHardwareChecksByMonitorId };


### PR DESCRIPTION
HardwareChecks should be deleted when a monitor is deleted. 

- [x] Add a `deleteHardwareChecksByMonitorId` method
- [x] Call method when a monitor is deleted to remove all associated checks 