### PR TITLE
hotfix: move filtering to the monitors facet

### DIFF
--- a/Client/src/Pages/Uptime/Home/index.jsx
+++ b/Client/src/Pages/Uptime/Home/index.jsx
@@ -137,8 +137,8 @@ const UptimeMonitors = () => {
 	const triggerUpdate = () => {
 		setMonitorUpdateTrigger((prev) => !prev);
 	};
-	const totalMonitors = monitorsSummary.totalMonitors;
-	const hasMonitors = totalMonitors > 0;
+	const totalMonitors = monitorsSummary?.totalMonitors ?? 0;
+	const hasMonitors = monitorsSummary?.totalMonitors ?? 0;
 	const canAddMonitor = isAdmin && hasMonitors;
 
 	return (

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -523,13 +523,6 @@ const getMonitorsByTeamId = async (req) => {
 
 	const sort = { [field]: order === "asc" ? 1 : -1 };
 
-	if (filter !== undefined) {
-		matchStage.$or = [
-			{ name: { $regex: filter, $options: "i" } },
-			{ url: { $regex: filter, $options: "i" } },
-		];
-	}
-
 	const results = await Monitor.aggregate([
 		{ $match: matchStage },
 		{
@@ -563,6 +556,18 @@ const getMonitorsByTeamId = async (req) => {
 					},
 				],
 				monitors: [
+					...(filter !== undefined
+						? [
+								{
+									$match: {
+										$or: [
+											{ name: { $regex: filter, $options: "i" } },
+											{ url: { $regex: filter, $options: "i" } },
+										],
+									},
+								},
+							]
+						: []),
 					{ $sort: sort },
 					{ $skip: skip },
 					...(rowsPerPage ? [{ $limit: rowsPerPage }] : []),


### PR DESCRIPTION
This PR moves the filtering portion of the match stage to the monitors facet instead of matching before the facets.

Filtering by name should only be done _after_ building summary data.