### PR TITLE
fix: Match the radio border gradient to checkbox border gradient

### DIFF
--- a/Client/src/Components/Inputs/Radio/index.jsx
+++ b/Client/src/Components/Inputs/Radio/index.jsx
@@ -25,62 +25,71 @@ import "./index.css";
  */
 
 const Radio = (props) => {
-	const theme = useTheme();
+  const theme = useTheme();
+  const borderColor = theme.palette.mode === "dark"
+    ? theme.palette.grey[400]
+    : theme.palette.grey[500]; // Use a lighter shade for light mode
 
-	return (
-		<FormControlLabel
-			className="custom-radio-button"
-			checked={props.checked}
-			value={props.value}
-			control={
-				<MUIRadio
-					id={props.id}
-					size={props.size}
-					checkedIcon={<RadioChecked />}
-					sx={{
-						color: "transparent",
-						width: 16,
-						height: 16,
-						boxShadow: `inset 0 0 0 1px ${theme.palette.secondary.main}`,
-						mt: theme.spacing(0.5),
-					}}
-				/>
-			}
-			onChange={props.onChange}
-			label={
-				<>
-					<Typography component="p">{props.title}</Typography>
-					<Typography
-						component="h6"
-						mt={theme.spacing(1)}
-						color={theme.palette.text.secondary}
-					>
-						{props.desc}
-					</Typography>
-				</>
-			}
-			labelPlacement="end"
-			sx={{
-				alignItems: "flex-start",
-				p: theme.spacing(2.5),
-				m: theme.spacing(-2.5),
-				borderRadius: theme.shape.borderRadius,
-				"&:hover": {
-					backgroundColor: theme.palette.background.accent,
-				},
-				"& .MuiButtonBase-root": {
-					p: 0,
-					mr: theme.spacing(6),
-				},
-			}}
-		/>
-	);
+  return (
+    <FormControlLabel
+      className="custom-radio-button"
+      checked={props.checked}
+      value={props.value}
+      control={
+        <MUIRadio
+          id={props.id}
+          size={props.size}
+          checkedIcon={<RadioChecked />}
+          sx={{
+            color: "transparent",
+            width: 16,
+            height: 16,
+            borderColor: borderColor, // Dynamic border color
+            borderWidth: "1px",
+            borderStyle: "solid",
+            borderRadius: "50%", // Ensure circular shape
+            mt: theme.spacing(0.5),
+            "&.Mui-checked": {
+              borderColor: theme.palette.primary.main, // Highlight when checked
+            },
+          }}
+        />
+      }
+      onChange={props.onChange}
+      label={
+        <>
+          <Typography component="p">{props.title}</Typography>
+          <Typography
+            component="h6"
+            mt={theme.spacing(1)}
+            color={theme.palette.text.secondary}
+          >
+            {props.desc}
+          </Typography>
+        </>
+      }
+      labelPlacement="end"
+      sx={{
+        alignItems: "flex-start",
+        p: theme.spacing(2.5),
+        m: theme.spacing(-2.5),
+        borderRadius: theme.shape.borderRadius,
+        "&:hover": {
+          backgroundColor: theme.palette.background.accent,
+        },
+        "& .MuiButtonBase-root": {
+          p: 0,
+          mr: theme.spacing(6),
+        },
+      }}
+    />
+  );
 };
 
 Radio.propTypes = {
-	title: PropTypes.string.isRequired,
-	desc: PropTypes.string,
-	size: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  desc: PropTypes.string,
+  size: PropTypes.string,
 };
 
 export default Radio;


### PR DESCRIPTION
Fix: #1404

### Code Changes:
previous style
boxShadow: inset 0 0 0 1px ${theme.palette.secondary.main},

current style after switching from boxShadow to a border approach.
borderColor: borderColor, // Dynamic border color
borderWidth: "1px",
borderStyle: "solid",
borderRadius: "50%", // Ensure circular shape

Added specific styling for the checked state.
"&.Mui-checked": {
  borderColor: theme.palette.primary.main, // Highlight when checked
},

Added a borderColor variable for cleaner and reusable logic:

const borderColor = theme.palette.mode === "dark"
  ? theme.palette.grey[400]
  : theme.palette.grey[500];


before fix
![image](https://github.com/user-attachments/assets/fa1adcda-1643-4823-9449-4291a6ed3a33)
after fix
light mode
![image](https://github.com/user-attachments/assets/fb66a111-556d-41f5-9d16-c2d01e71f22d)
dark mode
![image](https://github.com/user-attachments/assets/d630b7b6-a3e2-425d-8c94-3bd4faeecaaa)

