### PR TITLE
Feat/be/handle distributed monitors

### DIFF
--- a/Server/controllers/distributedUptimeController.js
+++ b/Server/controllers/distributedUptimeController.js
@@ -5,6 +5,10 @@ import { handleValidationError, handleError } from "./controllerUtils.js";
 const resultsCallback = async (req, res, next) => {
 	try {
 		console.log(req.body);
+
+		// TODO: Save the results to the database
+		// TODO: Update the monitor status
+
 		res.status(200).json({ message: "OK" });
 	} catch (error) {
 		throw handleError(error, SERVICE_NAME, "resultsCallback");

--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -162,6 +162,7 @@ class JobQueue {
 
 				// Get the current status
 				const networkResponse = await this.networkService.getStatus(job);
+				if (networkResponse === null) return;
 				// Handle status change
 				const { monitor, statusChanged, prevStatus } =
 					await this.statusService.updateStatus(networkResponse);

--- a/Server/service/networkService.js
+++ b/Server/service/networkService.js
@@ -264,15 +264,18 @@ class NetworkService {
 	}
 
 	async requestDistributed(job) {
+		let callbackUrl;
+		if (process.env.NODE_ENV === "development") {
+			callbackUrl = `${process.env.NGROK_URL}/api/v1/distributed-uptime/results`;
+		} else {
+			callbackUrl = `${process.env.NGROK_URL}/api/v1/distributed-uptime/results`;
+		}
 		try {
-			await this.axios.post(
-				`${process.env.NGROK_URL}/api/v1/distributed-uptime/results`,
-				{
-					targetUrl: job.data.url,
-					id: job.data._id,
-					callback: `${process.env.NGROK_URL}/api/v1/distributed-uptime/results`,
-				}
-			);
+			await this.axios.post(callbackUrl, {
+				targetUrl: job.data.url,
+				id: job.data._id,
+				callback: `${process.env.NGROK_URL}/api/v1/distributed-uptime/results`,
+			});
 			return null;
 		} catch (error) {
 			console.log(error);

--- a/Server/service/networkService.js
+++ b/Server/service/networkService.js
@@ -14,6 +14,7 @@ class NetworkService {
 		this.TYPE_PAGESPEED = "pagespeed";
 		this.TYPE_HARDWARE = "hardware";
 		this.TYPE_DOCKER = "docker";
+		this.TYPE_DISTRIBUTED = "distributed";
 		this.SERVICE_NAME = "NetworkService";
 		this.NETWORK_ERROR = 5000;
 		this.PING_ERROR = 5001;
@@ -262,6 +263,25 @@ class NetworkService {
 		}
 	}
 
+	async requestDistributed(job) {
+		try {
+			await this.axios.post(
+				`${process.env.NGROK_URL}/api/v1/distributed-uptime/results`,
+				{
+					targetUrl: job.data.url,
+					id: job.data._id,
+					callback: `${process.env.NGROK_URL}/api/v1/distributed-uptime/results`,
+				}
+			);
+			return null;
+		} catch (error) {
+			console.log(error);
+			error.service = this.SERVICE_NAME;
+			error.method = "requestDistributed";
+			throw error;
+		}
+	}
+
 	/**
 	 * Handles unsupported job types by throwing an error with details.
 	 *
@@ -297,6 +317,8 @@ class NetworkService {
 				return await this.requestHardware(job);
 			case this.TYPE_DOCKER:
 				return await this.requestDocker(job);
+			case this.TYPE_DISTRIBUTED:
+				return await this.requestDistributed(job);
 			default:
 				return this.handleUnsupportedType(type);
 		}


### PR DESCRIPTION
This PR lays the groundwork for handling distributed uptime responses

- [x] Add an early return to `JobQueue` if `networkResponse` is `null`.  Network response from distributed uptime will purposefully return `null` as a signal to return early from the job as we don't want to follow the regular monitor flow for distributed uptime monitors

- [x] Add a placeholder request for distributed uptime.  Currently calls the callback, will eventually call third party API endpoint

- [x] Move up ngrok config in the server config so the URL is available before job queue is spun up 