### PR TITLE
hotfix: checks query params

### DIFF
--- a/Client/src/Pages/Incidents/IncidentTable/index.jsx
+++ b/Client/src/Pages/Incidents/IncidentTable/index.jsx
@@ -39,6 +39,7 @@ const IncidentTable = ({ monitors, selectedMonitor, filter, dateRange }) => {
 				if (selectedMonitor === "0") {
 					res = await networkService.getChecksByTeam({
 						authToken: authToken,
+						status: false,
 						teamId: user.teamId,
 						sortOrder: "desc",
 						limit: null,
@@ -50,6 +51,7 @@ const IncidentTable = ({ monitors, selectedMonitor, filter, dateRange }) => {
 				} else {
 					res = await networkService.getChecksByMonitor({
 						authToken: authToken,
+						status: false,
 						monitorId: selectedMonitor,
 						sortOrder: "desc",
 						limit: null,

--- a/Client/src/Utils/NetworkService.js
+++ b/Client/src/Utils/NetworkService.js
@@ -614,6 +614,7 @@ class NetworkService {
 		if (config.filter) params.append("filter", config.filter);
 		if (config.page) params.append("page", config.page);
 		if (config.rowsPerPage) params.append("rowsPerPage", config.rowsPerPage);
+		if (config.status !== undefined) params.append("status", config.status);
 
 		return this.axiosInstance.get(`/checks/${config.monitorId}?${params.toString()}`, {
 			headers: { Authorization: `Bearer ${config.authToken}` },
@@ -646,6 +647,7 @@ class NetworkService {
 		if (config.filter) params.append("filter", config.filter);
 		if (config.page) params.append("page", config.page);
 		if (config.rowsPerPage) params.append("rowsPerPage", config.rowsPerPage);
+		if (config.status !== undefined) params.append("status", config.status);
 		return this.axiosInstance.get(`/checks/team/${config.teamId}?${params.toString()}`, {
 			headers: { Authorization: `Bearer ${config.authToken}` },
 		});

--- a/Server/db/mongo/modules/checkModule.js
+++ b/Server/db/mongo/modules/checkModule.js
@@ -70,13 +70,14 @@ const createCheck = async (checkData) => {
 const getChecksByMonitor = async (req) => {
 	try {
 		const { monitorId } = req.params;
-		let { sortOrder, dateRange, filter, page, rowsPerPage } = req.query;
+		let { sortOrder, dateRange, filter, page, rowsPerPage, status } = req.query;
+		status = typeof status !== "undefined" ? false : undefined;
 		page = parseInt(page);
 		rowsPerPage = parseInt(rowsPerPage);
 		// Match
 		const matchStage = {
 			monitorId: ObjectId.createFromHexString(monitorId),
-			status: false,
+			...(typeof status !== "undefined" && { status }),
 			...(dateRangeLookup[dateRange] && {
 				createdAt: {
 					$gte: dateRangeLookup[dateRange],
@@ -111,7 +112,6 @@ const getChecksByMonitor = async (req) => {
 		if (page && rowsPerPage) {
 			skip = page * rowsPerPage;
 		}
-
 		const checks = await Check.aggregate([
 			{ $match: matchStage },
 			{ $sort: { createdAt: sortOrder } },

--- a/Server/validation/joi.js
+++ b/Server/validation/joi.js
@@ -292,6 +292,7 @@ const getChecksQueryValidation = joi.object({
 	filter: joi.string().valid("all", "down", "resolve"),
 	page: joi.number(),
 	rowsPerPage: joi.number(),
+	status: joi.boolean(),
 });
 
 const getTeamChecksParamValidation = joi.object({
@@ -305,6 +306,7 @@ const getTeamChecksQueryValidation = joi.object({
 	filter: joi.string().valid("all", "down", "resolve"),
 	page: joi.number(),
 	rowsPerPage: joi.number(),
+	status: joi.boolean(),
 });
 
 const deleteChecksParamValidation = joi.object({


### PR DESCRIPTION
This PR is a hotfix for a missing status param for the `getChecksByTeam` and `getChecksByMonitor` endpoints.

This was set to false by default, it should be set to true by default, and false if a status parameter is provided, ie for incidents page.