### PR TITLE
hotfix: fix env vars for settings service

### DIFF
--- a/Server/controllers/authController.js
+++ b/Server/controllers/authController.js
@@ -8,14 +8,12 @@ import {
 	newPasswordValidation,
 } from "../validation/joi.js";
 import logger from "../utils/logger.js";
-import dotenv from "dotenv";
 import { errorMessages, successMessages } from "../utils/messages.js";
 import jwt from "jsonwebtoken";
 import { getTokenFromHeaders, tokenType } from "../utils/utils.js";
 import crypto from "crypto";
 import { handleValidationError, handleError } from "./controllerUtils.js";
 const SERVICE_NAME = "authController";
-dotenv.config();
 
 class AuthController {
 	constructor(db, settingsService, emailService, jobQueue) {

--- a/Server/service/settingsService.js
+++ b/Server/service/settingsService.js
@@ -1,4 +1,6 @@
 const SERVICE_NAME = "SettingsService";
+import dotenv from "dotenv";
+dotenv.config();
 const envConfig = {
 	logLevel: undefined,
 	apiBaseUrl: undefined,


### PR DESCRIPTION
This PR repairs the SettingsService as it was missing the `dotenv` import, hence env vars were not loaded resulting in default values being used.