### PR TITLE
fix: move tab styles to theme so they apply globally

### DIFF
--- a/Client/src/Pages/Account/index.jsx
+++ b/Client/src/Pages/Account/index.jsx
@@ -73,11 +73,6 @@ const Account = ({ open = "profile" }) => {
 					<TabList
 						onChange={handleTabChange}
 						aria-label="account tabs"
-						sx={{
-							"& .MuiTabs-indicator": {
-								backgroundColor: theme.palette.tertiary.contrastText,
-							},
-						}}
 					>
 						{tabList.map((label, index) => (
 							<Tab

--- a/Client/src/Utils/Theme/globalTheme.js
+++ b/Client/src/Utils/Theme/globalTheme.js
@@ -358,6 +358,15 @@ const baseTheme = (palette) => ({
 				}),
 			},
 		},
+		MuiTabs: {
+			styleOverrides: {
+				root: ({ theme }) => ({
+					"& .MuiTabs-indicator": {
+						backgroundColor: theme.palette.tertiary.contrastText,
+					},
+				}),
+			},
+		},
 	},
 	shape: {
 		borderRadius: 2,


### PR DESCRIPTION
This PR fixes tab styles.  Previously tab styles were declared inline and only applied to the particular component.

This PR moves the tab styles to the Theme so they apply to all tabs

- [x] Move tab styles to theme
- [x] Remove inline tab styles

![image](https://github.com/user-attachments/assets/ec2dd1a5-40bd-4667-a0e6-fa07b70c2d89)
 