### PR TITLE
feat: Wrap MUI button and apply styles, references #1318

### DIFF
--- a/Client/src/Components/BaseComponents/Button/index.jsx
+++ b/Client/src/Components/BaseComponents/Button/index.jsx
@@ -1,0 +1,71 @@
+import { styled } from "@mui/material/styles";
+import { Button as MuiButton } from "@mui/material";
+
+export const Button = styled(MuiButton)(({ theme }) => ({
+	disableRipple: true,
+	fontWeight: 400,
+	borderRadius: 4,
+	boxShadow: "none",
+	textTransform: "none",
+	"&:focus": {
+		outline: "none",
+	},
+	"&:hover": {
+		boxShadow: "none",
+	},
+	"&.MuiLoadingButton-root": {
+		"&:disabled": {
+			backgroundColor: theme.palette.secondary.main,
+			color: theme.palette.text.primary,
+		},
+	},
+	"&.MuiLoadingButton-loading": {
+		"& .MuiLoadingButton-label": {
+			color: "transparent",
+		},
+		"& .MuiLoadingButton-loadingIndicator": {
+			color: "inherit",
+		},
+	},
+	variants: [
+		{
+			props: (props) => props.variant === "group",
+			style: {
+				color: theme.palette.secondary.contrastText,
+				backgroundColor: theme.palette.background.main,
+				border: 1,
+				borderStyle: "solid",
+				borderColor: theme.palette.border.light,
+			},
+		},
+		{
+			props: (props) => props.variant === "group" && props.filled === "true",
+			style: {
+				backgroundColor: theme.palette.secondary.main,
+			},
+		},
+		{
+			props: (props) => props.variant === "contained" && props.color === "secondary",
+			style: {
+				border: 1,
+				borderStyle: "solid",
+				borderColor: theme.palette.border.light,
+			},
+		},
+		{
+			props: (props) => {
+				return (
+					props.variant === "contained" &&
+					props.disabled &&
+					props.classes.loadingIndicator === undefined // Do not apply to loading button
+				);
+			},
+			style: {
+				backgroundColor: `${theme.palette.secondary.main} !important`,
+				color: `${theme.palette.secondary.contrastText} !important`,
+			},
+		},
+	],
+}));
+
+export default Button;


### PR DESCRIPTION
This PR is a proposal for wrapping MUI components and applying styles as discussed and referenced in #1318.  It wraps an MUI Button and applies our styles from the `GlobalTheme`.  

Please try using the component next to a regular MUI Button, all styles appear to be applied correctly to me and the component appears identical to an MUI button styled by the `GlobalTheme`

I propose that we use styled components as this [MUI has support out of the box](https://mui.com/system/styled/) and this is how MUI components are styled themselves.

This will also allow us to pretty much directly copy and paste styles out of the Global theme which should speed up the process.

I suggest we standardize on this approach going forward.  That said I'm completely open to disucssion on the topic if anyone has strong opinions!

Once we've decided on the method of styling we'd like to use we can go forward and wrap all the necessary components.