### PR TITLE
chore(renovate): Auto label assign on Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
Dependabot assigning `dependencies` label for issue/pr categorization and it makes easy to filtering the PRs. This feature is also available on Renovate according to it's [documentation](https://docs.renovatebot.com/configuration-options/#labels)

- [x] Add `labels` field to `renovate.json`