### PR TITLE
fix: correctly calculate grouped uptime percentage, resolves #1684

### DIFF
--- a/Client/src/Pages/Uptime/Details/Components/ChartBoxes/index.jsx
+++ b/Client/src/Pages/Uptime/Details/Components/ChartBoxes/index.jsx
@@ -30,6 +30,12 @@ const ChartBoxes = ({
 		return <SkeletonLayout />;
 	}
 
+	const totalUpChecks = monitor?.upChecks?.totalChecks ?? 0;
+	const totalDownChecks = monitor?.downChecks?.totalChecks ?? 0;
+	const denominator =
+		totalUpChecks + totalDownChecks > 0 ? totalUpChecks + totalDownChecks : 1;
+	const groupedUptimePercentage = (totalUpChecks / denominator) * 100;
+
 	return (
 		<Stack
 			direction="row"
@@ -73,11 +79,7 @@ const ChartBoxes = ({
 						<Typography component="span">
 							{hoveredUptimeData !== null
 								? Math.floor(hoveredUptimeData?.avgResponseTime ?? 0)
-								: Math.floor(
-										((monitor?.upChecks?.totalChecks ?? 0) /
-											(monitor?.totalChecks ?? 1)) *
-											100
-									)}
+								: Math.floor(groupedUptimePercentage)}
 							<Typography component="span">
 								{hoveredUptimeData !== null ? " ms" : " %"}
 							</Typography>

--- a/Server/db/mongo/modules/monitorModule.js
+++ b/Server/db/mongo/modules/monitorModule.js
@@ -313,7 +313,7 @@ const calculateGroupStats = (group) => {
 		avgResponseTime:
 			checksWithResponseTime.length > 0
 				? checksWithResponseTime.reduce((sum, check) => sum + check.responseTime, 0) /
-				checksWithResponseTime.length
+					checksWithResponseTime.length
 				: 0,
 	};
 };
@@ -372,7 +372,10 @@ const getUptimeDetailsById = async (req) => {
 
 const getDistributedUptimeDetailsById = async (req) => {
 	try {
-		const { monitorId } = req.params;
+		const { monitorId } = req?.params ?? {};
+		if (typeof monitorId === "undefined") {
+			throw new Error();
+		}
 		const monitor = await Monitor.findById(monitorId);
 		if (monitor === null || monitor === undefined) {
 			throw new Error(this.stringService.dbFindMonitorById(monitorId));
@@ -605,98 +608,98 @@ const getMonitorsByTeamId = async (req) => {
 				filteredMonitors: [
 					...(filter !== undefined
 						? [
-							{
-								$match: {
-									$or: [
-										{ name: { $regex: filter, $options: "i" } },
-										{ url: { $regex: filter, $options: "i" } },
-									],
+								{
+									$match: {
+										$or: [
+											{ name: { $regex: filter, $options: "i" } },
+											{ url: { $regex: filter, $options: "i" } },
+										],
+									},
 								},
-							},
-						]
+							]
 						: []),
 					{ $sort: sort },
 					{ $skip: skip },
 					...(rowsPerPage ? [{ $limit: rowsPerPage }] : []),
 					...(limit
 						? [
-							{
-								$lookup: {
-									from: "checks",
-									let: { monitorId: "$_id" },
-									pipeline: [
-										{
-											$match: {
-												$expr: { $eq: ["$monitorId", "$$monitorId"] },
+								{
+									$lookup: {
+										from: "checks",
+										let: { monitorId: "$_id" },
+										pipeline: [
+											{
+												$match: {
+													$expr: { $eq: ["$monitorId", "$$monitorId"] },
+												},
 											},
-										},
-										{ $sort: { createdAt: -1 } },
-										...(limit ? [{ $limit: limit }] : []),
-									],
-									as: "standardchecks",
+											{ $sort: { createdAt: -1 } },
+											...(limit ? [{ $limit: limit }] : []),
+										],
+										as: "standardchecks",
+									},
 								},
-							},
-						]
+							]
 						: []),
 					...(limit
 						? [
-							{
-								$lookup: {
-									from: "pagespeedchecks",
-									let: { monitorId: "$_id" },
-									pipeline: [
-										{
-											$match: {
-												$expr: { $eq: ["$monitorId", "$$monitorId"] },
+								{
+									$lookup: {
+										from: "pagespeedchecks",
+										let: { monitorId: "$_id" },
+										pipeline: [
+											{
+												$match: {
+													$expr: { $eq: ["$monitorId", "$$monitorId"] },
+												},
 											},
-										},
-										{ $sort: { createdAt: -1 } },
-										...(limit ? [{ $limit: limit }] : []),
-									],
-									as: "pagespeedchecks",
+											{ $sort: { createdAt: -1 } },
+											...(limit ? [{ $limit: limit }] : []),
+										],
+										as: "pagespeedchecks",
+									},
 								},
-							},
-						]
+							]
 						: []),
 					...(limit
 						? [
-							{
-								$lookup: {
-									from: "hardwarechecks",
-									let: { monitorId: "$_id" },
-									pipeline: [
-										{
-											$match: {
-												$expr: { $eq: ["$monitorId", "$$monitorId"] },
+								{
+									$lookup: {
+										from: "hardwarechecks",
+										let: { monitorId: "$_id" },
+										pipeline: [
+											{
+												$match: {
+													$expr: { $eq: ["$monitorId", "$$monitorId"] },
+												},
 											},
-										},
-										{ $sort: { createdAt: -1 } },
-										...(limit ? [{ $limit: limit }] : []),
-									],
-									as: "hardwarechecks",
+											{ $sort: { createdAt: -1 } },
+											...(limit ? [{ $limit: limit }] : []),
+										],
+										as: "hardwarechecks",
+									},
 								},
-							},
-						]
+							]
 						: []),
 					...(limit
 						? [
-							{
-								$lookup: {
-									from: "distributeduptimechecks",
-									let: { monitorId: "$_id" },
-									pipeline: [
-										{
-											$match: {
-												$expr: { $eq: ["$monitorId", "$$monitorId"] },
+								{
+									$lookup: {
+										from: "distributeduptimechecks",
+										let: { monitorId: "$_id" },
+										pipeline: [
+											{
+												$match: {
+													$expr: { $eq: ["$monitorId", "$$monitorId"] },
+												},
 											},
-										},
-										{ $sort: { createdAt: -1 } },
-										...(limit ? [{ $limit: limit }] : []),
-									],
-									as: "distributeduptimechecks",
+											{ $sort: { createdAt: -1 } },
+											...(limit ? [{ $limit: limit }] : []),
+										],
+										as: "distributeduptimechecks",
+									},
 								},
-							},
-						]
+							]
 						: []),
 
 					{


### PR DESCRIPTION
This PR fixes an issue where uptime percentage used the aggregate total number of checks for a monitor to calculate uptime percentage for a fixed period, which is incorrect.

Uptime percentage should be calculated by dividing the total number of up checks in a group by the total number of checks in the group.

- [x] Use correct number of checks to determine grouped uptime