### PR TITLE
fix: remove ngrok

### DIFF
--- a/Server/package-lock.json
+++ b/Server/package-lock.json
@@ -42,7 +42,6 @@
 				"esm": "3.2.25",
 				"globals": "^15.14.0",
 				"mocha": "11.1.0",
-				"ngrok": "5.0.0-beta.2",
 				"nodemon": "3.1.9",
 				"prettier": "^3.3.3",
 				"sinon": "19.0.2"
@@ -1105,19 +1104,6 @@
 			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@sindresorhus/is": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
-			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/is?sponsor=1"
-			}
-		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -1167,19 +1153,6 @@
 			"dev": true,
 			"license": "(Unlicense OR Apache-2.0)"
 		},
-		"node_modules/@szmarczak/http-timer": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
-			"integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"defer-to-connect": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@trysound/sax": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -1189,31 +1162,11 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/@types/cacheable-request": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
-			"integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/http-cache-semantics": "*",
-				"@types/keyv": "^3.1.4",
-				"@types/node": "*",
-				"@types/responselike": "^1.0.0"
-			}
-		},
 		"node_modules/@types/estree": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
 			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
-		},
-		"node_modules/@types/http-cache-semantics": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-			"integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@types/istanbul-lib-coverage": {
 			"version": "2.0.6",
@@ -1228,16 +1181,6 @@
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true
 		},
-		"node_modules/@types/keyv": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
-			"integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/node": {
 			"version": "22.10.4",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.4.tgz",
@@ -1245,16 +1188,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.20.0"
-			}
-		},
-		"node_modules/@types/responselike": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
-			"integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/triple-beam": {
@@ -1276,17 +1209,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/webidl-conversions": "*"
-			}
-		},
-		"node_modules/@types/yauzl": {
-			"version": "2.10.3",
-			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@types/node": "*"
 			}
 		},
 		"node_modules/abbrev": {
@@ -1717,16 +1639,6 @@
 				"ieee754": "^1.1.13"
 			}
 		},
-		"node_modules/buffer-crc32": {
-			"version": "0.2.13",
-			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -1815,35 +1727,6 @@
 				"monocart-coverage-reports": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/cacheable-lookup": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
-			"integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.6.0"
-			}
-		},
-		"node_modules/cacheable-request": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
-			"integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"clone-response": "^1.0.2",
-				"get-stream": "^5.1.0",
-				"http-cache-semantics": "^4.0.0",
-				"keyv": "^4.0.0",
-				"lowercase-keys": "^2.0.0",
-				"normalize-url": "^6.0.1",
-				"responselike": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/call-bind-apply-helpers": {
@@ -2114,19 +1997,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/clone-response": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
-			"integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-response": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/cluster-key-slot": {
@@ -2639,35 +2509,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/decompress-response": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-response": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decompress-response/node_modules/mimic-response": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/deep-eql": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2683,16 +2524,6 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
-		},
-		"node_modules/defer-to-connect": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
-			"integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/delayed-stream": {
 			"version": "1.0.0",
@@ -3413,27 +3244,6 @@
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
 			"license": "MIT"
 		},
-		"node_modules/extract-zip": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"debug": "^4.1.1",
-				"get-stream": "^5.1.0",
-				"yauzl": "^2.10.0"
-			},
-			"bin": {
-				"extract-zip": "cli.js"
-			},
-			"engines": {
-				"node": ">= 10.17.0"
-			},
-			"optionalDependencies": {
-				"@types/yauzl": "^2.9.1"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3451,16 +3261,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
-		},
-		"node_modules/fd-slicer": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pend": "~1.2.0"
-			}
 		},
 		"node_modules/fecha": {
 			"version": "4.2.3",
@@ -3820,22 +3620,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-stream": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/glob": {
 			"version": "10.4.5",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -3891,32 +3675,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/got": {
-			"version": "11.8.6",
-			"resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
-			"integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@sindresorhus/is": "^4.0.0",
-				"@szmarczak/http-timer": "^4.0.5",
-				"@types/cacheable-request": "^6.0.1",
-				"@types/responselike": "^1.0.0",
-				"cacheable-lookup": "^5.0.3",
-				"cacheable-request": "^7.0.2",
-				"decompress-response": "^6.0.0",
-				"http2-wrapper": "^1.0.0-beta.5.2",
-				"lowercase-keys": "^2.0.0",
-				"p-cancelable": "^2.0.0",
-				"responselike": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10.19.0"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/got?sponsor=1"
 			}
 		},
 		"node_modules/handlebars": {
@@ -3999,14 +3757,6 @@
 				"node": ">=18.0.0"
 			}
 		},
