### PR TITLE
fix: update dockeringore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 Client/node_modules/
 Server/node_modules/
-*.env
+Server/*.env


### PR DESCRIPTION
This PR updates the `.dockerignore` file to ignore the `.env ` config file in the `Server` dir when copying folders to build the docker image. 

- [x] Update dockerignore file