### PR TITLE
hotfix: fix certificate format

### DIFF
--- a/Client/src/Pages/Uptime/Details/index.jsx
+++ b/Client/src/Pages/Uptime/Details/index.jsx
@@ -1,14 +1,6 @@
 import PropTypes from "prop-types";
 import { useEffect, useState, useCallback } from "react";
-import {
-	Box,
-	Button,
-	Popover,
-	Stack,
-	Tooltip,
-	Typography,
-	useTheme,
-} from "@mui/material";
+import { Box, Button, Stack, Tooltip, Typography, useTheme } from "@mui/material";
 import { useSelector } from "react-redux";
 import { useNavigate, useParams } from "react-router-dom";
 import { networkService } from "../../../main";
@@ -17,7 +9,6 @@ import { formatDurationRounded, formatDurationSplit } from "../../../Utils/timeU
 import MonitorDetailsAreaChart from "../../../Components/Charts/MonitorDetailsAreaChart";
 import ButtonGroup from "@mui/material/ButtonGroup";
 import SettingsIcon from "../../../assets/icons/settings-bold.svg?react";
-import CertificateIcon from "../../../assets/icons/certificate.svg?react";
 import UptimeIcon from "../../../assets/icons/uptime-icon.svg?react";
 import ResponseTimeIcon from "../../../assets/icons/response-time-icon.svg?react";
 import AverageResponseIcon from "../../../assets/icons/average-response-icon.svg?react";
@@ -50,15 +41,8 @@ const DetailsPage = () => {
 	const [certificateExpiry, setCertificateExpiry] = useState("N/A");
 	const navigate = useNavigate();
 
-	const [anchorEl, setAnchorEl] = useState(null);
-	const openCertificate = (event) => {
-		setAnchorEl(event.currentTarget);
-	};
-	const closeCertificate = () => {
-		setAnchorEl(null);
-	};
-
-	const dateFormat = dateRange === "day" ? "MMM D, YYYY h A" : "MMM D";
+	const certificateDateFormat = "MMM D, YYYY h A";
+	const dateFormat = dateRange === "day" ? "MMM D, h A" : "MMM D";
 	const uiTimezone = useSelector((state) => state.ui.timezone);
 
 	const fetchMonitor = useCallback(async () => {
@@ -95,7 +79,9 @@ const DetailsPage = () => {
 				});
 				if (res?.data?.data?.certificateDate) {
 					const date = res.data.data.certificateDate;
-					setCertificateExpiry(formatDateWithTz(date, dateFormat, uiTimezone) ?? "N/A");
+					setCertificateExpiry(
+						formatDateWithTz(date, certificateDateFormat, uiTimezone) ?? "N/A"
+					);
 				}
 			} catch (error) {
 				setCertificateExpiry("N/A");
@@ -210,7 +196,6 @@ const DetailsPage = () => {
 									alignSelf: "flex-end",
 								}}
 							>
-								
 								{isAdmin && (
 									<Button
 										variant="contained"


### PR DESCRIPTION
This PR fixes incorrect usage of a date format for the SSL certificate expiry format string.

It also removes unused imports