### PR TITLE
feat: be/unified uptime query

### DIFF
--- a/Client/src/Features/PageSpeedMonitor/pageSpeedMonitorSlice.js
+++ b/Client/src/Features/PageSpeedMonitor/pageSpeedMonitorSlice.js
@@ -40,7 +40,7 @@ export const checkEndpointResolution = createAsyncThunk(
 			const res = await networkService.checkEndpointResolution({
 				authToken: authToken,
 				monitorURL: monitorURL,
-			})
+			});
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -53,7 +53,7 @@ export const checkEndpointResolution = createAsyncThunk(
 			return thunkApi.rejectWithValue(payload);
 		}
 	}
-)
+);
 
 export const getPagespeedMonitorById = createAsyncThunk(
 	"monitors/getMonitorById",
@@ -88,7 +88,6 @@ export const getPageSpeedByTeamId = createAsyncThunk(
 				teamId: user.teamId,
 				types: ["pagespeed"],
 			});
-
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {

--- a/Client/src/Features/UptimeMonitors/uptimeMonitorsSlice.js
+++ b/Client/src/Features/UptimeMonitors/uptimeMonitorsSlice.js
@@ -78,62 +78,6 @@ export const getUptimeMonitorById = createAsyncThunk(
 	}
 );
 
-export const getUptimeSummaryByTeamId = createAsyncThunk(
-	"monitors/getSummaryByTeamId",
-	async (token, thunkApi) => {
-		const user = jwtDecode(token);
-		try {
-			const res = await networkService.getMonitorsSummaryByTeamId({
-				authToken: token,
-				teamId: user.teamId,
-				types: ["http", "ping", "docker", "port"],
-			});
-			return res.data;
-		} catch (error) {
-			if (error.response && error.response.data) {
-				return thunkApi.rejectWithValue(error.response.data);
-			}
-			const payload = {
-				status: false,
-				msg: error.message ? error.message : "Unknown error",
-			};
-			return thunkApi.rejectWithValue(payload);
-		}
-	}
-);
-
-export const getUptimeMonitorsByTeamId = createAsyncThunk(
-	"monitors/getMonitorsByTeamId",
-	async (config, thunkApi) => {
-		try {
-			const res = await networkService.getMonitorsByTeamId({
-				authToken: config.authToken,
-				teamId: config.teamId,
-				limit: 25,
-				types: ["http", "ping", "docker", "port"],
-				status: null,
-				checkOrder: "desc",
-				normalize: true,
-				page: config.page,
-				rowsPerPage: config.rowsPerPage,
-				filter: config.filter,
-				field: config.sort.field,
-				order: config.sort.order,
-			});
-			return res.data;
-		} catch (error) {
-			if (error.response && error.response.data) {
-				return thunkApi.rejectWithValue(error.response.data);
-			}
-			const payload = {
-				status: false,
-				msg: error.message ? error.message : "Unknown error",
-			};
-			return thunkApi.rejectWithValue(payload);
-		}
-	}
-);
-
 export const updateUptimeMonitor = createAsyncThunk(
 	"monitors/updateMonitor",
 	async (data, thunkApi) => {
@@ -289,42 +233,6 @@ const uptimeMonitorsSlice = createSlice({
 	},
 	extraReducers: (builder) => {
 		builder
-			// *****************************************************
-			// Summary by teamId
-			// *****************************************************
-
-			.addCase(getUptimeSummaryByTeamId.pending, (state) => {
-				state.isLoading = true;
-			})
-			.addCase(getUptimeSummaryByTeamId.fulfilled, (state, action) => {
-				state.isLoading = false;
-				state.success = action.payload.msg;
-				state.monitorsSummary = action.payload.data;
-			})
-			.addCase(getUptimeSummaryByTeamId.rejected, (state, action) => {
-				state.isLoading = false;
-				state.success = false;
-				state.msg = action.payload ? action.payload.msg : "Getting uptime summary failed";
-			})
-
-			// *****************************************************
-			// Monitors by teamId
-			// *****************************************************
-			.addCase(getUptimeMonitorsByTeamId.pending, (state) => {
-				state.isLoading = true;
-			})
-			.addCase(getUptimeMonitorsByTeamId.fulfilled, (state, action) => {
-				state.isLoading = false;
-				state.success = action.payload.success;
-				state.msg = action.payload.msg;
-			})
-			.addCase(getUptimeMonitorsByTeamId.rejected, (state, action) => {
-				state.isLoading = false;
-				state.success = false;
-				state.msg = action.payload
-					? action.payload.msg
-					: "Getting uptime monitors failed";
-			})
 			// *****************************************************
 			// Create Monitor
 			// *****************************************************

--- a/Client/src/Pages/Infrastructure/index.jsx
+++ b/Client/src/Pages/Infrastructure/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { /* useDispatch, */ useSelector } from "react-redux";
 import { useTheme } from "@emotion/react";
@@ -50,12 +50,13 @@ function Infrastructure() {
 		setRowsPerPage(parseInt(event.target.value));
 		setPage(0);
 	};
-	const [monitorState, setMonitorState] = useState({ monitors: [], total: 0 });
+	const [monitors, setMonitors] = useState([]);
+	const [summary, setSummary] = useState({});
 
 	const { authToken } = useSelector((state) => state.auth);
 	const user = jwtDecode(authToken);
 
-	const fetchMonitors = async () => {
+	const fetchMonitors = useCallback(async () => {
 		try {
 			setIsLoading(true);
 			const response = await networkService.getMonitorsByTeamId({
@@ -63,29 +64,23 @@ function Infrastructure() {
 				teamId: user.teamId,
 				limit: 1,
 				types: ["hardware"],
-				status: null,
-				checkOrder: "desc",
-				normalize: true,
 				page: page,
 				rowsPerPage: rowsPerPage,
 			});
-			setMonitorState({
-				monitors: response?.data?.data?.monitors ?? [],
-				total: response?.data?.data?.monitorCount ?? 0,
-			});
+			setMonitors(response?.data?.data?.monitors ?? []);
+			setSummary(response?.data?.data?.summary ?? {});
 		} catch (error) {
 			console.error(error);
 		} finally {
 			setIsLoading(false);
 		}
-	};
+	}, [page, rowsPerPage, authToken, user.teamId]);
 
 	useEffect(() => {
 		fetchMonitors();
-	}, [page, rowsPerPage]);
+	}, [fetchMonitors]);
 
 	const { determineState } = useUtils();
-	const { monitors, total: totalMonitors } = monitorState;
 	// do it here
 	function openDetails(id) {
 		navigate(`/infrastructure/${id}`);
@@ -191,7 +186,7 @@ function Infrastructure() {
 		};
 	});
 
-	let isActuallyLoading = isLoading && monitorState.monitors?.length === 0;
+	let isActuallyLoading = isLoading && monitors?.length === 0;
 	return (
 		<Box
 			className="infrastructure-monitor"
@@ -209,7 +204,7 @@ function Infrastructure() {
 		>
 			{isActuallyLoading ? (
 				<SkeletonLayout />
-			) : monitorState.monitors?.length !== 0 ? (
+			) : monitors?.length !== 0 ? (
 				<Stack gap={theme.spacing(8)}>
 					<Box>
 						<Breadcrumbs list={BREADCRUMBS} />
@@ -254,7 +249,7 @@ function Infrastructure() {
 								borderColor={theme.palette.border.light}
 								backgroundColor={theme.palette.background.accent}
 							>
-								{totalMonitors}
+								{summary?.totalMonitors ?? 0}
 							</Box>
 						</Stack>
 
@@ -272,7 +267,7 @@ function Infrastructure() {
 							data={monitorsAsRows}
 						/>
 						<Pagination
-							monitorCount={totalMonitors}
+							monitorCount={summary?.totalMonitors ?? 0}
 							page={page}
 							rowsPerPage={rowsPerPage}
 							handleChangePage={handleChangePage}

--- a/Client/src/Pages/PageSpeed/card.jsx
+++ b/Client/src/Pages/PageSpeed/card.jsx
@@ -267,7 +267,7 @@ const Card = ({ monitor }) => {
 					sx={{ gridColumnStart: 1, gridColumnEnd: 4 }}
 				>
 					<PagespeedAreaChart
-						data={monitor.checks}
+						data={monitor.checks.slice().reverse()}
 						status={monitorState}
 					/>
 				</Box>

--- a/Client/src/Pages/PageSpeed/index.jsx
+++ b/Client/src/Pages/PageSpeed/index.jsx
@@ -1,8 +1,7 @@
 import { Box, Button, Grid, Stack } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useTheme } from "@emotion/react";
-import { useDispatch, useSelector } from "react-redux";
-import { getPageSpeedByTeamId } from "../../Features/PageSpeedMonitor/pageSpeedMonitorSlice";
+import { useSelector } from "react-redux";
 import Fallback from "../../Components/Fallback";
 import "./index.css";
 import { useNavigate } from "react-router";
@@ -15,16 +14,12 @@ import { Heading } from "../../Components/Heading";
 import { useIsAdmin } from "../../Hooks/useIsAdmin";
 const PageSpeed = () => {
 	const theme = useTheme();
-	const dispatch = useDispatch();
 	const navigate = useNavigate();
 	const isAdmin = useIsAdmin();
 	const { user, authToken } = useSelector((state) => state.auth);
 	const [isLoading, setIsLoading] = useState(true);
 	const [monitors, setMonitors] = useState([]);
 	const [monitorCount, setMonitorCount] = useState(0);
-	useEffect(() => {
-		dispatch(getPageSpeedByTeamId(authToken));
-	}, [authToken, dispatch]);
 
 	useEffect(() => {
 		const fetchMonitors = async () => {

--- a/Client/src/Pages/PageSpeed/index.jsx
+++ b/Client/src/Pages/PageSpeed/index.jsx
@@ -19,7 +19,7 @@ const PageSpeed = () => {
 	const { user, authToken } = useSelector((state) => state.auth);
 	const [isLoading, setIsLoading] = useState(true);
 	const [monitors, setMonitors] = useState([]);
-	const [monitorCount, setMonitorCount] = useState(0);
+	const [summary, setSummary] = useState({});
 
 	useEffect(() => {
 		const fetchMonitors = async () => {
@@ -30,9 +30,6 @@ const PageSpeed = () => {
 					teamId: user.teamId,
 					limit: 10,
 					types: ["pagespeed"],
-					status: null,
-					checkOrder: "desc",
-					normalize: true,
 					page: null,
 					rowsPerPage: null,
 					filter: null,
@@ -41,7 +38,7 @@ const PageSpeed = () => {
 				});
 				if (res?.data?.data?.monitors) {
 					setMonitors(res.data.data.monitors);
-					setMonitorCount(res.data.data.monitorCount);
+					setSummary(res.data.data.summary);
 				}
 			} catch (error) {
 				console.log(error);
@@ -113,7 +110,7 @@ const PageSpeed = () => {
 							borderColor={theme.palette.border.light}
 							backgroundColor={theme.palette.background.accent}
 						>
-							{monitorCount}
+							{summary?.totalMonitors ?? 0}
 						</Box>
 					</Stack>
 					<Grid

--- a/Client/src/Pages/Uptime/Home/UptimeDataTable/index.jsx
+++ b/Client/src/Pages/Uptime/Home/UptimeDataTable/index.jsx
@@ -12,13 +12,42 @@ import ActionsMenu from "../actionsMenu";
 
 // Utils
 import { useTheme } from "@emotion/react";
-import useDebounce from "../../../../Utils/debounce";
-import { useState } from "react";
 import useUtils from "../../utils";
 import { memo } from "react";
 import { useNavigate } from "react-router-dom";
 import "../index.css";
+import PropTypes from "prop-types";
 
+/**
+ * UptimeDataTable displays a table of uptime monitors with sorting, searching, and action capabilities
+ * @param {Object} props - Component props
+ * @param {boolean} props.isAdmin - Whether the current user has admin privileges
+ * @param {boolean} props.isLoading - Loading state of the table
+ * @param {Array<{
+ *   _id: string,
+ *   url: string,
+ *   title: string,
+ *   percentage: number,
+ *   percentageColor: string,
+ *   monitor: {
+ *     _id: string,
+ *     type: string,
+ *     checks: Array
+ *   }
+ * }>} props.monitors - Array of monitor objects to display
+ * @param {number} props.monitorCount - Total count of monitors
+ * @param {Object} props.sort - Current sort configuration
+ * @param {string} props.sort.field - Field to sort by
+ * @param {'asc'|'desc'} props.sort.order - Sort direction
+ * @param {Function} props.setSort - Callback to update sort configuration
+ * @param {string} props.search - Current search query
+ * @param {Function} props.setSearch - Callback to update search query
+ * @param {boolean} props.isSearching - Whether a search is in progress
+ * @param {Function} props.setIsSearching - Callback to update search state
+ * @param {Function} props.setIsLoading - Callback to update loading state
+ * @param {Function} props.triggerUpdate - Callback to trigger a data refresh
+ * @returns {JSX.Element} Rendered component
+ */
 const UptimeDataTable = ({
 	isAdmin,
 	isLoading,
@@ -30,6 +59,7 @@ const UptimeDataTable = ({
 	setSearch,
 	isSearching,
 	setIsSearching,
+	setIsLoading,
 	triggerUpdate,
 }) => {
 	const { determineState } = useUtils();
@@ -37,8 +67,6 @@ const UptimeDataTable = ({
 	const theme = useTheme();
 	const navigate = useNavigate();
 
-	//Utils
-	const debouncedFilter = useDebounce(search, 500);
 	const handleSearch = (value) => {
 		setIsSearching(true);
 		setSearch(value);
@@ -146,6 +174,7 @@ const UptimeDataTable = ({
 					monitor={row.monitor}
 					isAdmin={isAdmin}
 					updateRowCallback={triggerUpdate}
+					setIsLoading={setIsLoading}
 					pauseCallback={triggerUpdate}
 				/>
 			),
@@ -187,7 +216,7 @@ const UptimeDataTable = ({
 				</Box>
 			</Stack>
 			<Box position="relative">
-				{isSearching && (
+				{(isSearching || isLoading) && (
 					<>
 						<Box
 							width="100%"
@@ -240,3 +269,21 @@ const UptimeDataTable = ({
 
 const MemoizedUptimeDataTable = memo(UptimeDataTable);
 export default MemoizedUptimeDataTable;
+
+UptimeDataTable.propTypes = {
+	isAdmin: PropTypes.bool,
+	isLoading: PropTypes.bool,
+	monitors: PropTypes.array,
+	monitorCount: PropTypes.number,
+	sort: PropTypes.shape({
+		field: PropTypes.string,
+		order: PropTypes.oneOf(["asc", "desc"]),
+	}),
+	setSort: PropTypes.func,
+	search: PropTypes.string,
+	setSearch: PropTypes.func,
+	isSearching: PropTypes.bool,
+	setIsSearching: PropTypes.func,
+	setIsLoading: PropTypes.func,
+	triggerUpdate: PropTypes.func,
+};

--- a/Client/src/Pages/Uptime/Home/actionsMenu.jsx
+++ b/Client/src/Pages/Uptime/Home/actionsMenu.jsx
@@ -8,13 +8,18 @@ import { IconButton, Menu, MenuItem } from "@mui/material";
 import {
 	deleteUptimeMonitor,
 	pauseUptimeMonitor,
-	getUptimeMonitorsByTeamId,
 } from "../../../Features/UptimeMonitors/uptimeMonitorsSlice";
 import Settings from "../../../assets/icons/settings-bold.svg?react";
 import PropTypes from "prop-types";
 import Dialog from "../../../Components/Dialog";
 
-const ActionsMenu = ({ monitor, isAdmin, updateRowCallback, pauseCallback }) => {
+const ActionsMenu = ({
+	monitor,
+	isAdmin,
+	updateRowCallback,
+	pauseCallback,
+	setIsLoading,
+}) => {
 	const [anchorEl, setAnchorEl] = useState(null);
 	const [actions, setActions] = useState({});
 	const [isOpen, setIsOpen] = useState(false);
@@ -33,7 +38,6 @@ const ActionsMenu = ({ monitor, isAdmin, updateRowCallback, pauseCallback }) => 
 		);
 		if (action.meta.requestStatus === "fulfilled") {
 			setIsOpen(false); // close modal
-			dispatch(getUptimeMonitorsByTeamId(authState.authToken));
 			updateRowCallback();
 			createToast({ body: "Monitor deleted successfully." });
 		} else {
@@ -43,6 +47,7 @@ const ActionsMenu = ({ monitor, isAdmin, updateRowCallback, pauseCallback }) => 
 
 	const handlePause = async () => {
 		try {
+			setIsLoading(true);
 			const action = await dispatch(
 				pauseUptimeMonitor({ authToken, monitorId: monitor._id })
 			);
@@ -223,6 +228,7 @@ ActionsMenu.propTypes = {
 	isAdmin: PropTypes.bool,
 	updateRowCallback: PropTypes.func,
 	pauseCallback: PropTypes.func,
+	setIsLoading: PropTypes.func,
 };
 
 export default ActionsMenu;

--- a/Client/src/Utils/NetworkService.js
+++ b/Client/src/Utils/NetworkService.js
@@ -157,9 +157,6 @@ class NetworkService {
 	 * @param {string} config.teamId - The ID of the team whose monitors are to be retrieved.
 	 * @param {number} [config.limit] - The maximum number of checks to retrieve.  0 for all, -1 for none
 	 * @param {Array<string>} [config.types] - The types of monitors to retrieve.
-	 * @param {string} [config.status] - The status of the monitors to retrieve.
-	 * @param {string} [config.checkOrder] - The order in which to sort the retrieved monitors.
-	 * @param {boolean} [config.normalize] - Whether to normalize the retrieved monitors.
 	 * @param {number} [config.page] - The page number for pagination.
 	 * @param {number} [config.rowsPerPage] - The number of rows per page for pagination.
 	 * @param {string} [config.filter] - The filter to apply to the monitors.
@@ -167,21 +164,10 @@ class NetworkService {
 	 * @param {string} [config.order] - The order in which to sort the field.
 	 * @returns {Promise<AxiosResponse>} The response from the axios GET request.
 	 */
+
 	async getMonitorsByTeamId(config) {
-		const {
-			authToken,
-			teamId,
-			limit,
-			types,
-			status,
-			checkOrder,
-			normalize,
-			page,
-			rowsPerPage,
-			filter,
-			field,
-			order,
-		} = config;
+		const { authToken, teamId, limit, types, page, rowsPerPage, filter, field, order } =
+			config;
 
 		const params = new URLSearchParams();
 
@@ -191,9 +177,6 @@ class NetworkService {
 				params.append("type", type);
 			});
 		}
-		if (status) params.append("status", status);
-		if (checkOrder) params.append("checkOrder", checkOrder);
-		if (normalize) params.append("normalize", normalize);
 		if (page) params.append("page", page);
 		if (rowsPerPage) params.append("rowsPerPage", rowsPerPage);
 		if (filter) params.append("filter", filter);

--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -1,13 +1,11 @@
 import {
 	getMonitorByIdParamValidation,
 	getMonitorByIdQueryValidation,
-	getMonitorsByTeamIdValidation,
+	getMonitorsByTeamIdParamValidation,
+	getMonitorsByTeamIdQueryValidation,
 	createMonitorBodyValidation,
 	getMonitorURLByQueryValidation,
 	editMonitorBodyValidation,
-	getMonitorsSummaryByTeamIdParamValidation,
-	getMonitorsSummaryByTeamIdQueryValidation,
-	getMonitorsByTeamIdQueryValidation,
 	pauseMonitorParamValidation,
 	getMonitorStatsByIdParamValidation,
 	getMonitorStatsByIdQueryValidation,
@@ -201,77 +199,6 @@ class MonitorController {
 			});
 		} catch (error) {
 			next(handleError(error, SERVICE_NAME, "getMonitorById"));
-		}
-	};
-
-	/**
-	 * Retrieves all monitors and a summary for a team based on the team ID.
-	 * @async
-	 * @param {Object} req - The Express request object.
-	 * @property {Object} req.params - The parameters of the request.
-	 * @property {string} req.params.teamId - The ID of the team.
-	 * @property {Object} req.query - The query parameters of the request.
-	 * @property {string} req.query.type - The type of the request.
-	 * @param {Object} res - The Express response object.
-	 * @param {function} next - The next middleware function.
-	 * @returns {Object} The response object with a success status, a message, and the data containing the monitors and summary for the team.
-	 * @throws {Error} If there is an error during the process, especially if there is a validation error (422).
-	 */
-	getMonitorsSummaryByTeamId = async (req, res, next) => {
-		try {
-			await getMonitorsSummaryByTeamIdParamValidation.validateAsync(req.params);
-			await getMonitorsSummaryByTeamIdQueryValidation.validateAsync(req.query);
-		} catch (error) {
-			next(handleValidationError(error, SERVICE_NAME));
-			return;
-		}
-
-		try {
-			const { teamId } = req.params;
-			const { type } = req.query;
-			const monitorsSummary = await this.db.getMonitorsSummaryByTeamId(teamId, type);
-			return res.status(200).json({
-				success: true,
-				msg: successMessages.MONITOR_GET_BY_USER_ID(teamId),
-				data: monitorsSummary,
-			});
-		} catch (error) {
-			next(handleError(error, SERVICE_NAME, "getMonitorsAndSummaryByTeamId"));
-		}
-	};
-
-	/**
-	 * Retrieves all monitors associated with a team by the team's ID.
-	 * @async
-	 * @param {Object} req - The Express request object.
-	 * @property {Object} req.params - The parameters of the request.
-	 * @property {string} req.params.teamId - The ID of the team.
-	 * @property {Object} req.query - The query parameters of the request.
-	 * @param {Object} res - The Express response object.
-	 * @param {function} next - The next middleware function.
-	 * @returns {Object} The response object with a success status, a message, and the data containing the monitors for the team.
-	 * @throws {Error} If there is an error during the process, especially if there is a validation error (422).
-	 */
-	getMonitorsByTeamId = async (req, res, next) => {
-		try {
-			await getMonitorsByTeamIdValidation.validateAsync(req.params);
-			await getMonitorsByTeamIdQueryValidation.validateAsync(req.query);
-		} catch (error) {
-			next(handleValidationError(error, SERVICE_NAME));
-			return;
-		}
-
-		try {
-			const teamId = req.params.teamId;
-			const monitors = await this.db.getMonitorsByTeamId(req, res);
-			return res.status(200).json({
-				success: true,
-				msg: successMessages.MONITOR_GET_BY_USER_ID(teamId),
-				data: monitors,
-			});
-		} catch (error) {
-			next(handleError(error, SERVICE_NAME, "getMonitorsByTeamId"));
-			next(error);
 		}
 	};
 
@@ -562,6 +489,26 @@ class MonitorController {
 			});
 		} catch (error) {
 			next(handleError(error, SERVICE_NAME, "addDemoMonitors"));
+		}
+	};
+
+	getMonitorsByTeamId = async (req, res, next) => {
+		try {
+			await getMonitorsByTeamIdParamValidation.validateAsync(req.params);
+			await getMonitorsByTeamIdQueryValidation.validateAsync(req.query);
+		} catch (error) {
+			next(handleValidationError(error, SERVICE_NAME));
+		}
+
+		try {
+			const monitors = await this.db.getMonitorsByTeamId(req);
+			return res.status(200).json({
+				success: true,
+				msg: "good",
+				data: monitors,
+			});
+		} catch (error) {
+			next(handleError(error, SERVICE_NAME, "getMonitorsForDisplay"));
 		}
 	};
 }

--- a/Server/routes/monitorRoute.js
+++ b/Server/routes/monitorRoute.js
@@ -17,6 +17,7 @@ class MonitorRoutes {
 			"/hardware/details/:monitorId",
 			this.monitorController.getHardwareDetailsById
 		);
+
 		this.router.get(
 			"/uptime/details/:monitorId",
 			this.monitorController.getUptimeDetailsById
@@ -30,10 +31,7 @@ class MonitorRoutes {
 			);
 		});
 		this.router.get("/:monitorId", this.monitorController.getMonitorById);
-		this.router.get(
-			"/team/summary/:teamId",
-			this.monitorController.getMonitorsSummaryByTeamId
-		);
+
 		this.router.get("/team/:teamId", this.monitorController.getMonitorsByTeamId);
 
 		this.router.get(

--- a/Server/validation/joi.js
+++ b/Server/validation/joi.js
@@ -136,32 +136,12 @@ const getMonitorByIdQueryValidation = joi.object({
 	normalize: joi.boolean(),
 });
 
-const getMonitorsSummaryByTeamIdParamValidation = joi.object({
-	teamId: joi.string().required(),
-});
-
-const getMonitorsSummaryByTeamIdQueryValidation = joi.object({
-	type: joi
-		.alternatives()
-		.try(
-			joi.string().valid("http", "ping", "pagespeed", "docker", "hardware", "port"),
-			joi
-				.array()
-				.items(
-					joi.string().valid("http", "ping", "pagespeed", "docker", "hardware", "port")
-				)
-		),
-});
-
-const getMonitorsByTeamIdValidation = joi.object({
+const getMonitorsByTeamIdParamValidation = joi.object({
 	teamId: joi.string().required(),
 });
 
 const getMonitorsByTeamIdQueryValidation = joi.object({
-	status: joi.boolean(),
-	checkOrder: joi.string().valid("asc", "desc"),
 	limit: joi.number(),
-	normalize: joi.boolean(),
 	type: joi
 		.alternatives()
 		.try(
@@ -467,9 +447,7 @@ export {
 	createMonitorBodyValidation,
 	getMonitorByIdParamValidation,
 	getMonitorByIdQueryValidation,
-	getMonitorsSummaryByTeamIdParamValidation,
-	getMonitorsSummaryByTeamIdQueryValidation,
-	getMonitorsByTeamIdValidation,
+	getMonitorsByTeamIdParamValidation,
 	getMonitorsByTeamIdQueryValidation,
 	getMonitorStatsByIdParamValidation,
 	getMonitorStatsByIdQueryValidation,


### PR DESCRIPTION
This PR unifies two separate queries that were made in order to fetch monitors.  Previously, one query was made for a summary of monitors, one query made for a list of monitors with checks.  Now one query is made using the aggregate pipeline and facets in order to get all the data in one go. 

- [x] Combine two separate queries in to one
- [x] Update queries to remove unnecessary params
- [x] Update validation

In order to make use of these queries some changes were requried on the FE.  There is no need to store these monitors in the redux state any longer, so fetching has been moved to the component.  Unnecessary redux thunks are removed and loading managed locally.  

- [x] Refactor all pages that make use of the `getMonitorsById` and `getMonitorsSummary` methods to use the new unified method.
- [x] Remove unused redux thunks
- [x] Handle loading locally 