### PR TITLE
hotfix: move middleware to after JobQueue initialization

### DIFF
--- a/Server/index.js
+++ b/Server/index.js
@@ -70,15 +70,6 @@ const startApp = async () => {
 	app.use(express.json());
 	app.use(helmet());
 
-	// Add db, jobQueue, emailService, and settingsService to request object for easy access
-	app.use((req, res, next) => {
-		req.db = db;
-		req.jobQueue = jobQueue;
-		req.emailService = emailService;
-		req.settingsService = settingsService;
-		next();
-	});
-
 	// Swagger UI
 	app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(openApiSpec));
 
@@ -161,6 +152,15 @@ const startApp = async () => {
 		Queue,
 		Worker
 	);
+
+	// Add db, jobQueue, emailService, and settingsService to request object for easy access
+	app.use((req, res, next) => {
+		req.db = db;
+		req.jobQueue = jobQueue;
+		req.emailService = emailService;
+		req.settingsService = settingsService;
+		next();
+	});
 
 	const shutdown = async () => {
 		if (isShuttingDown) {


### PR DESCRIPTION
This PR moves middleware that uses `JobQueue` to after `JobQueue` initialization