### PR TITLE
feat: devops/add healthcheck to redis image

### DIFF
--- a/Docker/dev/docker-compose.yaml
+++ b/Docker/dev/docker-compose.yaml
@@ -24,6 +24,12 @@ services:
       - "6379:6379"
     volumes:
       - ./redis/data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 5s
   mongodb:
     image: uptime_database_mongo:latest
     restart: always

--- a/Docker/dist/docker-compose.yaml
+++ b/Docker/dist/docker-compose.yaml
@@ -29,6 +29,12 @@ services:
       - "6379:6379"
     volumes:
       - ./redis/data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 5s
   mongodb:
     image: bluewaveuptime/uptime_database_mongo:latest
     restart: always

--- a/Docker/prod/docker-compose.yaml
+++ b/Docker/prod/docker-compose.yaml
@@ -37,6 +37,12 @@ services:
       - "6379:6379"
     volumes:
       - ./redis/data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 5s
   mongodb:
     image: uptime_database_mongo:latest
     restart: always

--- a/Docker/test/docker-compose.yaml
+++ b/Docker/test/docker-compose.yaml
@@ -37,6 +37,12 @@ services:
       - "6379:6379"
     volumes:
       - ./redis/data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 5s
   mongodb:
     image: uptime_database_mongo:latest
     command: ["mongod", "--quiet", "--auth"]


### PR DESCRIPTION
This PR adds a health check to the docker-compose files for the Redis image.  This should improve stability as the server won't try to connect before Redis responds to the ping.