### PR TITLE
feat: add additionalfields

### DIFF
--- a/Server/controllers/distributedUptimeController.js
+++ b/Server/controllers/distributedUptimeController.js
@@ -54,8 +54,13 @@ class DistributedUptimeController {
 				status,
 				code: status_code,
 				responseTime,
+				first_byte_took,
+				body_read_took,
+				dns_took,
+				conn_took,
+				connect_took,
+				tls_took,
 			};
-
 			if (error) {
 				const code = status_code || this.NETWORK_ERROR;
 				distributedUptimeResponse.code = code;

--- a/Server/db/models/DistributedUptimeCheck.js
+++ b/Server/db/models/DistributedUptimeCheck.js
@@ -61,6 +61,30 @@ const LocationSchema = new mongoose.Schema(
 const DistributedUptimeCheckSchema = mongoose.Schema(
 	{
 		...BaseCheckSchema.obj,
+		first_byte_took: {
+			type: Number,
+			required: false,
+		},
+		body_read_took: {
+			type: Number,
+			required: false,
+		},
+		dns_took: {
+			type: Number,
+			required: false,
+		},
+		conn_took: {
+			type: Number,
+			required: false,
+		},
+		connect_took: {
+			type: Number,
+			required: false,
+		},
+		tls_took: {
+			type: Number,
+			required: false,
+		},
 		location: {
 			type: LocationSchema,
 			required: false,

--- a/Server/service/statusService.js
+++ b/Server/service/statusService.js
@@ -83,8 +83,22 @@ class StatusService {
 	 * @returns {Object} The check object.
 	 */
 	buildCheck = (networkResponse) => {
-		const { monitorId, teamId, type, status, responseTime, code, message, payload } =
-			networkResponse;
+		const {
+			monitorId,
+			teamId,
+			type,
+			status,
+			responseTime,
+			code,
+			message,
+			payload,
+			first_byte_took,
+			body_read_took,
+			dns_took,
+			conn_took,
+			connect_took,
+			tls_took,
+		} = networkResponse;
 
 		const check = {
 			monitorId,
@@ -93,6 +107,12 @@ class StatusService {
 			statusCode: code,
 			responseTime,
 			message,
+			first_byte_took,
+			body_read_took,
+			dns_took,
+			conn_took,
+			connect_took,
+			tls_took,
 		};
 
 		if (type === "distributed_http") {
@@ -101,6 +121,12 @@ class StatusService {
 			check.city = payload.city;
 			check.location = payload.location;
 			check.uptBurnt = payload.upt_burnt;
+			check.first_byte_took = payload.first_byte_took;
+			check.body_read_took = payload.body_read_took;
+			check.dns_took = payload.dns_took;
+			check.conn_took = payload.conn_took;
+			check.connect_took = payload.connect_took;
+			check.tls_took = payload.tls_took;
 		}
 
 		if (type === "pagespeed") {


### PR DESCRIPTION
This PR adds some additional fields to the DU Checks model

```
"first_byte_took": 425133400,
"body_read_took": 56030000,
"dns_took": 278123300,
"conn_took": 527499900,
"connect_took": 83643800,
"tls_took": 165732800,
```

These will be used in queries eventually