### PR TITLE
Add a new uptime monitor > Radio buttons: unselected radio buttons are hard to see #1404 #1412

### DIFF
--- a/Client/src/Components/Inputs/Radio/index.jsx
+++ b/Client/src/Components/Inputs/Radio/index.jsx
@@ -42,6 +42,9 @@ const Radio = (props) => {
 						width: 16,
 						height: 16,
 						boxShadow: `inset 0 0 0 1px ${theme.palette.secondary.main}`,
+						"&:not(.Mui-checked)": {
+							boxShadow: `inset 0 0 0 1px ${theme.palette.text.primary}70`, // Use theme text color for the outline
+						},
 						mt: theme.spacing(0.5),
 					}}
 				/>


### PR DESCRIPTION
## Describe your changes
Changed the visibility of the radio buttons and made it darker.

## Issue Number
#1404 

## Please ensure all items are checked off before requesting a review:
- [x] I deployed the code locally.
- [x] I have performed a self-review of my code.
- [x] I have included the issue # in the PR.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I have labelled the PR correctly.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached this to PR if there is a UI change.

## Screenshot

![WhatsApp Image 2024-12-16 at 21 17 04_f9f24705](https://github.com/user-attachments/assets/fe1eed34-8329-445a-9e84-8a12d97aeb0c)
