### PR TITLE
Fix server is down mjml to show monitor name

### DIFF
--- a/Server/templates/serverIsDown.mjml
+++ b/Server/templates/serverIsDown.mjml
@@ -16,7 +16,7 @@
       </mj-column>
       <mj-column width="45%" padding-top="20px">
         <mj-text align="center" font-weight="500" padding="0px" font-size="18px" color="red">
-          Google.com is down
+          {{monitor}} is down
         </mj-text>
         <mj-divider border-width="2px" border-color="#616161"></mj-divider>
       </mj-column>


### PR DESCRIPTION
Was static google.com is now the monitor name in the header

## Describe your changes

The mjml/email `serverIsDown` always showed _google.com_ is down in any monitor.
Now it shows the actual name of the monitor that went down.

## Issue number

Mention the issue number(s) this PR addresses (e.g., #123).

## Please ensure all items are checked off before requesting a review:

- [ ] I deployed the application locally.
- [x] I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [ ] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.
