### PR TITLE
Using envstub to modify nginx/default.conf

### DIFF
--- a/Docker/dist/client.Dockerfile
+++ b/Docker/dist/client.Dockerfile
@@ -13,7 +13,15 @@ RUN npm run build
 
 FROM nginx:1.27.1-alpine
 
-COPY ./Docker/dist/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf
+# Default values for envstub
+ENV LISTEN_PORT=80
+ENV SERVER_URL=http://server:5000
+ENV SERVER_NAME=checkmate-demo.bluewavelabs.ca
+
+# Using envstub to modify config on startup
+# See https://hub.docker.com/_/nginx
+COPY ./default.conf.template /etc/nginx/templates/default.conf.template
+
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY --from=build /app/env.sh /docker-entrypoint.d/env.sh
 RUN chmod +x /docker-entrypoint.d/env.sh

--- a/Docker/dist/nginx/conf.d/default.conf.template
+++ b/Docker/dist/nginx/conf.d/default.conf.template
@@ -12,7 +12,7 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
-        try_files $uri $uri/ /index.htmLISTl;
+        try_files $uri $uri/ /index.html;
     }
     
     location /api/ {

--- a/Docker/dist/nginx/conf.d/default.conf.template
+++ b/Docker/dist/nginx/conf.d/default.conf.template
@@ -1,8 +1,8 @@
 server {
-    listen       80;
-    listen  [::]:80;
+    listen       $LISTEN_PORT;
+    listen  [::]:$LISTEN_PORT;
 
-    server_name checkmate-demo.bluewavelabs.ca;
+    server_name $SERVER_NAME;
     server_tokens off;
 
     location /.well-known/acme-challenge/ {
@@ -12,11 +12,11 @@ server {
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ /index.htmLISTl;
     }
     
     location /api/ {
-        proxy_pass http://server:5000/api/;
+        proxy_pass $SERVER_URL/api/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -25,7 +25,7 @@ server {
     }
 
     location /api-docs/ {
-        proxy_pass http://server:5000/api-docs/;
+        proxy_pass $SERVER_URL/api-docs/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Describe your changes

Creating the final `nginx/default.conf` using envstub.
This is a default feature from nginx 1.19 on.

I wanted to use the image in my helm chart/kubernetes but I got the following error:
```
[emerg] 1#1: host not found in upstream "server" in /etc/nginx/conf.d/default.conf:19
[emerg] host not found in upstream "server" in /etc/nginx/conf.d/default.conf:19
```

This is because in `Docker/dist/nginx/conf.d/default.conf` is set to the docker-compose hostname `server`.
But because I do not have that hostname, it tries to find it upstream.

## Issue number

... ?? none ...

## Please ensure all items are checked off before requesting a review:

- [x] I deployed the application locally.
- [x] I have performed a self-review and testing of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

