### PR TITLE
fix: hasMonitors logic

### DIFF
--- a/Client/src/Pages/Uptime/Home/index.jsx
+++ b/Client/src/Pages/Uptime/Home/index.jsx
@@ -140,7 +140,7 @@ const UptimeMonitors = () => {
 		setMonitorUpdateTrigger((prev) => !prev);
 	}, []);
 	const totalMonitors = monitorsSummary?.totalMonitors ?? 0;
-	const hasMonitors = monitorsSummary?.totalMonitors ?? 0;
+	const hasMonitors = totalMonitors > 0;
 	const canAddMonitor = isAdmin && hasMonitors;
 
 	return (


### PR DESCRIPTION
The logic for `hasMonitors` was incorrect, looks like probably a copy/paste error occurred at some point.

- [x] use totalMonitors > 0 to set `hasMonitors` to `true` or `false` for correct comparison.