### PR TITLE
fix: protected route proptype

### DIFF
--- a/Client/src/Components/ProtectedRoute/index.jsx
+++ b/Client/src/Components/ProtectedRoute/index.jsx
@@ -26,7 +26,7 @@ const ProtectedRoute = ({ children }) => {
 };
 
 ProtectedRoute.propTypes = {
-	children: PropTypes.elementType.isRequired,
+	children: PropTypes.element.isRequired,
 };
 
 export default ProtectedRoute;


### PR DESCRIPTION
This PR fixes the prop type for the `ProtectedRoute` component

- [x] Fix prop type `elementType` -> `element`