### PR TITLE
fix: be/db indices

### DIFF
--- a/Server/db/models/Check.js
+++ b/Server/db/models/Check.js
@@ -67,5 +67,8 @@ const BaseCheckSchema = mongoose.Schema({
  */
 const CheckSchema = mongoose.Schema({ ...BaseCheckSchema.obj }, { timestamps: true });
 CheckSchema.index({ createdAt: 1 });
+CheckSchema.index({ monitorId: 1, createdAt: 1 });
+CheckSchema.index({ monitorId: 1, createdAt: -1 });
+
 export default mongoose.model("Check", CheckSchema);
 export { BaseCheckSchema };

--- a/Server/db/models/HardwareCheck.js
+++ b/Server/db/models/HardwareCheck.js
@@ -64,5 +64,7 @@ const HardwareCheckSchema = mongoose.Schema(
 );
 
 HardwareCheckSchema.index({ createdAt: 1 });
+HardwareCheckSchema.index({ monitorId: 1, createdAt: 1 });
+HardwareCheckSchema.index({ monitorId: 1, createdAt: -1 });
 
 export default mongoose.model("HardwareCheck", HardwareCheckSchema);

--- a/Server/db/mongo/MongoDB.js
+++ b/Server/db/mongo/MongoDB.js
@@ -91,6 +91,13 @@ class MongoDB {
 				appSettings = new AppSettings({});
 				await appSettings.save();
 			}
+			// Sync indexes
+			const models = mongoose.modelNames();
+			for (const modelName of models) {
+				const model = mongoose.model(modelName);
+				await model.syncIndexes();
+			}
+
 			logger.info({ message: "Connected to MongoDB" });
 		} catch (error) {
 			logger.error({

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -223,15 +223,22 @@ const getDateRange = (dateRange) => {
  * @returns {Promise<Object>} All checks and date-ranged checks
  */
 const getMonitorChecks = async (monitorId, model, dateRange, sortOrder) => {
+	const indexSpec = {
+		monitorId: 1,
+		createdAt: sortOrder, // This will be 1 or -1
+	};
+
 	const [checksAll, checksForDateRange] = await Promise.all([
-		model.find({ monitorId }).sort({ createdAt: sortOrder }),
+		model.find({ monitorId }).sort({ createdAt: sortOrder }).hint(indexSpec).lean(),
 		model
 			.find({
 				monitorId,
 				createdAt: { $gte: dateRange.start, $lte: dateRange.end },
 			})
-			.sort({ createdAt: sortOrder }),
+			.hint(indexSpec)
+			.lean(),
 	]);
+
 	return { checksAll, checksForDateRange };
 };
 


### PR DESCRIPTION
This PR adds indices to some models to improve query performance.  Some queries, especially check queries, have a lot of data and can benefit from DB indices.

- [x] Add indices to Check model
- [x]  Add indices to HardwareCheck model
- [x] Force index use in `getMonitorStatsById` 