### PR TITLE
fix: always restart docker images

### DIFF
--- a/Docker/dev/docker-compose.yaml
+++ b/Docker/dev/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   client:
     image: uptime_client:latest
+    restart: always
     ports:
       - "5173:5173"
 
@@ -8,6 +9,7 @@ services:
       - server
   server:
     image: uptime_server:latest
+    restart: always
     ports:
       - "5000:5000"
     env_file:
@@ -17,12 +19,14 @@ services:
       - mongodb
   redis:
     image: uptime_redis:latest
+    restart: always
     ports:
       - "6379:6379"
     volumes:
       - ./redis/data:/data
   mongodb:
     image: uptime_database_mongo:latest
+    restart: always
     command: ["mongod", "--quiet"]
     ports:
       - "27017:27017"

--- a/Docker/dist/docker-compose.yaml
+++ b/Docker/dist/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   client:
     image: bluewaveuptime/uptime_client:latest
+    restart: always
     environment:
       UPTIME_APP_API_BASE_URL: "http://localhost:5000/api/v1"
     ports:
@@ -10,6 +11,7 @@ services:
       - server
   server:
     image: bluewaveuptime/uptime_server:latest
+    restart: always
     ports:
       - "5000:5000"
     depends_on:
@@ -22,12 +24,14 @@ services:
     # - /var/run/docker.sock:/var/run/docker.sock:ro
   redis:
     image: bluewaveuptime/uptime_redis:latest
+    restart: always
     ports:
       - "6379:6379"
     volumes:
       - ./redis/data:/data
   mongodb:
     image: bluewaveuptime/uptime_database_mongo:latest
+    restart: always
     volumes:
       - ./mongo/data:/data/db
     command: ["mongod", "--quiet"]

--- a/Docker/prod/docker-compose.yaml
+++ b/Docker/prod/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   client:
     image: uptime_client:latest
+    restart: always
     environment:
       UPTIME_APP_API_BASE_URL: "https://checkmate-demo.bluewavelabs.ca/api/v1"
     ports:
@@ -15,11 +16,13 @@ services:
 
   certbot:
     image: certbot/certbot:latest
+    restart: always
     volumes:
       - ./certbot/www/:/var/www/certbot/:rw
       - ./certbot/conf/:/etc/letsencrypt/:rw
   server:
     image: uptime_server:latest
+    restart: always
     ports:
       - "5000:5000"
     env_file:
@@ -29,12 +32,14 @@ services:
       - mongodb
   redis:
     image: uptime_redis:latest
+    restart: always
     ports:
       - "6379:6379"
     volumes:
       - ./redis/data:/data
   mongodb:
     image: uptime_database_mongo:latest
+    restart: always
     command: ["mongod", "--quiet", "--auth"]
     ports:
       - "27017:27017"

--- a/Docker/test/docker-compose.yaml
+++ b/Docker/test/docker-compose.yaml
@@ -1,6 +1,7 @@
 services:
   client:
     image: uptime_client:latest
+    restart: always
     environment:
       UPTIME_APP_API_BASE_URL: "https://checkmate-demo.bluewavelabs.ca/api/v1"
     ports:
@@ -15,11 +16,13 @@ services:
 
   certbot:
     image: certbot/certbot:latest
+    restart: always
     volumes:
       - ./certbot/www/:/var/www/certbot/:rw
       - ./certbot/conf/:/etc/letsencrypt/:rw
   server:
     image: uptime_server:latest
+    restart: always
     ports:
       - "5000:5000"
     env_file:
@@ -29,6 +32,7 @@ services:
       - mongodb
   redis:
     image: uptime_redis:latest
+    restart: always
     ports:
       - "6379:6379"
     volumes:


### PR DESCRIPTION
This PR adds the `restart:always` flag to the docker-compose files. 