### PR TITLE
fix: remove local IP address exclusion from moniotr validation regex

### DIFF
--- a/Client/src/Validation/validation.js
+++ b/Client/src/Validation/validation.js
@@ -103,11 +103,6 @@ const monitorValidation = joi.object({
 					"(?:(?:https?|ftp):\\/\\/)?" +
 					// user:pass BasicAuth (optional)
 					"(?:" +
-					// IP address exclusion
-					// private & local networks
-					"(?!(?:10|127)(?:\\.\\d{1,3}){3})" +
-					"(?!(?:169\\.254|192\\.168)(?:\\.\\d{1,3}){2})" +
-					"(?!172\\.(?:1[6-9]|2\\d|3[0-1])(?:\\.\\d{1,3}){2})" +
 					// IP address dotted notation octets
 					// excludes loopback network 0.0.0.0
 					// excludes reserved space >= 224.0.0.0


### PR DESCRIPTION
This hotfix removes a local IP address exclusion from the monitor validation regex