-		"node_modules/hpagent": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
-			"integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true
-		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4080,13 +3830,6 @@
 				"entities": "^4.4.0"
 			}
 		},
-		"node_modules/http-cache-semantics": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-			"integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
 		"node_modules/http-errors": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -4101,20 +3844,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
-			}
-		},
-		"node_modules/http2-wrapper": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
-			"integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"quick-lru": "^5.1.1",
-				"resolve-alpn": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=10.19.0"
 			}
 		},
 		"node_modules/https-proxy-agent": {
@@ -4703,13 +4432,6 @@
 			"integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
 			"license": "MIT"
 		},
-		"node_modules/lodash.clonedeep": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-			"integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/lodash.defaults": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -4835,16 +4557,6 @@
 			"integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/lowercase-keys": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-			"integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/lru-cache": {
 			"version": "10.4.3",
@@ -4981,16 +4693,6 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/minimatch": {
@@ -5739,40 +5441,6 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"license": "MIT"
 		},
-		"node_modules/ngrok": {
-			"version": "5.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/ngrok/-/ngrok-5.0.0-beta.2.tgz",
-			"integrity": "sha512-UzsyGiJ4yTTQLCQD11k1DQaMwq2/SsztBg2b34zAqcyjS25qjDpogMKPaCKHwe/APRTHeel3iDXcVctk5CNaCQ==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"extract-zip": "^2.0.1",
-				"got": "^11.8.5",
-				"lodash.clonedeep": "^4.5.0",
-				"uuid": "^7.0.0 || ^8.0.0",
-				"yaml": "^2.2.2"
-			},
-			"bin": {
-				"ngrok": "bin/ngrok"
-			},
-			"engines": {
-				"node": ">=14.2"
-			},
-			"optionalDependencies": {
-				"hpagent": "^0.1.2"
-			}
-		},
-		"node_modules/ngrok/node_modules/uuid": {
-			"version": "8.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/bin/uuid"
-			}
-		},
 		"node_modules/nise": {
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/nise/-/nise-6.1.1.tgz",
@@ -5981,19 +5649,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/normalize-url": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
-			"integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/npmlog": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
@@ -6085,16 +5740,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/p-cancelable": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
-			"integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/p-limit": {
@@ -6270,13 +5915,6 @@
 			"engines": {
 				"node": ">= 14.16"
 			}
-		},
-		"node_modules/pend": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -6997,19 +6635,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/quick-lru": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/rambda": {
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/rambda/-/rambda-7.5.0.tgz",
@@ -7112,13 +6737,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/resolve-alpn": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-			"integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -7126,19 +6744,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/responselike": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
-			"integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"lowercase-keys": "^2.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/rimraf": {
@@ -8628,19 +8233,6 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"license": "ISC"
 		},
-		"node_modules/yaml": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -8723,17 +8315,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/Server/package.json
+++ b/Server/package.json
@@ -49,7 +49,6 @@
 		"esm": "3.2.25",
 		"globals": "^15.14.0",
 		"mocha": "11.1.0",
-		"ngrok": "5.0.0-beta.2",
 		"nodemon": "3.1.9",
 		"prettier": "^3.3.3",
 		"sinon": "19.0.2"

--- a/Server/service/networkService.js
+++ b/Server/service/networkService.js
@@ -393,9 +393,7 @@ class NetworkService {
 	async requestDistributedHttp(job) {
 		try {
 			const monitor = job.data;
-			const CALLBACK_URL = process.env.NGROK_URL
-				? process.env.NGROK_URL
-				: process.env.CALLBACK_URL;
+			const CALLBACK_URL = process.env.CALLBACK_URL;
 
 			const response = await this.axios.post(
 				UPROCK_ENDPOINT,


### PR DESCRIPTION
This PR removes ngrok from the backend.

Ngrok was used to create a tunnel in order to receive callbacks from UpRock.

Creating a tunnel is now up to the developer, recommend using [zrok.io](https://zrok.io/).

Callback url must be specified in server .env file in order to receive callbacks:

`CALLBACK_URL="https://callback.share.zrok.io"`