### PR TITLE
hotfix: fe/be/incidents page

### DIFF
--- a/Client/src/Pages/Incidents/index.jsx
+++ b/Client/src/Pages/Incidents/index.jsx
@@ -29,7 +29,7 @@ const Incidents = () => {
 				const res = await networkService.getMonitorsByTeamId({
 					authToken: authState.authToken,
 					teamId: authState.user.teamId,
-					limit: -1,
+					limit: null,
 					types: null,
 					status: null,
 					checkOrder: null,
@@ -40,7 +40,6 @@ const Incidents = () => {
 					field: null,
 					order: null,
 				});
-				// Reduce to a lookup object for 0(1) lookup
 				if (res?.data?.data?.monitors?.length > 0) {
 					const monitorLookup = res.data.data.monitors.reduce((acc, monitor) => {
 						acc[monitor._id] = monitor;
@@ -56,7 +55,7 @@ const Incidents = () => {
 			}
 		};
 		fetchMonitors();
-	}, [authState]);
+	}, [authState, monitorId]);
 
 	useEffect(() => {}, [monitors]);
 

--- a/Server/controllers/monitorController.js
+++ b/Server/controllers/monitorController.js
@@ -508,7 +508,7 @@ class MonitorController {
 				data: monitors,
 			});
 		} catch (error) {
-			next(handleError(error, SERVICE_NAME, "getMonitorsForDisplay"));
+			next(handleError(error, SERVICE_NAME, "getMonitorsByTeamId"));
 		}
 	};
 }

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -508,7 +508,6 @@ const getMonitorById = async (monitorId) => {
 const getMonitorsByTeamId = async (req) => {
 	let { limit, type, page, rowsPerPage, filter, field, order } = req.query;
 
-	// Parse ints
 	limit = parseInt(limit);
 	page = parseInt(page);
 	rowsPerPage = parseInt(rowsPerPage);
@@ -571,54 +570,67 @@ const getMonitorsByTeamId = async (req) => {
 					{ $sort: sort },
 					{ $skip: skip },
 					...(rowsPerPage ? [{ $limit: rowsPerPage }] : []),
-					{
-						$lookup: {
-							from: "checks",
-							let: { monitorId: "$_id" },
-							pipeline: [
+					...(limit
+						? [
 								{
-									$match: {
-										$expr: { $eq: ["$monitorId", "$$monitorId"] },
+									$lookup: {
+										from: "checks",
+										let: { monitorId: "$_id" },
+										pipeline: [
+											{
+												$match: {
+													$expr: { $eq: ["$monitorId", "$$monitorId"] },
+												},
+											},
+											{ $sort: { createdAt: -1 } },
+											...(limit ? [{ $limit: limit }] : []),
+										],
+										as: "standardchecks",
 									},
 								},
-								{ $sort: { createdAt: -1 } },
-								...(limit ? [{ $limit: limit }] : []),
-							],
-							as: "standardchecks",
-						},
-					},
-					{
-						$lookup: {
-							from: "pagespeedchecks",
-							let: { monitorId: "$_id" },
-							pipeline: [
+							]
+						: []),
+					...(limit
+						? [
 								{
-									$match: {
-										$expr: { $eq: ["$monitorId", "$$monitorId"] },
+									$lookup: {
+										from: "pagespeedchecks",
+										let: { monitorId: "$_id" },
+										pipeline: [
+											{
+												$match: {
+													$expr: { $eq: ["$monitorId", "$$monitorId"] },
+												},
+											},
+											{ $sort: { createdAt: -1 } },
+											...(limit ? [{ $limit: limit }] : []),
+										],
+										as: "pagespeedchecks",
 									},
 								},
-								{ $sort: { createdAt: -1 } },
-								...(limit ? [{ $limit: limit }] : []),
-							],
-							as: "pagespeedchecks",
-						},
-					},
-					{
-						$lookup: {
-							from: "hardwarechecks",
-							let: { monitorId: "$_id" },
-							pipeline: [
+							]
+						: []),
+					...(limit
+						? [
 								{
-									$match: {
-										$expr: { $eq: ["$monitorId", "$$monitorId"] },
+									$lookup: {
+										from: "hardwarechecks",
+										let: { monitorId: "$_id" },
+										pipeline: [
+											{
+												$match: {
+													$expr: { $eq: ["$monitorId", "$$monitorId"] },
+												},
+											},
+											{ $sort: { createdAt: -1 } },
+											...(limit ? [{ $limit: limit }] : []),
+										],
+										as: "hardwarechecks",
 									},
 								},
-								{ $sort: { createdAt: -1 } },
-								...(limit ? [{ $limit: limit }] : []),
-							],
-							as: "hardwarechecks",
-						},
-					},
+							]
+						: []),
+
 					{
 						$addFields: {
 							checks: {
@@ -662,6 +674,9 @@ const getMonitorsByTeamId = async (req) => {
 
 	let { monitors, summary } = results[0];
 	monitors = monitors.map((monitor) => {
+		if (!monitor.checks) {
+			return monitor;
+		}
 		monitor.checks = NormalizeData(monitor.checks, 10, 100);
 		return monitor;
 	});


### PR DESCRIPTION
This PR resolves #1538.  The aggregate pipeline doesn't deal with negative values for `limit` gracefully so `null` is used instead.

- [x] replace limit value of `-1` with `null`