### PR TITLE
hotfix: fe/monitor validation, resolves #1518

### DIFF
--- a/Client/src/Validation/validation.js
+++ b/Client/src/Validation/validation.js
@@ -95,6 +95,7 @@ const monitorValidation = joi.object({
 		.string()
 		.trim()
 		.custom((value, helpers) => {
+			// Regex from https://gist.github.com/dperini/729294
 			var urlRegex = new RegExp(
 				"^" +
 					// protocol identifier (optional)

--- a/Client/src/Validation/validation.js
+++ b/Client/src/Validation/validation.js
@@ -95,9 +95,48 @@ const monitorValidation = joi.object({
 		.string()
 		.trim()
 		.custom((value, helpers) => {
-			const urlRegex =
-				/^(https?:\/\/)?(([0-9]{1,3}\.){3}[0-9]{1,3}|[\da-z\.-]+)(\.[a-z\.]{2,6})?(:(\d+))?([\/\w \.-]*)*\/?$/i;
-
+			var urlRegex = new RegExp(
+				"^" +
+					// protocol identifier (optional)
+					// short syntax // still required
+					"(?:(?:(?:https?|ftp):)?\\/\\/)" +
+					// user:pass BasicAuth (optional)
+					"(?:\\S+(?::\\S*)?@)?" +
+					"(?:" +
+					// IP address exclusion
+					// private & local networks
+					"(?!(?:10|127)(?:\\.\\d{1,3}){3})" +
+					"(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})" +
+					"(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})" +
+					// IP address dotted notation octets
+					// excludes loopback network 0.0.0.0
+					// excludes reserved space >= 224.0.0.0
+					// excludes network & broadcast addresses
+					// (first & last IP address of each class)
+					"(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
+					"(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
+					"(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
+					"|" +
+					// host & domain names, may end with dot
+					// can be replaced by a shortest alternative
+					// (?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.)+
+					"(?:" +
+					"(?:" +
+					"[a-z0-9\\u00a1-\\uffff]" +
+					"[a-z0-9\\u00a1-\\uffff_-]{0,62}" +
+					")?" +
+					"[a-z0-9\\u00a1-\\uffff]\\." +
+					")+" +
+					// TLD identifier name, may end with dot
+					"(?:[a-z\\u00a1-\\uffff]{2,}\\.?)" +
+					")" +
+					// port number (optional)
+					"(?::\\d{2,5})?" +
+					// resource path (optional)
+					"(?:[/?#]\\S*)?" +
+					"$",
+				"i"
+			);
 			if (!urlRegex.test(value)) {
 				return helpers.error("string.invalidUrl");
 			}


### PR DESCRIPTION
This PR resovles a backtracking isue with a regex used to verify URLs on the client side.
