### PR TITLE
fix: update red palette colors

### DIFF
--- a/Client/src/Utils/Theme/constants.js
+++ b/Client/src/Utils/Theme/constants.js
@@ -51,7 +51,8 @@ const paletteColors = {
 	red50: "#F9ECED",
 	red100: "#FBD1D1",
 	red200: "#F04438",
-	red300: "#D32F2F",
+	red300: "#EBA8A9",
+	red400: "#D32F2F",
 	red700: "#542426",
 	red800: "#301A1F",
 	orange50: "#FEF8EA",
@@ -109,12 +110,12 @@ const semanticColors = {
 	},
 	error: {
 		main: {
-			light: paletteColors.red300,
-			dark: paletteColors.red300,
+			light: paletteColors.red400,
+			dark: paletteColors.red400,
 		},
 		contrastText: {
-			light: paletteColors.gray50,
-			dark: paletteColors.gray50,
+			light: paletteColors.red300,
+			dark: paletteColors.red300,
 		},
 		light: {
 			light: paletteColors.red100,


### PR DESCRIPTION
### Summary
This PR fixes the issue for average response time chart color under `Monitor > Details` page.

### Changes Made
- Updated color palette for red color
- Updated the old `red300` to `red400`
- Updated `red300` with value of `#EBA8A9`

### Related Issue/s
Fixes #1328 

### Screenshots / Demo Video
**Before:**
![issue1328-before](https://github.com/user-attachments/assets/8fdda620-ecb1-4e45-8eea-68341e7f1691)

**After:**
![issue1328-after](https://github.com/user-attachments/assets/dc93712a-c65e-4407-b6e6-d33c78947b0b)

### Additional Context
N/A