### PR TITLE
fix test config docker-compose URL

### DIFF
--- a/Docker/test/docker-compose.yaml
+++ b/Docker/test/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   client:
     image: uptime_client:latest
     environment:
-      UPTIME_APP_API_BASE_URL: "https://checkmate-demo.bluewavelabs.ca/api/v1"
+      UPTIME_APP_API_BASE_URL: "https://checkmate-test.bluewavelabs.ca/api/v1"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
This PR updates the test config's API base url