### PR TITLE
fix: use jobScheduler instead of deprecatred repeatable

### DIFF
--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -463,8 +463,6 @@ class NewJobQueue {
 				jobTemplate
 			);
 
-			await queue.upsert;
-
 			const workerStats = await this.getWorkerStats(queue);
 			await this.scaleWorkers(workerStats, queue);
 		} catch (error) {


### PR DESCRIPTION
BullMQ recently depcrecated their [Repeatable API](https://docs.bullmq.io/guide/jobs/repeatable) in favour of their [Job Scheudler API](https://docs.bullmq.io/guide/job-schedulers)

This PR migrates to the new API.  This is timely as there were some issues with repeatable getting stuck anyways.

- [x] Use Job Sheduler API instead of Repeatable API