### PR TITLE
hotfix: stauts page config link

### DIFF
--- a/Client/src/Pages/StatusPage/Status/Components/ControlsHeader/index.jsx
+++ b/Client/src/Pages/StatusPage/Status/Components/ControlsHeader/index.jsx
@@ -43,7 +43,11 @@ const Controls = ({ isDeleteOpen, setIsDeleteOpen, isDeleting, url, type }) => {
 					variant="contained"
 					color="secondary"
 					onClick={() => {
-						navigate(`/status/`);
+						if (type === "uptime") {
+							navigate(`/status/uptime/configure/${url}`);
+						} else {
+							navigate(`/status/distributed/configure/${url}`);
+						}
 					}}
 					sx={{
 						px: theme.spacing(5),


### PR DESCRIPTION
This PR reverts a mistaken change to the Status page configure button link target