### PR TITLE
- Change to grey  color for pending status

### DIFF
--- a/Client/src/Components/Label/index.jsx
+++ b/Client/src/Components/Label/index.jsx
@@ -141,9 +141,9 @@ const StatusLabel = ({ status, text, customStyles }) => {
 			borderColor: theme.palette.warning.light,
 		},
 		pending: {
-			dotColor: theme.palette.warning.main,
-			bgColor: theme.palette.warning.dark,
-			borderColor: theme.palette.warning.light,
+			dotColor: theme.palette.text.secondary,
+			bgColor: theme.palette.background.main,
+			borderColor: theme.palette.border.dark,
 		},
 		"cannot resolve": {
 			dotColor: theme.palette.unresolved.main,


### PR DESCRIPTION
- [x] update dot, background and border color to grey for both light and dark mode

Refer to below

![Screenshot from 2024-12-10 14-27-58](https://github.com/user-attachments/assets/10f301ef-1a56-49ca-a8e1-b2ca1101c4ea)
![Screenshot from 2024-12-10 14-27-31](https://github.com/user-attachments/assets/7bea5000-f8f7-44a2-b8d1-4fdae2f56198)
