### PR TITLE
Fix: Sidemenu Profile Section Overflows

### DIFF
--- a/Client/src/Components/Sidebar/index.jsx
+++ b/Client/src/Components/Sidebar/index.jsx
@@ -183,6 +183,8 @@ function Sidebar() {
 			This is the top lever for styles
 			*/
 			sx={{
+				position: "relative",
+				height: "100vh",
 				border: 1,
 				borderColor: theme.palette.primary.lowContrast,
 				borderRadius: theme.shape.borderRadius,
@@ -302,72 +304,55 @@ function Sidebar() {
 					</Typography>
 				</Stack>
 			</Stack>
-			<List
-				component="nav"
-				aria-labelledby="nested-menu-subheader"
-				disablePadding
-				subheader={
-					<ListSubheader
-						component="div"
-						id="nested-menu-subheader"
-						sx={{
-							py: theme.spacing(4),
-							/* TODO px should be centralized in container */
-							px: collapsed ? theme.spacing(2) : theme.spacing(4),
-							backgroundColor: "transparent",
-						}}
-					>
-						Menu
-					</ListSubheader>
-				}
+			<Box
 				sx={{
-					px: theme.spacing(6),
-					height: "100%",
-					/* overflow: "hidden", */
+					flexGrow: 1,
+					overflow: "auto",
+					maxHeight: `calc(100vh - ${theme.spacing(50)})`,
+					"&::-webkit-scrollbar": {
+						width: "6px",
+					},
+					"&::-webkit-scrollbar-thumb": {
+						backgroundColor: theme.palette.primary.lowContrast,
+						borderRadius: "3px",
+					},
 				}}
 			>
-				{menu.map((item) => {
-					if (item.path === "distributed-uptime" && distributedUptimeEnabled === false) {
-						return null;
-					}
-					return item.path ? (
-						/* If item has a path */
-						<Tooltip
-							key={item.path}
-							placement="right"
-							title={collapsed ? item.name : ""}
-							slotProps={{
-								popper: {
-									modifiers: [
-										{
-											name: "offset",
-											options: {
-												offset: [0, -16],
-											},
-										},
-									],
-								},
+				<List
+					component="nav"
+					aria-labelledby="nested-menu-subheader"
+					disablePadding
+					subheader={
+						<ListSubheader
+							component="div"
+							id="nested-menu-subheader"
+							sx={{
+								py: theme.spacing(4),
+								/* TODO px should be centralized in container */
+								px: collapsed ? theme.spacing(2) : theme.spacing(4),
+								backgroundColor: "transparent",
 							}}
-							disableInteractive
 						>
-							<ListItemButton
-								className={location.pathname === `/${item.path}` ? "selected-path" : ""}
-								onClick={() => navigate(`/${item.path}`)}
-								sx={{
-									height: "37px",
-									gap: theme.spacing(4),
-									borderRadius: theme.shape.borderRadius,
-									px: theme.spacing(4),
-								}}
-							>
-								<ListItemIcon sx={{ minWidth: 0 }}>{item.icon}</ListItemIcon>
-								<ListItemText>{item.name}</ListItemText>
-							</ListItemButton>
-						</Tooltip>
-					) : collapsed ? (
-						/* TODO Do we ever get here? If item does not have a path and collapsed state is true  */
-						<React.Fragment key={item.name}>
+							Menu
+						</ListSubheader>
+					}
+					sx={{
+						px: theme.spacing(6),
+						height: "100%",
+						/* overflow: "hidden", */
+					}}
+				>
+					{menu.map((item) => {
+						if (
+							item.path === "distributed-uptime" &&
+							distributedUptimeEnabled === false
+						) {
+							return null;
+						}
+						return item.path ? (
+							/* If item has a path */
 							<Tooltip
+								key={item.path}
 								placement="right"
 								title={collapsed ? item.name : ""}
 								slotProps={{
@@ -385,12 +370,10 @@ function Sidebar() {
 								disableInteractive
 							>
 								<ListItemButton
-									className={
-										Boolean(anchorEl) && popup === item.name ? "selected-path" : ""
-									}
-									onClick={(event) => openPopup(event, item.name)}
+									className={location.pathname === `/${item.path}` ? "selected-path" : ""}
+									onClick={() => navigate(`/${item.path}`)}
 									sx={{
-										position: "relative",
+										height: "37px",
 										gap: theme.spacing(4),
 										borderRadius: theme.shape.borderRadius,
 										px: theme.spacing(4),
@@ -400,104 +383,68 @@ function Sidebar() {
 									<ListItemText>{item.name}</ListItemText>
 								</ListItemButton>
 							</Tooltip>
-							<Menu
-								className="sidebar-popup"
-								anchorEl={anchorEl}
-								open={Boolean(anchorEl) && popup === item.name}
-								onClose={closePopup}
-								disableScrollLock
-								anchorOrigin={{
-									vertical: "top",
-									horizontal: "right",
-								}}
-								slotProps={{
-									paper: {
-										sx: {
-											mt: theme.spacing(-2),
-											ml: theme.spacing(1),
-										},
-									},
-								}}
-								MenuListProps={{ sx: { px: 1, py: 2 } }}
-								sx={{
-									ml: theme.spacing(8),
-									/* TODO what is this selection? */
-									"& .selected-path": {
-										backgroundColor: theme.palette.tertiary.main,
-									},
-								}}
-							>
-								{item.nested.map((child) => {
-									if (
-										child.name === "Team" &&
-										authState.user?.role &&
-										!authState.user.role.includes("superadmin")
-									) {
-										return null;
-									}
-
-									return (
-										<MenuItem
-											className={
-												location.pathname.includes(child.path) ? "selected-path" : ""
-											}
-											key={child.path}
-											onClick={() => {
-												const url = URL_MAP[child.path];
-												if (url) {
-													window.open(url, "_blank", "noreferrer");
-												} else {
-													navigate(`/${child.path}`);
-												}
-												closePopup();
-											}}
-											sx={{
-												gap: theme.spacing(4),
-												opacity: 0.9,
-												/* TODO this has no effect? */
-												"& svg": {
-													"& path": {
-														stroke: theme.palette.primary.contrastTextTertiary,
-														strokeWidth: 1.1,
+						) : collapsed ? (
+							/* TODO Do we ever get here? If item does not have a path and collapsed state is true  */
+							<React.Fragment key={item.name}>
+								<Tooltip
+									placement="right"
+									title={collapsed ? item.name : ""}
+									slotProps={{
+										popper: {
+											modifiers: [
+												{
+													name: "offset",
+													options: {
+														offset: [0, -16],
 													},
 												},
-											}}
-										>
-											{child.icon}
-											{child.name}
-										</MenuItem>
-									);
-								})}
-							</Menu>
-						</React.Fragment>
-					) : (
-						/* TODO Do we ever get here? If item does not have a path and collapsed state is false */
-						<React.Fragment key={item.name}>
-							<ListItemButton
-								onClick={() =>
-									setOpen((prev) => ({
-										...Object.fromEntries(Object.keys(prev).map((key) => [key, false])),
-										[item.name]: !prev[item.name],
-									}))
-								}
-								sx={{
-									gap: theme.spacing(4),
-									borderRadius: theme.shape.borderRadius,
-									px: theme.spacing(4),
-								}}
-							>
-								<ListItemIcon sx={{ minWidth: 0 }}>{item.icon}</ListItemIcon>
-								<ListItemText>{item.name}</ListItemText>
-								{open[`${item.name}`] ? <ArrowUp /> : <ArrowDown />}
-							</ListItemButton>
-							<Collapse
-								in={open[`${item.name}`]}
-								timeout="auto"
-							>
-								<List
-									component="div"
-									disablePadding
-									sx={{ pl: theme.spacing(12) }}
+											],
+										},
+									}}
+									disableInteractive
+								>
+									<ListItemButton
+										className={
+											Boolean(anchorEl) && popup === item.name ? "selected-path" : ""
+										}
+										onClick={(event) => openPopup(event, item.name)}
+										sx={{
+											position: "relative",
+											gap: theme.spacing(4),
+											borderRadius: theme.shape.borderRadius,
+											px: theme.spacing(4),
+										}}
+									>
+										<ListItemIcon sx={{ minWidth: 0 }}>{item.icon}</ListItemIcon>
+										<ListItemText>{item.name}</ListItemText>
+									</ListItemButton>
+								</Tooltip>
+								<Menu
+									className="sidebar-popup"
+									anchorEl={anchorEl}
+									open={Boolean(anchorEl) && popup === item.name}
+									onClose={closePopup}
+									disableScrollLock
+									anchorOrigin={{
+										vertical: "top",
+										horizontal: "right",
+									}}
+									slotProps={{
+										paper: {
+											sx: {
+												mt: theme.spacing(-2),
+												ml: theme.spacing(1),
+											},
+										},
+									}}
+									MenuListProps={{ sx: { px: 1, py: 2 } }}
+									sx={{
+										ml: theme.spacing(8),
+										/* TODO what is this selection? */
+										"& .selected-path": {
+											backgroundColor: theme.palette.tertiary.main,
+										},
+									}}
 								>
 									{item.nested.map((child) => {
 										if (
@@ -509,7 +456,7 @@ function Sidebar() {
 										}
 
 										return (
-											<ListItemButton
+											<MenuItem
 												className={
 													location.pathname.includes(child.path) ? "selected-path" : ""
 												}
@@ -521,52 +468,125 @@ function Sidebar() {
 													} else {
 														navigate(`/${child.path}`);
 													}
+													closePopup();
 												}}
 												sx={{
 													gap: theme.spacing(4),
-													borderRadius: theme.shape.borderRadius,
-													pl: theme.spacing(4),
-													"&::before": {
-														content: `""`,
-														position: "absolute",
-														top: 0,
-														left: "-7px",
-														height: "100%",
-														borderLeft: 1,
-														borderLeftColor: theme.palette.primary.lowContrast,
-													},
-													"&:last-child::before": {
-														height: "50%",
-													},
-													"&::after": {
-														content: `""`,
-														position: "absolute",
-														top: "45%",
-														left: "-8px",
-														height: "3px",
-														width: "3px",
-														borderRadius: "50%",
-														backgroundColor: theme.palette.primary.lowContrast,
-													},
-													"&.selected-path::after": {
-														/* TODO what is this selector doing? */
-														backgroundColor: theme.palette.primary.contrastTextTertiary,
-														transform: "scale(1.2)",
+													opacity: 0.9,
+													/* TODO this has no effect? */
+													"& svg": {
+														"& path": {
+															stroke: theme.palette.primary.contrastTextTertiary,
+															strokeWidth: 1.1,
+														},
 													},
 												}}
 											>
-												<ListItemIcon sx={{ minWidth: 0 }}>{child.icon}</ListItemIcon>
-												<ListItemText>{child.name}</ListItemText>
-											</ListItemButton>
+												{child.icon}
+												{child.name}
+											</MenuItem>
 										);
 									})}
-								</List>
-							</Collapse>
-						</React.Fragment>
-					);
-				})}
-			</List>
-			<Divider sx={{ mt: "auto" }} />
+								</Menu>
+							</React.Fragment>
+						) : (
+							/* TODO Do we ever get here? If item does not have a path and collapsed state is false */
+							<React.Fragment key={item.name}>
+								<ListItemButton
+									onClick={() =>
+										setOpen((prev) => ({
+											...Object.fromEntries(Object.keys(prev).map((key) => [key, false])),
+											[item.name]: !prev[item.name],
+										}))
+									}
+									sx={{
+										gap: theme.spacing(4),
+										borderRadius: theme.shape.borderRadius,
+										px: theme.spacing(4),
+									}}
+								>
+									<ListItemIcon sx={{ minWidth: 0 }}>{item.icon}</ListItemIcon>
+									<ListItemText>{item.name}</ListItemText>
+									{open[`${item.name}`] ? <ArrowUp /> : <ArrowDown />}
+								</ListItemButton>
+								<Collapse
+									in={open[`${item.name}`]}
+									timeout="auto"
+								>
+									<List
+										component="div"
+										disablePadding
+										sx={{ pl: theme.spacing(12) }}
+									>
+										{item.nested.map((child) => {
+											if (
+												child.name === "Team" &&
+												authState.user?.role &&
+												!authState.user.role.includes("superadmin")
+											) {
+												return null;
+											}
+
+											return (
+												<ListItemButton
+													className={
+														location.pathname.includes(child.path) ? "selected-path" : ""
+													}
+													key={child.path}
+													onClick={() => {
+														const url = URL_MAP[child.path];
+														if (url) {
+															window.open(url, "_blank", "noreferrer");
+														} else {
+															navigate(`/${child.path}`);
+														}
+													}}
+													sx={{
+														gap: theme.spacing(4),
+														borderRadius: theme.shape.borderRadius,
+														pl: theme.spacing(4),
+														"&::before": {
+															content: `""`,
+															position: "absolute",
+															top: 0,
+															left: "-7px",
+															height: "100%",
+															borderLeft: 1,
+															borderLeftColor: theme.palette.primary.lowContrast,
+														},
+														"&:last-child::before": {
+															height: "50%",
+														},
+														"&::after": {
+															content: `""`,
+															position: "absolute",
+															top: "45%",
+															left: "-8px",
+															height: "3px",
+															width: "3px",
+															borderRadius: "50%",
+															backgroundColor: theme.palette.primary.lowContrast,
+														},
+														"&.selected-path::after": {
+															/* TODO what is this selector doing? */
+															backgroundColor: theme.palette.primary.contrastTextTertiary,
+															transform: "scale(1.2)",
+														},
+													}}
+												>
+													<ListItemIcon sx={{ minWidth: 0 }}>{child.icon}</ListItemIcon>
+													<ListItemText>{child.name}</ListItemText>
+												</ListItemButton>
+											);
+										})}
+									</List>
+								</Collapse>
+							</React.Fragment>
+						);
+					})}
+				</List>
+			</Box>
+			<Divider sx={{ mt: "auto", borderColor: theme.palette.primary.lowContrast }} />
 
 			<Stack
 				direction="row"


### PR DESCRIPTION
## Describe your changes

- Fixed visibility issue with sidemenu divider in dark mode by adjusting its color to use proper values
- Added scrollable functionality to sidemenu to prevent profile section from being pushed out of view when dropdowns are expanded
- Menu items now scroll independently while keeping the profile section fixed at the bottom

## Issue number

#1646 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="266" alt="Screenshot 2025-02-12 at 4 18 07 PM" src="https://github.com/user-attachments/assets/0e11e0b1-e2ee-40eb-b48d-2224f1bc39e0" />
<img width="267" alt="Screenshot 2025-02-12 at 4 17 49 PM" src="https://github.com/user-attachments/assets/475a3493-cb1b-4992-bae5-db20c950f367" />


<img width="256" alt="Screenshot 2025-02-12 at 4 18 24 PM" src="https://github.com/user-attachments/assets/82759004-882d-43b4-af9a-6e4b00cfa01b" />
