### PR TITLE
update docker compose for replica set

### DIFF
--- a/Docker/test/docker-compose.yaml
+++ b/Docker/test/docker-compose.yaml
@@ -46,7 +46,8 @@ services:
       start_period: 5s
   mongodb:
     image: uptime_database_mongo:latest
-    command: ["mongod", "--quiet", "--auth"]
+    restart: always
+    command: ["mongod", "--quiet", "--replSet", "rs0", "--bind_ip_all"]
     ports:
       - "27017:27017"
     volumes:


### PR DESCRIPTION
This PR updates the docker-compose file for the test server.  It starts MongoDB in replicaset mode