### PR TITLE
feat(docker): Use named volumes and add env_file field to dist compose

### DIFF
--- a/Docker/dist/docker-compose.yaml
+++ b/Docker/dist/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
     environment:
       - DB_CONNECTION_STRING=mongodb://mongodb:27017/uptime_db
       - REDIS_HOST=redis
+    env_file:
+      - server.env
     # volumes:
     # - /var/run/docker.sock:/var/run/docker.sock:ro
   redis:
@@ -29,7 +31,7 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - ./redis/data:/data
+      - checkmate-redis-data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 30s
@@ -40,7 +42,13 @@ services:
     image: bluewaveuptime/uptime_database_mongo:latest
     restart: always
     volumes:
-      - ./mongo/data:/data/db
+      - checkmate-mongo-data:/data/db
     command: ["mongod", "--quiet"]
     ports:
       - "27017:27017"
+
+volumes:
+  checkmate-mongo-data:
+    name: checkmate-mongo-data
+  checkmate-redis-data:
+    name: checkmate-redis-data


### PR DESCRIPTION
## Describe your changes

This PR adds pre-defined volume names to the `dist/` docker compose file. With the pre-defined volume names, our volumes are getting unique and we can use these unique names to use with [Checkmate CLI](https://github.com/bluewave-labs/checkmate-cli) backup and restore commands.
Also, to make Checkmate Server configured with `dist/server.env` file add `env_file` field to **server** container.

If it's ok, I can update other dev, test and prod compose files too.

## Issue number

- https://github.com/bluewave-labs/Checkmate/issues/1558#issuecomment-2646342865

Old, checkmate data location: `Docker/dist/mongo/data`, `Docker/dist/redis/data`

New checkmate data location: checkmate-mongo-data and checkmate-redis-data volumes. And these volumes are mounted on `/var/lib/docker/volumes/checkmate-mongo-data` or `/var/lib/docker/volumes/checkmate-redis-data`

#### Checkmarks

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] My PR is granular and targeted to one specific feature.

