### PR TITLE
Fix: Old name reference on the Server Side

### DIFF
--- a/Server/controllers/authController.js
+++ b/Server/controllers/authController.js
@@ -361,7 +361,7 @@ const requestRecovery = async (req, res, next) => {
 				url,
 			},
 			email,
-			"Bluewave Uptime Password Reset"
+			"Checkmate Password Reset"
 		);
 
 		return res.status(200).json({

--- a/Server/openapi.json
+++ b/Server/openapi.json
@@ -1,9 +1,9 @@
 {
 	"openapi": "3.1.0",
 	"info": {
-		"title": "BlueWave Uptime",
-		"summary": "BlueWave Uptime OpenAPI Specifications",
-		"description": "BlueWave Uptime is an open source server monitoring application used to track the operational status and performance of servers and websites. It regularly checks whether a server/website is accessible and performs optimally, providing real-time alerts and reports on the monitored services' availability, downtime, and response time.",
+		"title": "Checkmate",
+		"summary": "Checkmate OpenAPI Specifications",
+		"description": "Checkmate is an open source monitoring tool used to track the operational status and performance of servers and websites. It regularly checks whether a server/website is accessible and performs optimally, providing real-time alerts and reports on the monitored services' availability, downtime, and response time.",
 		"contact": {
 			"name": "API Support",
 			"url": "mailto:support@bluewavelabs.ca",
@@ -11,7 +11,7 @@
 		},
 		"license": {
 			"name": "AGPLv3",
-			"url": "https://github.com/bluewave-labs/bluewave-uptime/tree/HEAD/LICENSE"
+			"url": "https://github.com/bluewave-labs/checkmate/tree/HEAD/LICENSE"
 		},
 		"version": "1.0"
 	},
@@ -45,7 +45,7 @@
 		},
 		{
 			"url": "https://checkmate-demo.bluewavelabs.ca/{API_PATH}",
-			"description": "Bluewave Demo Server",
+			"description": "Checkmate Demo Server",
 			"variables": {
 				"PORT": {
 					"description": "API Port",

--- a/Server/templates/employeeActivation.mjml
+++ b/Server/templates/employeeActivation.mjml
@@ -22,7 +22,7 @@
 				<mj-text
 					align="left"
 					font-size="10px"
-					>Message from BlueWave Uptime Service</mj-text
+					>Message from Checkmate Service</mj-text
 				>
 			</mj-column>
 		</mj-section>
@@ -31,7 +31,7 @@
 				<mj-text>
 					<p>Hello {{name}}!</p>
 					<p>
-						One of the admins created an account for you on the BlueWave Uptime server.
+						One of the admins created an account for you on the Checkmate server.
 					</p>
 					<p>You can go ahead and create your account using this link.</p>
 					<p><a href="{{link}}">{{link}}</a></p>
@@ -44,7 +44,7 @@
 					border-color="#E0E0E0"
 				></mj-divider>
 				<mj-text font-size="12px">
-					<p>This email was sent by BlueWave Uptime.</p>
+					<p>This email was sent by Checkmate.</p>
 				</mj-text>
 			</mj-column>
 		</mj-section>

--- a/Server/templates/noIncidentsThisWeek.mjml
+++ b/Server/templates/noIncidentsThisWeek.mjml
@@ -21,7 +21,7 @@
 				<mj-text
 					align="left"
 					font-size="10px"
-					>Message from BlueWave Uptime Service</mj-text
+					>Message from Checkmate Service</mj-text
 				>
 			</mj-column>
 			<mj-column
@@ -58,7 +58,7 @@
 					border-color="#E0E0E0"
 				></mj-divider>
 				<mj-text font-size="12px">
-					<p>This email was sent by BlueWave Uptime.</p>
+					<p>This email was sent by Checkmate.</p>
 				</mj-text>
 			</mj-column>
 		</mj-section>

--- a/Server/templates/passwordReset.mjml
+++ b/Server/templates/passwordReset.mjml
@@ -24,7 +24,7 @@
 					align="left"
 					font-size="10px"
 				>
-					Message from BlueWave Uptime Service
+					Message from Checkmate Service
 				</mj-text>
 			</mj-column>
 		</mj-section>
@@ -48,7 +48,7 @@
 					border-color="#E0E0E0"
 				></mj-divider>
 				<mj-text font-size="12px">
-					<p>This email was sent by BlueWave Uptime.</p>
+					<p>This email was sent by Checkmate.</p>
 				</mj-text>
 			</mj-column>
 		</mj-section>

--- a/Server/templates/serverIsDown.mjml
+++ b/Server/templates/serverIsDown.mjml
@@ -11,7 +11,7 @@
     <mj-section padding="20px 0">
       <mj-column width="100%">
         <mj-text align="left" font-size="10px">
-          Message from BlueWave Uptime Service
+          Message from Checkmate Service
         </mj-text>
       </mj-column>
       <mj-column width="45%" padding-top="20px">
@@ -37,7 +37,7 @@
         <mj-divider border-width="1px" border-color="#E0E0E0"></mj-divider>
         <mj-button background-color="#1570EF"> View incident details </mj-button>
         <mj-text font-size="12px">
-          <p>This email was sent by BlueWave Uptime.</p>
+          <p>This email was sent by Checkmate.</p>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/Server/templates/serverIsUp.mjml
+++ b/Server/templates/serverIsUp.mjml
@@ -11,7 +11,7 @@
     <mj-section padding="20px 0">
       <mj-column width="100%">
         <mj-text align="left" font-size="10px">
-          Message from BlueWave Uptime Service
+          Message from Checkmate Service
         </mj-text>
       </mj-column>
       <mj-column width="45%" padding-top="20px">
@@ -34,7 +34,7 @@
         <mj-divider border-width="1px" border-color="#E0E0E0"></mj-divider>
         <mj-button background-color="#1570EF"> View incident details </mj-button>
         <mj-text font-size="12px">
-          <p>This email was sent by BlueWave Uptime.</p>
+          <p>This email was sent by Checkmate.</p>
         </mj-text>
       </mj-column>
     </mj-section>

--- a/Server/templates/welcomeEmail.mjml
+++ b/Server/templates/welcomeEmail.mjml
@@ -23,7 +23,7 @@
 					align="left"
 					font-size="10px"
 				>
-					Message from BlueWave Uptime Service
+					Message from Checkmate Service
 				</mj-text>
 			</mj-column>
 		</mj-section>
@@ -32,11 +32,11 @@
 				<mj-text>
 					<p>Hello {{name}}!</p>
 					<p>
-						Thank you for trying out BlueWave Uptime! We developed it with great care to
+						Thank you for trying out Checkmate! We developed it with great care to
 						meet our own needs, and we're excited to share it with you.
 					</p>
 					<p>
-						BlueWave Uptime is an automated way of checking whether a service such as a
+						Checkmate is an automated way of checking whether a service such as a
 						website or an application is available or not.
 					</p>
 					<p>We hope you find our service as valuable as we do.</p>
@@ -49,7 +49,7 @@
 					border-color="#E0E0E0"
 				></mj-divider>
 				<mj-text font-size="12px">
-					<p>This email was sent by BlueWave Uptime.</p>
+					<p>This email was sent by Checkmate.</p>
 				</mj-text>
 			</mj-column>
 		</mj-section>

--- a/Server/tests/controllers/authController.test.js
+++ b/Server/tests/controllers/authController.test.js
@@ -649,7 +649,7 @@ describe("Auth Controller - requestRecovery", () => {
 					url: "http://localhost/set-new-password/recovery-token",
 				},
 				"test@test.com",
-				"Bluewave Uptime Password Reset"
+				"Checkmate Password Reset"
 			)
 		).to.be.true;
 		expect(res.status.calledOnceWith(200)).to.be.true;


### PR DESCRIPTION
- [x] Update `openapi.json` to work with new Checkmate name instead of old BlueWave Uptime. Also update description below with the same text on the README.md
- [x] Replace all `BlueWave Uptime` with `Checkmate` under the `Server/` directory.

There are also old naming under the `Client/` directory. If you are thinking changing all `BlueWave Uptime` strings to `Checkmate` in this PR please let me know.

I'm not thinking about updating docs, guides for now.