### PR TITLE
Fix: No Incidents Message

### DIFF
--- a/src/Components/Charts/ChartBox/EmptyView.jsx
+++ b/src/Components/Charts/ChartBox/EmptyView.jsx
@@ -21,7 +21,7 @@ import IconBox from "../../IconBox";
  * <EmptyView
  *   icon={<SomeIcon />}
  *   header="Average Response Time"
- *   message="No Resposne Time Available"
+ *   message="No Response Time Available"
  *   headingLevel="h2"
  *   justifyContent="center"
  *   height="50%"

--- a/src/Components/Charts/ChartBox/EmptyView.jsx
+++ b/src/Components/Charts/ChartBox/EmptyView.jsx
@@ -4,6 +4,32 @@ import PropTypes from "prop-types";
 import { useTheme } from "@emotion/react";
 import IconBox from "../../IconBox";
 
+/**
+ * `EmptyView` is a functional React component that displays an empty state view with an optional icon, header, and message.
+ *
+ * @component
+ * @param {Object} props - The properties that define the `EmptyView` component.
+ * @param {React.ReactNode} [props.icon] - An optional icon to display at the top of the empty view.
+ * @param {string} [props.header] - An optional header text displayed next to the icon.
+ * @param {string} [props.message="No Data"] - The message to be displayed in the empty view.
+ * @param {'h1' | 'h2' | 'h3'} [props.headingLevel="h2"] - The heading level for the message text.
+ * @param {string} [props.justifyContent="flex-start"] - The CSS `justify-content` value to align elements vertically.
+ * @param {string} [props.height="100%"] - The height of the empty view container.
+ *
+ * @example
+ * // Example usage of EmptyView component:
+ * <EmptyView
+ *   icon={<SomeIcon />}
+ *   header="Average Response Time"
+ *   message="No Resposne Time Available"
+ *   headingLevel="h2"
+ *   justifyContent="center"
+ *   height="50%"
+ * />
+ *
+ * @returns {React.Element} The `EmptyView` component with customizable icon, header, and message.
+ */
+
 const EmptyView = ({
     icon,
     header,
@@ -74,7 +100,9 @@ EmptyView.propTypes = {
     message: PropTypes.string,
     icon: PropTypes.node,
     header: PropTypes.string,
-    headingLevel: PropTypes.oneOf(['h1', 'h2', 'h3'])
+    headingLevel: PropTypes.oneOf(['h1', 'h2', 'h3']),
+    justifyContent: PropTypes.string,
+    height: PropTypes.string
 };
 
 export default EmptyView;

--- a/src/Components/Charts/ChartBox/EmptyView.jsx
+++ b/src/Components/Charts/ChartBox/EmptyView.jsx
@@ -8,10 +8,9 @@ const EmptyView = ({
     icon,
     header,
     message = "No Data",
-    size = "h2",
-    borderRadiusRight = 4,
+    headingLevel = "h2",
     justifyContent = "flex-start",
-    height = "300px"
+    height = "100%"
 }) => {
     const theme = useTheme();
     return (
@@ -25,8 +24,8 @@ const EmptyView = ({
                 borderStyle: "solid",
                 borderColor: theme.palette.primary.lowContrast,
                 borderRadius: 2,
-                borderTopRightRadius: borderRadiusRight,
-                borderBottomRightRadius: borderRadiusRight,
+                borderTopRightRadius: 4,
+                borderBottomRightRadius: 4,
             }}
         >
             <Stack
@@ -37,7 +36,6 @@ const EmptyView = ({
                     justifyContent,
                     gap: theme.spacing(8),
                     height,
-                    minWidth: 250,
                     "& h2": {
                         color: theme.palette.primary.contrastTextSecondary,
                         fontSize: 15,
@@ -63,7 +61,7 @@ const EmptyView = ({
                     justifyContent="center"
                     alignItems="center"               
                 >
-                    <Typography component={size}>
+                    <Typography component={headingLevel}>
                         {message}
                     </Typography>
                 </Stack>
@@ -76,7 +74,7 @@ EmptyView.propTypes = {
     message: PropTypes.string,
     icon: PropTypes.node,
     header: PropTypes.string,
-    size: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body1', 'body2'])
+    headingLevel: PropTypes.oneOf(['h1', 'h2', 'h3'])
 };
 
 export default EmptyView;

--- a/src/Components/Charts/ChartBox/EmptyView.jsx
+++ b/src/Components/Charts/ChartBox/EmptyView.jsx
@@ -1,0 +1,82 @@
+// Components
+import { Typography, Stack } from "@mui/material";
+import PropTypes from "prop-types";
+import { useTheme } from "@emotion/react";
+import IconBox from "../../IconBox";
+
+const EmptyView = ({
+    icon,
+    header,
+    message = "No Data",
+    size = "h2",
+    borderRadiusRight = 4,
+    justifyContent = "flex-start",
+    height = "300px"
+}) => {
+    const theme = useTheme();
+    return (
+        <Stack
+            flex={1}
+            direction="row"
+            sx={{
+                backgroundColor: theme.palette.primary.main,
+
+                border: 1,
+                borderStyle: "solid",
+                borderColor: theme.palette.primary.lowContrast,
+                borderRadius: 2,
+                borderTopRightRadius: borderRadiusRight,
+                borderBottomRightRadius: borderRadiusRight,
+            }}
+        >
+            <Stack
+                flex={1}
+                alignItems="center"
+                sx={{
+                    padding: theme.spacing(8),
+                    justifyContent,
+                    gap: theme.spacing(8),
+                    height,
+                    minWidth: 250,
+                    "& h2": {
+                        color: theme.palette.primary.contrastTextSecondary,
+                        fontSize: 15,
+                        fontWeight: 500,
+                    },
+
+                    "& tspan, & text": {
+                        fill: theme.palette.primary.contrastTextTertiary,
+                    },
+                }}
+            >
+                <Stack
+                    alignSelf="flex-start"
+                    direction="row"
+                    alignItems="center"
+                    gap={theme.spacing(6)}
+                >
+                    {icon && <IconBox>{icon}</IconBox>}
+                    {header && <Typography component="h2">{header}</Typography>}
+                </Stack>
+                <Stack
+                    flex={1}
+                    justifyContent="center"
+                    alignItems="center"               
+                >
+                    <Typography component={size}>
+                        {message}
+                    </Typography>
+                </Stack>
+            </Stack>
+        </Stack>
+    );
+};
+
+EmptyView.propTypes = {
+    message: PropTypes.string,
+    icon: PropTypes.node,
+    header: PropTypes.string,
+    size: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'body1', 'body2'])
+};
+
+export default EmptyView;

--- a/src/Components/Charts/ChartBox/index.jsx
+++ b/src/Components/Charts/ChartBox/index.jsx
@@ -1,6 +1,7 @@
 import { Stack, Typography } from "@mui/material";
 import { useTheme } from "@emotion/react";
 import IconBox from "../../IconBox";
+import EmptyView from "./EmptyView";
 import PropTypes from "prop-types";
 
 const ChartBox = ({
@@ -12,8 +13,13 @@ const ChartBox = ({
 	Legend,
 	borderRadiusRight = 4,
 	sx,
+	noDataMessage,
+	isEmpty = false,
 }) => {
 	const theme = useTheme();
+	if (isEmpty) {
+		return <EmptyView icon={icon} header={header} message={noDataMessage} />; 
+	}
 	return (
 		<Stack
 			flex={1}
@@ -88,4 +94,6 @@ ChartBox.propTypes = {
 	icon: PropTypes.node,
 	header: PropTypes.string,
 	height: PropTypes.string,
+	noDataMessage: PropTypes.string,
+	isEmpty: PropTypes.bool
 };

--- a/src/Pages/Uptime/Details/Components/ChartBoxes/index.jsx
+++ b/src/Pages/Uptime/Details/Components/ChartBoxes/index.jsx
@@ -97,7 +97,7 @@ const ChartBoxes = ({
 				icon={<IncidentsIcon />}
 				header="Incidents"
 				noDataMessage="Great. No Incidents, yet!"
-				isEmpty={!monitor?.groupedDownChecks?.length}
+				isEmpty={monitor?.groupedDownChecks?.length === 0}
 			>
 				<Stack width={"100%"}>
 					<Box position="relative">

--- a/src/Pages/Uptime/Details/Components/ChartBoxes/index.jsx
+++ b/src/Pages/Uptime/Details/Components/ChartBoxes/index.jsx
@@ -35,6 +35,7 @@ const ChartBoxes = ({
 	const denominator =
 		totalUpChecks + totalDownChecks > 0 ? totalUpChecks + totalDownChecks : 1;
 	const groupedUptimePercentage = (totalUpChecks / denominator) * 100;
+	const noIncidentsMessage = "Great. No Incidents, yet!";
 
 	return (
 		<Stack
@@ -96,7 +97,7 @@ const ChartBoxes = ({
 			<ChartBox
 				icon={<IncidentsIcon />}
 				header="Incidents"
-				noDataMessage="Great. No Incidents, yet!"
+				noDataMessage={noIncidentsMessage}
 				isEmpty={monitor?.groupedDownChecks?.length === 0}
 			>
 				<Stack width={"100%"}>

--- a/src/Pages/Uptime/Details/Components/ChartBoxes/index.jsx
+++ b/src/Pages/Uptime/Details/Components/ChartBoxes/index.jsx
@@ -45,6 +45,7 @@ const ChartBoxes = ({
 			<ChartBox
 				icon={<UptimeIcon />}
 				header="Uptime"
+				isEmpty={monitor?.uptimePercentage === 0 && !monitor?.upChecks?.length}
 			>
 				<Stack
 					width={"100%"}
@@ -95,6 +96,8 @@ const ChartBoxes = ({
 			<ChartBox
 				icon={<IncidentsIcon />}
 				header="Incidents"
+				noDataMessage="Great. No Incidents, yet!"
+				isEmpty={!monitor?.groupedDownChecks?.length}
 			>
 				<Stack width={"100%"}>
 					<Box position="relative">


### PR DESCRIPTION
## Describe your changes

This update modifies the incident display logic in the UI. It now conditionally renders the following:

- For existing incidents: The original layout is displayed with the count of total checks and the timestamp of the hovered incident.
- For "No incidents" scenario: A centered message saying "Great. No incidents, yet!" is shown.

[Have tested on Safari, Chrome & Firefox]

## Issue number

#1757 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="360" alt="Screenshot 2025-02-14 at 10 48 17 AM" src="https://github.com/user-attachments/assets/cf02e0fd-b2a0-44cf-8967-8049399d6d2a" />


