### PR TITLE
Fix: HTTPS monitors show HTTP on the table

### DIFF
--- a/Client/src/Pages/Uptime/Home/Components/UptimeDataTable/index.jsx
+++ b/Client/src/Pages/Uptime/Home/Components/UptimeDataTable/index.jsx
@@ -190,7 +190,9 @@ const UptimeDataTable = (props) => {
 			id: "type",
 			content: "Type",
 			render: (row) => (
-				<span style={{ textTransform: "uppercase" }}>{row.monitor.type}</span>
+				<span style={{ textTransform: "uppercase" }}>
+					{row.monitor.type === "http" ? "HTTP(s)" : row.monitor.type}
+				</span>
 			),
 		},
 		{


### PR DESCRIPTION
## Describe your changes

Changed the monitor types in UptimeDataTable from "HTTP" to "HTTP(s)" for better clarity and accuracy in representing HTTPS monitors.

## Issue number

#1626 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

