### PR TITLE
fix: update demo server URLs to 'checkmate-demo.bluewavelabs.ca'

### DIFF
--- a/Docker/dist/nginx/conf.d/default.conf
+++ b/Docker/dist/nginx/conf.d/default.conf
@@ -2,7 +2,7 @@ server {
     listen       80;
     listen  [::]:80;
 
-    server_name uptime-demo.bluewavelabs.ca;
+    server_name checkmate-demo.bluewavelabs.ca;
     server_tokens off;
 
     location /.well-known/acme-challenge/ {

--- a/Docker/test/docker-compose.yaml
+++ b/Docker/test/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   client:
     image: uptime_client:latest
     environment:
-      UPTIME_APP_API_BASE_URL: "https://uptime-demo.bluewavelabs.ca/api/v1"
+      UPTIME_APP_API_BASE_URL: "https://checkmate-demo.bluewavelabs.ca/api/v1"
     ports:
       - "80:80"
       - "443:443"

--- a/Docker/test/prod/docker-compose.yaml
+++ b/Docker/test/prod/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   client:
     image: uptime_client:latest
     environment:
-      UPTIME_APP_API_BASE_URL: "https://uptime-demo.bluewavelabs.ca/api/v1"
+      UPTIME_APP_API_BASE_URL: "https://checkmate-demo.bluewavelabs.ca/api/v1"
     ports:
       - "80:80"
       - "443:443"

--- a/Docker/test/prod/nginx/conf.d/default.conf
+++ b/Docker/test/prod/nginx/conf.d/default.conf
@@ -2,7 +2,7 @@ server {
     listen       80;
     listen  [::]:80;
 
-    server_name uptime-demo.bluewavelabs.ca;
+    server_name checkmate-demo.bluewavelabs.ca;
     server_tokens off;
 
     location /.well-known/acme-challenge/ {
@@ -38,10 +38,10 @@ server {
     listen 443 default_server ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name uptime-demo.bluewavelabs.ca;
+    server_name checkmate-demo.bluewavelabs.ca;
 
-    ssl_certificate /etc/nginx/ssl/live/uptime-demo.bluewavelabs.ca/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/uptime-demo.bluewavelabs.ca/privkey.pem;
+    ssl_certificate /etc/nginx/ssl/live/checkmate-demo.bluewavelabs.ca/fullchain.pem;
+    ssl_certificate_key /etc/nginx/ssl/live/checkmate-demo.bluewavelabs.ca/privkey.pem;
     
     location / {
         root   /usr/share/nginx/html;

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -44,7 +44,7 @@
 			}
 		},
 		{
-			"url": "https://uptime-demo.bluewavelabs.ca/{API_PATH}",
+			"url": "https://checkmate-demo.bluewavelabs.ca/{API_PATH}",
 			"description": "Bluewave Demo Server",
 			"variables": {
 				"PORT": {

--- a/guides/README.md
+++ b/guides/README.md
@@ -26,7 +26,7 @@ It regularly checks whether a server/website is accessible and performs optimall
 
 ## Demo
 
-We have a [demo](https://uptime-demo.bluewavelabs.ca/) where you can test how the Uptime Manager works. The username is [uptimedemo@demo.com](mailto:uptimedemo@demo.com) and the password is Demouser1!
+We have a [demo](https://checkmate-demo.bluewavelabs.ca/) where you can test how the Uptime Manager works. The username is [uptimedemo@demo.com](mailto:uptimedemo@demo.com) and the password is Demouser1!
 
 ## Questions & ideas
 

--- a/guides/developers-guide/general-project-structure.md
+++ b/guides/developers-guide/general-project-structure.md
@@ -20,7 +20,7 @@ When making changes to the Front end please always keep future developers in min
 
 ### Back end
 
-The back end of this project is not especially complex and is built around Express.  The back end is a RESTful API and the [documentation can be found here](https://uptime-demo.bluewavelabs.ca/api-docs).
+The back end of this project is not especially complex and is built around Express.  The back end is a RESTful API and the [documentation can be found here](https://checkmate-demo.bluewavelabs.ca/api-docs).
 
 The application consists of several main conceptual models:
 

--- a/guides/users-guide/quickstart.md
+++ b/guides/users-guide/quickstart.md
@@ -201,7 +201,7 @@ Our API is documented in accordance with the [OpenAPI spec](https://www.openapis
 
 You can see the documentation on your local development server at http://localhost:{port}/api-docs
 
-You can also view the documentation on our demo server at [https://uptime-demo.bluewavelabs.ca/api-docs](https://uptime-demo.bluewavelabs.ca/api-docs)
+You can also view the documentation on our demo server at [https://checkmate-demo.bluewavelabs.ca/api-docs](https://checkmate-demo.bluewavelabs.ca/api-docs)
 
 ### Error handling
 


### PR DESCRIPTION
I noticed that the [back end api documentation link](https://bluewavelabs.gitbook.io/checkmate/developers-guide/general-project-structure#back-end) is broken. I changed the demo server URL from `uptime-demo.bluewavelabs.ca` to `checkmate-demo.bluewavelabs.ca` across multiple files.

#### Changed files

- nginx configs
- `UPTIME_APP_API_BASE_URL` values in docker compose files
- guides/
- openapi.json