### PR TITLE
Fix Sidebar height to occupy viewport height

### DIFF
--- a/Client/src/Components/Sidebar/index.jsx
+++ b/Client/src/Components/Sidebar/index.jsx
@@ -262,7 +262,11 @@ function Sidebar() {
 						Menu
 					</ListSubheader>
 				}
-				sx={{ px: theme.spacing(6) }}
+				sx={{ 
+					px: theme.spacing(6),
+					height: "100%",
+					overflow: "hidden"
+				}}
 			>
 				{menu.map((item) =>
 					item.path ? (


### PR DESCRIPTION
This PR resolves issue #1290 fixing the empty space caused by the height mismatch of the viewport and sidebar. Also fixes the overflowing content of the profile section at the bottom of the sidebar.

![image](https://github.com/user-attachments/assets/a2033c45-43d0-4854-84b5-2a2d5d47bc5e)
![image](https://github.com/user-attachments/assets/0300a5eb-9217-4ab7-af56-bdc6efd1e267)
![image](https://github.com/user-attachments/assets/bef07819-f2ff-451d-abae-dd2df0db728a)

