### PR TITLE
fix: invite route

### DIFF
--- a/Server/routes/inviteRoute.js
+++ b/Server/routes/inviteRoute.js
@@ -9,6 +9,6 @@ import {
 const router = Router();
 
 router.post("/", isAllowed(["admin", "superadmin"]), verifyJWT, issueInvitation);
-router.post("/verify", issueInvitation);
+router.post("/verify", inviteVerifyController);
 
 export default router;


### PR DESCRIPTION
This PR fixes an error in the `InviteController`.

The wrong controller method was specified for the `/invite/verify` route.