### PR TITLE
Fix: Sidemenu UI Overflow

### DIFF
--- a/Client/src/Components/Sidebar/index.jsx
+++ b/Client/src/Components/Sidebar/index.jsx
@@ -183,6 +183,7 @@ function Sidebar() {
 			This is the top lever for styles
 			*/
 			sx={{
+				position: 'relative',
 				border: 1,
 				borderColor: theme.palette.primary.lowContrast,
 				borderRadius: theme.shape.borderRadius,
@@ -302,6 +303,20 @@ function Sidebar() {
 					</Typography>
 				</Stack>
 			</Stack>
+			<Box
+ 			sx={{
+ 				flexGrow: 1,
+ 				overflow: 'auto',
+ 				overflowX: 'hidden',
+ 				'&::-webkit-scrollbar': {
+ 					width: theme.spacing(2),
+                 },
+ 				'&::-webkit-scrollbar-thumb': {
+                     backgroundColor: theme.palette.primary.lowContrast,
+                     borderRadius: theme.spacing(4),
+                 },
+ 			}}
+ 			>
 			<List
 				component="nav"
 				aria-labelledby="nested-menu-subheader"
@@ -315,6 +330,7 @@ function Sidebar() {
 							/* TODO px should be centralized in container */
 							px: collapsed ? theme.spacing(2) : theme.spacing(4),
 							backgroundColor: "transparent",
+							position: "static",
 						}}
 					>
 						Menu
@@ -566,7 +582,8 @@ function Sidebar() {
 					);
 				})}
 			</List>
-			<Divider sx={{ mt: "auto" }} />
+			</Box>
+			<Divider sx={{ mt: "auto", borderColor: theme.palette.primary.lowContrast }} />
 
 			<Stack
 				direction="row"


### PR DESCRIPTION
## Describe your changes

- Fixed visibility issue with sidemenu divider in dark mode by adjusting its color to use proper values
- Added scrollable functionality to sidemenu to prevent profile section from being pushed out of view when dropdowns are expanded
- Menu items now scroll independently while keeping the profile section fixed at the bottom

## Issue number

#1646 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

