### PR TITLE
hotfix: add port type monitors to queue mapping

### DIFF
--- a/Server/service/jobQueue.js
+++ b/Server/service/jobQueue.js
@@ -5,6 +5,7 @@ const QUEUE_LOOKUP = {
 	hardware: "hardware",
 	http: "uptime",
 	ping: "uptime",
+	port: "uptime",
 	docker: "uptime",
 	pagespeed: "pagespeed",
 };


### PR DESCRIPTION
This PR adds missing port types to the queue mapping