### PR TITLE
fix: incorrect password on password change causes user to be logged out, resolves #1384

### DIFF
--- a/Server/controllers/authController.js
+++ b/Server/controllers/authController.js
@@ -281,7 +281,8 @@ const editUser = async (req, res, next) => {
 			const user = await req.db.getUserByEmail(email);
 			// Compare passwords
 			const match = await user.comparePassword(req.body.password);
-			// If not a match, throw a 401
+			// If not a match, throw a 403
+			// 403 instead of 401 to avoid triggering axios interceptor
 			if (!match) {
 				const error = new Error(errorMessages.AUTH_INCORRECT_PASSWORD);
 				error.status = 403;

--- a/Server/controllers/authController.js
+++ b/Server/controllers/authController.js
@@ -284,7 +284,7 @@ const editUser = async (req, res, next) => {
 			// If not a match, throw a 401
 			if (!match) {
 				const error = new Error(errorMessages.AUTH_INCORRECT_PASSWORD);
-				error.status = 401;
+				error.status = 403;
 				next(error);
 				return;
 			}


### PR DESCRIPTION
This PR resolves the issue where if you enter an incorrect password when tryring to update your password you are logged out.

The reason for this is that we have an axios interceptor that boots the user on any 401 responses, ie trying to access resources that they don't have access to.

This is a special case where we don't want the user booted, so an incorrect password on reset now returns 403 instead of 401 which doesn't trigger the interceptor.

- [x] Incorrect password response code changed from 401 -> 403