### PR TITLE
fix: remove old loading state

### DIFF
--- a/Client/src/Components/ActionsMenu/index.jsx
+++ b/Client/src/Components/ActionsMenu/index.jsx
@@ -18,7 +18,7 @@ const ActionsMenu = ({
 	isAdmin,
 	updateRowCallback,
 	pauseCallback,
-	setIsLoading,
+	setIsLoading = () => {},
 }) => {
 	const [anchorEl, setAnchorEl] = useState(null);
 	const [actions, setActions] = useState({});

--- a/Client/src/Pages/Uptime/Monitors/Components/UptimeDataTable/index.jsx
+++ b/Client/src/Pages/Uptime/Monitors/Components/UptimeDataTable/index.jsx
@@ -49,7 +49,6 @@ import PropTypes from "prop-types";
 const UptimeDataTable = ({
 	isAdmin,
 	isSearching,
-	setIsLoading,
 	filteredMonitors,
 	sort,
 	setSort,
@@ -167,7 +166,6 @@ const UptimeDataTable = ({
 					monitor={row.monitor}
 					isAdmin={isAdmin}
 					updateRowCallback={triggerUpdate}
-					setIsLoading={setIsLoading}
 					pauseCallback={triggerUpdate}
 				/>
 			),
@@ -206,12 +204,10 @@ UptimeDataTable.propTypes = {
 	isSearching: PropTypes.bool,
 	setSort: PropTypes.func,
 	setSearch: PropTypes.func,
-	setIsLoading: PropTypes.func,
 	triggerUpdate: PropTypes.func,
 	debouncedSearch: PropTypes.string,
 	onSearchChange: PropTypes.func,
 	isAdmin: PropTypes.bool,
-	isLoading: PropTypes.bool,
 	monitors: PropTypes.array,
 	filteredMonitors: PropTypes.array,
 	monitorCount: PropTypes.number,

--- a/Client/src/Pages/Uptime/Monitors/index.jsx
+++ b/Client/src/Pages/Uptime/Monitors/index.jsx
@@ -62,7 +62,6 @@ const UptimeMonitors = () => {
 	const [page, setPage] = useState(undefined);
 	const [sort, setSort] = useState(undefined);
 	const [isSearching, setIsSearching] = useState(false);
-	const [isLoading, setIsLoading] = useState(false);
 	const [monitorUpdateTrigger, setMonitorUpdateTrigger] = useState(false);
 
 	// Utils
@@ -107,8 +106,7 @@ const UptimeMonitors = () => {
 		order: sort?.order,
 		triggerUpdate: monitorUpdateTrigger,
 	});
-	const totalMonitors = monitorsSummary?.totalMonitors ?? 0;
-
+	const totalMonitors = monitorsSummary?.totalMonitors;
 	if (networkError) {
 		return (
 			<GenericFallback>
@@ -123,7 +121,10 @@ const UptimeMonitors = () => {
 			</GenericFallback>
 		);
 	}
-	if (!isLoading && !monitorsAreLoading && totalMonitors === 0) {
+	if (
+		!monitorsAreLoading &&
+		(totalMonitors === 0 || typeof totalMonitors === "undefined")
+	) {
 		return (
 			<Fallback
 				vowelStart={true}
@@ -134,7 +135,6 @@ const UptimeMonitors = () => {
 			/>
 		);
 	}
-
 	return (
 		<Stack
 			className="monitors"
@@ -143,7 +143,7 @@ const UptimeMonitors = () => {
 			<Breadcrumbs list={BREADCRUMBS} />
 			<CreateMonitorHeader
 				isAdmin={isAdmin}
-				shouldRender={!isLoading}
+				shouldRender={!monitorsAreLoading}
 				path="/uptime/create"
 			/>
 			<Greeting type="uptime" />
@@ -166,8 +166,7 @@ const UptimeMonitors = () => {
 			</Stack>
 			<UptimeDataTable
 				isAdmin={isAdmin}
-				isLoading={isLoading}
-				setIsLoading={setIsLoading}
+				isLoading={monitorsAreLoading}
 				filteredMonitors={filteredMonitors}
 				monitors={monitors}
 				monitorCount={totalMonitors}


### PR DESCRIPTION
This PR removes remnants of an old loading state which was causing the "Create" button to become stuck in a loading state.

- [x] Remove old loading state
- [x] Remove unused props
- [x] Add default empty funciton to ActionsMenu  