### PR TITLE
fix: add pause toast to PageSpeed and Uptime configure pages, resolves #1380

### DIFF
--- a/Client/src/Pages/PageSpeed/Configure/index.jsx
+++ b/Client/src/Pages/PageSpeed/Configure/index.jsx
@@ -135,6 +135,8 @@ const PageSpeedConfigure = () => {
 			if (pausePageSpeed.fulfilled.match(action)) {
 				const monitor = action.payload.data;
 				setMonitor(monitor);
+				const state = action?.payload?.data.isActive === false ? "paused" : "resumed";
+				createToast({ body: `Monitor ${state} successfully.` });
 			} else if (pausePageSpeed.rejected.match(action)) {
 				throw new Error(action.error.message);
 			}

--- a/Client/src/Pages/Uptime/Configure/index.jsx
+++ b/Client/src/Pages/Uptime/Configure/index.jsx
@@ -141,6 +141,8 @@ const Configure = () => {
 			if (pauseUptimeMonitor.fulfilled.match(action)) {
 				const monitor = action.payload.data;
 				setMonitor(monitor);
+				const state = action?.payload?.data.isActive === false ? "paused" : "resumed";
+				createToast({ body: `Monitor ${state} successfully.` });
 			} else if (pauseUptimeMonitor.rejected.match(action)) {
 				throw new Error(action.error.message);
 			}


### PR DESCRIPTION
This PR adds a toast to be displayed on pause/resume of monitor
- [x] Add toast to Uptime configure page
- [x] Add toast to PageSpeed configure page 