### PR TITLE
Update sidebar settings label for clarity and it's path configured

### DIFF
--- a/Client/src/Components/Sidebar/index.jsx
+++ b/Client/src/Components/Sidebar/index.jsx
@@ -98,7 +98,7 @@ const PATH_MAP = {
 	pagespeed: "Dashboard",
 	infrastructure: "Dashboard",
 	account: "Account",
-	settings: "Other",
+	settings: "Settings",
 };
 
 /**


### PR DESCRIPTION
Fixed the setting button so that it won't open the option drop-down menu.