### PR TITLE
Left align Profile > Password components

### DIFF
--- a/Client/src/Components/TabPanels/Account/PasswordPanel.jsx
+++ b/Client/src/Components/TabPanels/Account/PasswordPanel.jsx
@@ -126,8 +126,8 @@ const PasswordPanel = () => {
 				noValidate
 				spellCheck="false"
 				gap={theme.spacing(26)}
-				maxWidth={"80ch"}
-				marginInline={"auto"}
+				maxWidth={"80ch"}  // Keep maxWidth
+				
 			>
 				<TextInput
 					type="text"
@@ -166,7 +166,7 @@ const PasswordPanel = () => {
 				</Stack>
 				<Stack
 					direction="row"
-					alignItems={"center"}
+					alignItems={"flex-start"}
 					gap={SPACING_GAP} 
 					flexWrap={"wrap"}
 				>
@@ -192,7 +192,7 @@ const PasswordPanel = () => {
 				</Stack>
 				<Stack
 					direction="row"
-					alignItems={"center"}
+					alignItems={"flex-start"}
 					gap={SPACING_GAP} 
 					flexWrap={"wrap"}
 				>


### PR DESCRIPTION
## Describe your changes
- Left aligning password component to match the profile page alignment.

Briefly describe the changes you made and their purpose. 
- Edited `Client/src/Components/TabPanels/PasswordPanel.jsx`, removed marginInline and changed alignItems to flex-start

## Issue number
Fixes #1508 
## Please ensure all items are checked off before requesting a review:

- [x] I deployed the application locally.
- [x] I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


Screenshots:
Light Mode:
<img width="1097" alt="Screenshot 2025-01-03 at 2 21 33 PM" src="https://github.com/user-attachments/assets/fa991569-16f4-4a80-ba0e-bf9fe0eaff4b" />

Dark Mode:
<img width="1041" alt="Screenshot 2025-01-03 at 2 21 47 PM" src="https://github.com/user-attachments/assets/52978bda-61b4-4249-bd99-8398858b4088" />


