### PR TITLE
fix: DU status page placeholder

### DIFF
--- a/Client/src/Pages/DistributedUptimeStatus/Status/index.jsx
+++ b/Client/src/Pages/DistributedUptimeStatus/Status/index.jsx
@@ -75,9 +75,9 @@ const DistributedUptimeStatus = () => {
 						marginY={theme.spacing(4)}
 						color={theme.palette.primary.contrastTextTertiary}
 					>
-						A public status page is not set up.
+						A status page is not set up.
 					</Typography>
-					<Typography>Please contact to your administrator</Typography>
+					<Typography>Please contact your administrator</Typography>
 				</GenericFallback>
 			</Stack>
 		);


### PR DESCRIPTION
This PR fixes the empty view message for DU status pages

- [x] Update message
- [x] Fix grammatical error 

![image](https://github.com/user-attachments/assets/fc93baf3-b1cb-4370-ae03-fb0b4265224c)
