### PR TITLE
Setting Authorization in axios interceptor instead of passing from UI component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
 				"i18next": "^24.2.2",
 				"immutability-helper": "^3.1.1",
 				"joi": "17.13.3",
-				"jwt-decode": "^4.0.0",
 				"maplibre-gl": "5.1.0",
 				"mui-color-input": "^5.0.1",
 				"react": "18.3.1",
@@ -13820,15 +13819,6 @@
 			},
 			"engines": {
 				"node": ">=4.0"
-			}
-		},
-		"node_modules/jwt-decode": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-			"integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/kdbush": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
 		"i18next": "^24.2.2",
 		"immutability-helper": "^3.1.1",
 		"joi": "17.13.3",
-		"jwt-decode": "^4.0.0",
 		"maplibre-gl": "5.1.0",
 		"mui-color-input": "^5.0.1",
 		"react": "18.3.1",

--- a/src/Components/ActionsMenu/index.jsx
+++ b/src/Components/ActionsMenu/index.jsx
@@ -25,8 +25,6 @@ const ActionsMenu = ({
 	const [isOpen, setIsOpen] = useState(false);
 	const dispatch = useDispatch();
 	const theme = useTheme();
-	const authState = useSelector((state) => state.auth);
-	const authToken = authState.authToken;
 	const { isLoading } = useSelector((state) => state.uptimeMonitors);
 
 	const handleRemove = async (event) => {
@@ -34,7 +32,7 @@ const ActionsMenu = ({
 		event.stopPropagation();
 		let monitor = { _id: actions.id };
 		const action = await dispatch(
-			deleteUptimeMonitor({ authToken: authState.authToken, monitor })
+			deleteUptimeMonitor({ monitor })
 		);
 		if (action.meta.requestStatus === "fulfilled") {
 			setIsOpen(false); // close modal
@@ -49,7 +47,7 @@ const ActionsMenu = ({
 		try {
 			setIsLoading(true);
 			const action = await dispatch(
-				pauseUptimeMonitor({ authToken, monitorId: monitor._id })
+				pauseUptimeMonitor({ monitorId: monitor._id })
 			);
 			if (pauseUptimeMonitor.fulfilled.match(action)) {
 				const state = action?.payload?.data.isActive === false ? "paused" : "resumed";

--- a/src/Components/TabPanels/Account/PasswordPanel.jsx
+++ b/src/Components/TabPanels/Account/PasswordPanel.jsx
@@ -30,7 +30,7 @@ const PasswordPanel = () => {
 	const SPACING_GAP = theme.spacing(12);
 
 	//redux state
-	const { authToken, isLoading } = useSelector((state) => state.auth);
+	const { isLoading } = useSelector((state) => state.auth);
 
 	const idToName = {
 		"edit-current-password": "password",
@@ -89,7 +89,7 @@ const PasswordPanel = () => {
 			});
 			setErrors(newErrors);
 		} else {
-			const action = await dispatch(update({ authToken, localData }));
+			const action = await dispatch(update({ localData }));
 			if (action.payload.success) {
 				createToast({
 					body: "Your password was changed successfully.",

--- a/src/Components/TabPanels/Account/ProfilePanel.jsx
+++ b/src/Components/TabPanels/Account/ProfilePanel.jsx
@@ -32,7 +32,7 @@ const ProfilePanel = () => {
 	const SPACING_GAP = theme.spacing(12);
 
 	//redux state
-	const { user, authToken, isLoading } = useSelector((state) => state.auth);
+	const { user, isLoading } = useSelector((state) => state.auth);
 
 	const idToName = {
 		"edit-first-name": "firstName",
@@ -164,7 +164,7 @@ const ProfilePanel = () => {
 			return;
 		}
 
-		const action = await dispatch(update({ authToken, localData }));
+		const action = await dispatch(update({ localData }));
 		if (action.payload.success) {
 			createToast({
 				body: "Your profile data was changed successfully.",
@@ -187,7 +187,7 @@ const ProfilePanel = () => {
 
 	// Initiates the account deletion process
 	const handleDeleteAccount = async () => {
-		const action = await dispatch(deleteUser(authToken));
+		const action = await dispatch(deleteUser());
 		if (action.payload.success) {
 			dispatch(clearAuthState());
 			dispatch(clearUptimeMonitorState());

--- a/src/Components/TabPanels/Account/TeamPanel.jsx
+++ b/src/Components/TabPanels/Account/TeamPanel.jsx
@@ -23,7 +23,6 @@ const TeamPanel = () => {
 
 	const SPACING_GAP = theme.spacing(12);
 
-	const { authToken } = useSelector((state) => state.auth);
 	const [toInvite, setToInvite] = useState({
 		email: "",
 		role: ["0"],
@@ -63,9 +62,7 @@ const TeamPanel = () => {
 	useEffect(() => {
 		const fetchTeam = async () => {
 			try {
-				const response = await networkService.getAllUsers({
-					authToken: authToken,
-				});
+				const response = await networkService.getAllUsers();
 				setMembers(response.data.data);
 			} catch (error) {
 				createToast({
@@ -75,7 +72,7 @@ const TeamPanel = () => {
 		};
 
 		fetchTeam();
-	}, [authToken]);
+	}, []);
 
 	useEffect(() => {
 		const ROLE_MAP = {
@@ -150,7 +147,6 @@ const TeamPanel = () => {
 
 		try {
 			await networkService.requestInvitationToken({
-				authToken: authToken,
 				email: toInvite.email,
 				role: toInvite.role,
 			});

--- a/src/Features/Auth/authSlice.js
+++ b/src/Features/Auth/authSlice.js
@@ -1,6 +1,5 @@
 import { networkService } from "../../main";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { jwtDecode } from "jwt-decode";
 import axios from "axios";
 
 const initialState = {
@@ -45,7 +44,7 @@ export const login = createAsyncThunk("auth/login", async (form, thunkApi) => {
 
 export const update = createAsyncThunk("auth/update", async (data, thunkApi) => {
 	const { localData: form } = data;
-	const user = jwtDecode(token);
+	const user = thunkApi.getState().auth.user;
 	try {
 		const fd = new FormData();
 		form.firstName && fd.append("firstName", form.firstName);
@@ -77,8 +76,8 @@ export const update = createAsyncThunk("auth/update", async (data, thunkApi) => 
 	}
 });
 
-export const deleteUser = createAsyncThunk("auth/delete", async (data, thunkApi) => {
-	const user = jwtDecode(data);
+export const deleteUser = createAsyncThunk("auth/delete", async (_, thunkApi) => {
+	const user = thunkApi.getState().auth.user;
 
 	try {
 		const res = await networkService.deleteUser({ userId: user._id, });

--- a/src/Features/Auth/authSlice.js
+++ b/src/Features/Auth/authSlice.js
@@ -44,7 +44,7 @@ export const login = createAsyncThunk("auth/login", async (form, thunkApi) => {
 });
 
 export const update = createAsyncThunk("auth/update", async (data, thunkApi) => {
-	const { authToken: token, localData: form } = data;
+	const { localData: form } = data;
 	const user = jwtDecode(token);
 	try {
 		const fd = new FormData();
@@ -61,7 +61,6 @@ export const update = createAsyncThunk("auth/update", async (data, thunkApi) => 
 		form.deleteProfileImage && fd.append("deleteProfileImage", form.deleteProfileImage);
 
 		const res = await networkService.updateUser({
-			authToken: token,
 			userId: user._id,
 			form: fd,
 		});
@@ -82,10 +81,7 @@ export const deleteUser = createAsyncThunk("auth/delete", async (data, thunkApi)
 	const user = jwtDecode(data);
 
 	try {
-		const res = await networkService.deleteUser({
-			authToken: data,
-			userId: user._id,
-		});
+		const res = await networkService.deleteUser({ userId: user._id, });
 		return res.data;
 	} catch (error) {
 		if (error.response && error.response.data) {

--- a/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -12,11 +12,8 @@ export const createInfrastructureMonitor = createAsyncThunk(
 	"infrastructureMonitors/createMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
-			const res = await networkService.createMonitor({
-				authToken: authToken,
-				monitor: monitor,
-			});
+			const { monitor } = data;
+			const res = await networkService.createMonitor({ monitor: monitor });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -35,12 +32,8 @@ export const checkInfrastructureEndpointResolution = createAsyncThunk(
 	"infrastructureMonitors/CheckEndpoint",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorURL } = data;
-
-			const res = await networkService.checkEndpointResolution({
-				authToken: authToken,
-				monitorURL: monitorURL,
-			});
+			const { monitorURL } = data;
+			const res = await networkService.checkEndpointResolution({ monitorURL: monitorURL, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -59,11 +52,8 @@ export const getInfrastructureMonitorById = createAsyncThunk(
 	"infrastructureMonitors/getMonitorById",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorId } = data;
-			const res = await networkService.getMonitorById({
-				authToken: authToken,
-				monitorId: monitorId,
-			});
+			const { monitorId } = data;
+			const res = await networkService.getMonitorById({ monitorId: monitorId });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -84,7 +74,6 @@ export const getInfrastructureMonitorsByTeamId = createAsyncThunk(
 		const user = jwtDecode(token);
 		try {
 			const res = await networkService.getMonitorsAndSummaryByTeamId({
-				authToken: token,
 				teamId: user.teamId,
 				types: ["hardware"],
 				limit: 1,
@@ -108,7 +97,7 @@ export const updateInfrastructureMonitor = createAsyncThunk(
 	"infrastructureMonitors/updateMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
+			const { monitor } = data;
 			const updatedFields = {
 				name: monitor.name,
 				description: monitor.description,
@@ -117,7 +106,6 @@ export const updateInfrastructureMonitor = createAsyncThunk(
 				threshold: monitor.threshold,
 			};
 			const res = await networkService.updateMonitor({
-				authToken: authToken,
 				monitorId: monitor._id,
 				updatedFields: updatedFields,
 			});
@@ -139,11 +127,8 @@ export const deleteInfrastructureMonitor = createAsyncThunk(
 	"infrastructureMonitors/deleteMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
-			const res = await networkService.deleteMonitorById({
-				authToken: authToken,
-				monitorId: monitor._id,
-			});
+			const { monitor } = data;
+			const res = await networkService.deleteMonitorById({ monitorId: monitor._id, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -162,11 +147,8 @@ export const pauseInfrastructureMonitor = createAsyncThunk(
 	"infrastructureMonitors/pauseMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorId } = data;
-			const res = await networkService.pauseMonitorById({
-				authToken: authToken,
-				monitorId: monitorId,
-			});
+			const { monitorId } = data;
+			const res = await networkService.pauseMonitorById({ monitorId: monitorId, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -185,11 +167,8 @@ export const deleteInfrastructureMonitorChecksByTeamId = createAsyncThunk(
 	"infrastructureMonitors/deleteChecksByTeamId",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, teamId } = data;
-			const res = await networkService.deleteChecksByTeamId({
-				authToken: authToken,
-				teamId: teamId,
-			});
+			const { teamId } = data;
+			const res = await networkService.deleteChecksByTeamId({ teamId: teamId, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -208,10 +187,7 @@ export const deleteAllInfrastructureMonitors = createAsyncThunk(
 	"infrastructureMonitors/deleteAllMonitors",
 	async (data, thunkApi) => {
 		try {
-			const { authToken } = data;
-			const res = await networkService.deleteAllMonitors({
-				authToken: authToken,
-			});
+			const res = await networkService.deleteAllMonitors();
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {

--- a/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
+++ b/src/Features/InfrastructureMonitors/infrastructureMonitorsSlice.js
@@ -1,5 +1,4 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { jwtDecode } from "jwt-decode";
 import { networkService } from "../../main";
 const initialState = {
 	isLoading: false,
@@ -70,8 +69,8 @@ export const getInfrastructureMonitorById = createAsyncThunk(
 
 export const getInfrastructureMonitorsByTeamId = createAsyncThunk(
 	"infrastructureMonitors/getMonitorsByTeamId",
-	async (token, thunkApi) => {
-		const user = jwtDecode(token);
+	async (_, thunkApi) => {
+		const user = thunkApi.getState().auth.user;
 		try {
 			const res = await networkService.getMonitorsAndSummaryByTeamId({
 				teamId: user.teamId,

--- a/src/Features/PageSpeedMonitor/pageSpeedMonitorSlice.js
+++ b/src/Features/PageSpeedMonitor/pageSpeedMonitorSlice.js
@@ -12,11 +12,8 @@ export const createPageSpeed = createAsyncThunk(
 	"pageSpeedMonitors/createPageSpeed",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
-			const res = await networkService.createMonitor({
-				authToken: authToken,
-				monitor: monitor,
-			});
+			const { monitor } = data;
+			const res = await networkService.createMonitor({ monitor: monitor, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -35,12 +32,8 @@ export const checkEndpointResolution = createAsyncThunk(
 	"monitors/checkEndpoint",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorURL } = data;
-
-			const res = await networkService.checkEndpointResolution({
-				authToken: authToken,
-				monitorURL: monitorURL,
-			});
+			const { monitorURL } = data;
+			const res = await networkService.checkEndpointResolution({ monitorURL: monitorURL, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -59,11 +52,8 @@ export const getPagespeedMonitorById = createAsyncThunk(
 	"monitors/getMonitorById",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorId } = data;
-			const res = await networkService.getMonitorById({
-				authToken: authToken,
-				monitorId: monitorId,
-			});
+			const { monitorId } = data;
+			const res = await networkService.getMonitorById({ monitorId: monitorId, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -84,7 +74,6 @@ export const getPageSpeedByTeamId = createAsyncThunk(
 		const user = jwtDecode(token);
 		try {
 			const res = await networkService.getMonitorsAndSummaryByTeamId({
-				authToken: token,
 				teamId: user.teamId,
 				types: ["pagespeed"],
 			});
@@ -106,7 +95,7 @@ export const updatePageSpeed = createAsyncThunk(
 	"pageSpeedMonitors/updatePageSpeed",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
+			const { monitor } = data;
 			const updatedFields = {
 				name: monitor.name,
 				description: monitor.description,
@@ -114,7 +103,6 @@ export const updatePageSpeed = createAsyncThunk(
 				// notifications: monitor.notifications,
 			};
 			const res = await networkService.updateMonitor({
-				authToken: authToken,
 				monitorId: monitor._id,
 				updatedFields: updatedFields,
 			});
@@ -136,11 +124,8 @@ export const deletePageSpeed = createAsyncThunk(
 	"pageSpeedMonitors/deletePageSpeed",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
-			const res = await networkService.deleteMonitorById({
-				authToken: authToken,
-				monitorId: monitor._id,
-			});
+			const { monitor } = data;
+			const res = await networkService.deleteMonitorById({ monitorId: monitor._id, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -158,11 +143,8 @@ export const pausePageSpeed = createAsyncThunk(
 	"pageSpeedMonitors/pausePageSpeed",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorId } = data;
-			const res = await networkService.pauseMonitorById({
-				authToken: authToken,
-				monitorId: monitorId,
-			});
+			const { monitorId } = data;
+			const res = await networkService.pauseMonitorById({ monitorId: monitorId, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {

--- a/src/Features/PageSpeedMonitor/pageSpeedMonitorSlice.js
+++ b/src/Features/PageSpeedMonitor/pageSpeedMonitorSlice.js
@@ -1,5 +1,4 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { jwtDecode } from "jwt-decode";
 import { networkService } from "../../main";
 const initialState = {
 	isLoading: false,
@@ -70,8 +69,8 @@ export const getPagespeedMonitorById = createAsyncThunk(
 
 export const getPageSpeedByTeamId = createAsyncThunk(
 	"pageSpeedMonitors/getPageSpeedByTeamId",
-	async (token, thunkApi) => {
-		const user = jwtDecode(token);
+	async (_, thunkApi) => {
+		const user = thunkApi.getState().auth.user;
 		try {
 			const res = await networkService.getMonitorsAndSummaryByTeamId({
 				teamId: user.teamId,

--- a/src/Features/Settings/settingsSlice.js
+++ b/src/Features/Settings/settingsSlice.js
@@ -11,9 +11,7 @@ export const getAppSettings = createAsyncThunk(
 	"settings/getSettings",
 	async (data, thunkApi) => {
 		try {
-			const res = await networkService.getAppSettings({
-				authToken: data.authToken,
-			});
+			const res = await networkService.getAppSettings();
 			return res.data;
 		} catch (error) {
 			if (error.response.data) {
@@ -30,7 +28,7 @@ export const getAppSettings = createAsyncThunk(
 
 export const updateAppSettings = createAsyncThunk(
 	"settings/updateSettings",
-	async ({ settings, authToken }, thunkApi) => {
+	async ({ settings }, thunkApi) => {
 		networkService.setBaseUrl(settings.apiBaseUrl);
 		try {
 			const parsedSettings = {
@@ -49,10 +47,7 @@ export const updateAppSettings = createAsyncThunk(
 				systemEmailAddress: settings.systemEmailAddress,
 				systemEmailPassword: settings.systemEmailPassword,
 			};
-			const res = await networkService.updateAppSettings({
-				settings: parsedSettings,
-				authToken,
-			});
+			const res = await networkService.updateAppSettings({ settings: parsedSettings, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {

--- a/src/Features/UptimeMonitors/uptimeMonitorsSlice.js
+++ b/src/Features/UptimeMonitors/uptimeMonitorsSlice.js
@@ -12,11 +12,8 @@ export const createUptimeMonitor = createAsyncThunk(
 	"monitors/createMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
-			const res = await networkService.createMonitor({
-				authToken: authToken,
-				monitor: monitor,
-			});
+			const { monitor } = data;
+			const res = await networkService.createMonitor({ monitor: monitor });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -35,12 +32,8 @@ export const checkEndpointResolution = createAsyncThunk(
 	"monitors/checkEndpoint",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorURL } = data;
-
-			const res = await networkService.checkEndpointResolution({
-				authToken: authToken,
-				monitorURL: monitorURL,
-			});
+			const { monitorURL } = data;
+			const res = await networkService.checkEndpointResolution({ monitorURL: monitorURL, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -59,11 +52,8 @@ export const getUptimeMonitorById = createAsyncThunk(
 	"monitors/getMonitorById",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorId } = data;
-			const res = await networkService.getMonitorById({
-				authToken: authToken,
-				monitorId: monitorId,
-			});
+			const { monitorId } = data;
+			const res = await networkService.getMonitorById({ monitorId: monitorId, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -82,7 +72,7 @@ export const updateUptimeMonitor = createAsyncThunk(
 	"monitors/updateMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
+			const { monitor } = data;
 			const updatedFields = {
 				name: monitor.name,
 				description: monitor.description,
@@ -93,7 +83,6 @@ export const updateUptimeMonitor = createAsyncThunk(
 				jsonPath: monitor.jsonPath,
 			};
 			const res = await networkService.updateMonitor({
-				authToken: authToken,
 				monitorId: monitor._id,
 				monitor,
 			});
@@ -115,11 +104,8 @@ export const deleteUptimeMonitor = createAsyncThunk(
 	"monitors/deleteMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitor } = data;
-			const res = await networkService.deleteMonitorById({
-				authToken: authToken,
-				monitorId: monitor._id,
-			});
+			const { monitor } = data;
+			const res = await networkService.deleteMonitorById({ monitorId: monitor._id, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -138,11 +124,8 @@ export const pauseUptimeMonitor = createAsyncThunk(
 	"monitors/pauseMonitor",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, monitorId } = data;
-			const res = await networkService.pauseMonitorById({
-				authToken: authToken,
-				monitorId: monitorId,
-			});
+			const { monitorId } = data;
+			const res = await networkService.pauseMonitorById({ monitorId: monitorId, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -161,11 +144,8 @@ export const deleteMonitorChecksByTeamId = createAsyncThunk(
 	"monitors/deleteChecksByTeamId",
 	async (data, thunkApi) => {
 		try {
-			const { authToken, teamId } = data;
-			const res = await networkService.deleteChecksByTeamId({
-				authToken: authToken,
-				teamId: teamId,
-			});
+			const { teamId } = data;
+			const res = await networkService.deleteChecksByTeamId({ teamId: teamId, });
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -183,10 +163,7 @@ export const addDemoMonitors = createAsyncThunk(
 	"monitors/addDemoMonitors",
 	async (data, thunkApi) => {
 		try {
-			const { authToken } = data;
-			const res = await networkService.addDemoMonitors({
-				authToken: authToken,
-			});
+			const res = await networkService.addDemoMonitors();
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {
@@ -205,10 +182,7 @@ export const deleteAllMonitors = createAsyncThunk(
 	"monitors/deleteAllMonitors",
 	async (data, thunkApi) => {
 		try {
-			const { authToken } = data;
-			const res = await networkService.deleteAllMonitors({
-				authToken: authToken,
-			});
+			const res = await networkService.deleteAllMonitors();
 			return res.data;
 		} catch (error) {
 			if (error.response && error.response.data) {

--- a/src/Features/UptimeMonitors/uptimeMonitorsSlice.js
+++ b/src/Features/UptimeMonitors/uptimeMonitorsSlice.js
@@ -1,5 +1,4 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
-import { jwtDecode } from "jwt-decode";
 import { networkService } from "../../main";
 const initialState = {
 	isLoading: false,

--- a/src/Pages/DistributedUptime/Create/Hooks/useCreateDistributedUptimeMonitor.jsx
+++ b/src/Pages/DistributedUptime/Create/Hooks/useCreateDistributedUptimeMonitor.jsx
@@ -4,17 +4,15 @@ import { useSelector } from "react-redux";
 import { createToast } from "../../../../Utils/toastUtils";
 
 const useCreateDistributedUptimeMonitor = ({ isCreate, monitorId }) => {
-	const { authToken, user } = useSelector((state) => state.auth);
-
 	const [isLoading, setIsLoading] = useState(false);
 	const [networkError, setNetworkError] = useState(false);
 	const createDistributedUptimeMonitor = async ({ form }) => {
 		setIsLoading(true);
 		try {
 			if (isCreate) {
-				await networkService.createMonitor({ authToken, monitor: form });
+				await networkService.createMonitor({ monitor: form });
 			} else {
-				await networkService.updateMonitor({ authToken, monitor: form, monitorId });
+				await networkService.updateMonitor({ monitor: form, monitorId });
 			}
 
 			return true;

--- a/src/Pages/DistributedUptime/Create/Hooks/useMonitorFetch.jsx
+++ b/src/Pages/DistributedUptime/Create/Hooks/useMonitorFetch.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { networkService } from "../../../../main";
 import { createToast } from "../../../../Utils/toastUtils";
 
-export const useMonitorFetch = ({ authToken, monitorId, isCreate }) => {
+export const useMonitorFetch = ({ monitorId, isCreate }) => {
 	const [networkError, setNetworkError] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
 	const [monitor, setMonitor] = useState(undefined);
@@ -12,7 +12,6 @@ export const useMonitorFetch = ({ authToken, monitorId, isCreate }) => {
 			try {
 				if (isCreate) return;
 				const res = await networkService.getUptimeDetailsById({
-					authToken: authToken,
 					monitorId: monitorId,
 					normalize: true,
 				});
@@ -25,7 +24,7 @@ export const useMonitorFetch = ({ authToken, monitorId, isCreate }) => {
 			}
 		};
 		fetchMonitors();
-	}, [authToken, monitorId, isCreate]);
+	}, [monitorId, isCreate]);
 	return [monitor, isLoading, networkError];
 };
 

--- a/src/Pages/DistributedUptime/Create/index.jsx
+++ b/src/Pages/DistributedUptime/Create/index.jsx
@@ -48,7 +48,7 @@ const CreateDistributedUptime = () => {
 	];
 
 	// Redux state
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	// Local state
 	const [https, setHttps] = useState(true);
@@ -68,7 +68,6 @@ const CreateDistributedUptime = () => {
 		useCreateDistributedUptimeMonitor({ isCreate, monitorId });
 
 	const [monitor, monitorIsLoading, monitorNetworkError] = useMonitorFetch({
-		authToken,
 		monitorId,
 		isCreate,
 	});

--- a/src/Pages/DistributedUptime/Details/Hooks/useDeleteMonitor.jsx
+++ b/src/Pages/DistributedUptime/Details/Hooks/useDeleteMonitor.jsx
@@ -5,11 +5,10 @@ import { createToast } from "../../../../Utils/toastUtils";
 
 const useDeleteMonitor = ({ monitorId }) => {
 	const [isLoading, setIsLoading] = useState(false);
-	const { authToken } = useSelector((state) => state.auth);
 	const deleteMonitor = async () => {
 		try {
 			setIsLoading(true);
-			await networkService.deleteMonitorById({ authToken, monitorId });
+			await networkService.deleteMonitorById({ monitorId });
 			return true;
 		} catch (error) {
 			createToast({

--- a/src/Pages/DistributedUptime/Details/Hooks/useSubscribeToDetails.jsx
+++ b/src/Pages/DistributedUptime/Details/Hooks/useSubscribeToDetails.jsx
@@ -53,7 +53,6 @@ const useSubscribeToDetails = ({ monitorId, isPublic, isPublished, dateRange }) 
 	const [monitor, setMonitor] = useState(undefined);
 	const [lastUpdateTrigger, setLastUpdateTrigger] = useState(0);
 	const [devices, setDevices] = useState(Array.from({ length: 5 }, getRandomDevice));
-	const authToken = useSelector((state) => state.auth.token);
 
 	const prevDateRangeRef = useRef(dateRange);
 
@@ -68,7 +67,6 @@ const useSubscribeToDetails = ({ monitorId, isPublic, isPublished, dateRange }) 
 
 		try {
 			const cleanup = networkService.subscribeToDistributedUptimeDetails({
-				authToken,
 				monitorId,
 				dateRange: dateRange,
 				normalize: true,
@@ -105,7 +103,6 @@ const useSubscribeToDetails = ({ monitorId, isPublic, isPublished, dateRange }) 
 			setNetworkError(true);
 		}
 	}, [
-		authToken,
 		dateRange,
 		monitorId,
 		retryCount,

--- a/src/Pages/DistributedUptime/Monitors/Hooks/useSubscribeToMonitors.jsx
+++ b/src/Pages/DistributedUptime/Monitors/Hooks/useSubscribeToMonitors.jsx
@@ -7,7 +7,7 @@ import { createToast } from "../../../../Utils/toastUtils";
 
 const useSubscribeToMonitors = () => {
 	// Redux
-	const { authToken, user } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	// Local state
 	const [isLoading, setIsLoading] = useState(true);
@@ -22,7 +22,6 @@ const useSubscribeToMonitors = () => {
 	useEffect(() => {
 		try {
 			const cleanup = networkService.subscribeToDistributedUptimeMonitors({
-				authToken: authToken,
 				teamId: user.teamId,
 				limit: 25,
 				types: ["distributed_http"],
@@ -57,7 +56,7 @@ const useSubscribeToMonitors = () => {
 			});
 			setNetworkError(true);
 		}
-	}, [authToken, user, getMonitorWithPercentage, theme]);
+	}, [user, getMonitorWithPercentage, theme]);
 	return [isLoading, networkError, monitors, monitorsSummary, filteredMonitors];
 };
 export { useSubscribeToMonitors };

--- a/src/Pages/DistributedUptimeStatus/Status/Hooks/useStatusPageFetchByUrl.jsx
+++ b/src/Pages/DistributedUptimeStatus/Status/Hooks/useStatusPageFetchByUrl.jsx
@@ -9,12 +9,10 @@ const useStatusPageFetchByUrl = ({ url }) => {
 	const [statusPage, setStatusPage] = useState(undefined);
 	const [monitorId, setMonitorId] = useState(undefined);
 	const [isPublished, setIsPublished] = useState(false);
-	const { authToken } = useSelector((state) => state.auth);
 	useEffect(() => {
 		const fetchStatusPageByUrl = async () => {
 			try {
 				const response = await networkService.getStatusPageByUrl({
-					authToken,
 					url,
 					type: "distributed",
 				});
@@ -33,7 +31,7 @@ const useStatusPageFetchByUrl = ({ url }) => {
 			}
 		};
 		fetchStatusPageByUrl();
-	}, [authToken, url]);
+	}, [url]);
 
 	return [isLoading, networkError, statusPage, monitorId, isPublished];
 };

--- a/src/Pages/Incidents/Hooks/useChecksFetch.jsx
+++ b/src/Pages/Incidents/Hooks/useChecksFetch.jsx
@@ -4,7 +4,7 @@ import { createToast } from "../../../Utils/toastUtils";
 import { useSelector } from "react-redux";
 const useChecksFetch = ({ selectedMonitor, filter, dateRange, page, rowsPerPage }) => {
 	//Redux
-	const { authToken, user } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	//Local
 	const [isLoading, setIsLoading] = useState(true);
@@ -20,7 +20,6 @@ const useChecksFetch = ({ selectedMonitor, filter, dateRange, page, rowsPerPage 
 
 				if (selectedMonitor === "0") {
 					res = await networkService.getChecksByTeam({
-						authToken: authToken,
 						status: false,
 						teamId: user.teamId,
 						sortOrder: "desc",
@@ -32,7 +31,6 @@ const useChecksFetch = ({ selectedMonitor, filter, dateRange, page, rowsPerPage 
 					});
 				} else {
 					res = await networkService.getChecksByMonitor({
-						authToken: authToken,
 						status: false,
 						monitorId: selectedMonitor,
 						sortOrder: "desc",
@@ -53,7 +51,7 @@ const useChecksFetch = ({ selectedMonitor, filter, dateRange, page, rowsPerPage 
 			}
 		};
 		fetchChecks();
-	}, [authToken, user, dateRange, page, rowsPerPage, filter, selectedMonitor]);
+	}, [user, dateRange, page, rowsPerPage, filter, selectedMonitor]);
 	return { isLoading, networkError, checks, checksCount };
 };
 

--- a/src/Pages/Incidents/Hooks/useMonitorsFetch.jsx
+++ b/src/Pages/Incidents/Hooks/useMonitorsFetch.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { networkService } from "../../../main";
 import { createToast } from "../../../Utils/toastUtils";
-const useMonitorsFetch = ({ authToken, teamId }) => {
+const useMonitorsFetch = ({ teamId }) => {
 	//Local state
 	const [isLoading, setIsLoading] = useState(true);
 	const [networkError, setNetworkError] = useState(false);
@@ -13,7 +13,6 @@ const useMonitorsFetch = ({ authToken, teamId }) => {
 			try {
 				setIsLoading(true);
 				const res = await networkService.getMonitorsByTeamId({
-					authToken,
 					teamId,
 					limit: null,
 					types: null,
@@ -44,7 +43,7 @@ const useMonitorsFetch = ({ authToken, teamId }) => {
 		};
 
 		fetchMonitors();
-	}, [authToken, teamId]);
+	}, [teamId]);
 	return { isLoading, monitors, networkError };
 };
 

--- a/src/Pages/Incidents/index.jsx
+++ b/src/Pages/Incidents/index.jsx
@@ -16,7 +16,7 @@ const BREADCRUMBS = [{ name: `Incidents`, path: "/incidents" }];
 
 const Incidents = () => {
 	// Redux state
-	const { authToken, user } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	// Local state
 	const [selectedMonitor, setSelectedMonitor] = useState("0");
@@ -26,7 +26,6 @@ const Incidents = () => {
 	const theme = useTheme();
 
 	const { monitors, isLoading, networkError } = useMonitorsFetch({
-		authToken,
 		teamId: user.teamId,
 	});
 

--- a/src/Pages/Infrastructure/Create/index.jsx
+++ b/src/Pages/Infrastructure/Create/index.jsx
@@ -48,7 +48,7 @@ const getAlertError = (errors) => {
 
 const CreateInfrastructureMonitor = () => {
 	const theme = useTheme();
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 	const monitorState = useSelector((state) => state.infrastructureMonitor);
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
@@ -148,7 +148,7 @@ const CreateInfrastructureMonitor = () => {
 		};
 
 		const action = await dispatch(
-			createInfrastructureMonitor({ authToken, monitor: form })
+			createInfrastructureMonitor({ monitor: form })
 		);
 		if (action.meta.requestStatus === "fulfilled") {
 			createToast({ body: "Infrastructure monitor created successfully!" });

--- a/src/Pages/Infrastructure/Details/Hooks/useHardwareMonitorsFetch.jsx
+++ b/src/Pages/Infrastructure/Details/Hooks/useHardwareMonitorsFetch.jsx
@@ -7,13 +7,10 @@ const useHardwareMonitorsFetch = ({ monitorId, dateRange }) => {
 	const [networkError, setNetworkError] = useState(false);
 	const [monitor, setMonitor] = useState(undefined);
 
-	const { authToken } = useSelector((state) => state.auth);
-
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
 				const response = await networkService.getHardwareDetailsByMonitorId({
-					authToken: authToken,
 					monitorId: monitorId,
 					dateRange: dateRange,
 				});
@@ -26,7 +23,7 @@ const useHardwareMonitorsFetch = ({ monitorId, dateRange }) => {
 			}
 		};
 		fetchData();
-	}, [monitorId, dateRange, authToken]);
+	}, [monitorId, dateRange]);
 
 	return {
 		isLoading,

--- a/src/Pages/Infrastructure/Monitors/Components/MonitorsTableMenu/index.jsx
+++ b/src/Pages/Infrastructure/Monitors/Components/MonitorsTableMenu/index.jsx
@@ -30,8 +30,6 @@ const InfrastructureMenu = ({ monitor, isAdmin, updateCallback }) => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [isDialogOpen, setIsDialogOpen] = useState(false);
 	const theme = useTheme();
-	const authState = useSelector((state) => state.auth);
-	const authToken = authState.authToken;
 	const { isLoading } = useSelector((state) => state.uptimeMonitors);
 
 	const openMenu = (e) => {
@@ -61,7 +59,6 @@ const InfrastructureMenu = ({ monitor, isAdmin, updateCallback }) => {
 	const handleRemove = async () => {
 		try {
 			await networkService.deleteMonitorById({
-				authToken,
 				monitorId: monitor.id,
 			});
 			createToast({ body: "Monitor deleted successfully." });

--- a/src/Pages/Infrastructure/Monitors/Hooks/useMonitorFetch.jsx
+++ b/src/Pages/Infrastructure/Monitors/Hooks/useMonitorFetch.jsx
@@ -5,7 +5,7 @@ import { createToast } from "../../../../Utils/toastUtils";
 
 const useMonitorFetch = ({ page, rowsPerPage, updateTrigger }) => {
 	// Redux state
-	const { authToken, user } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	// Local state
 	const [isLoading, setIsLoading] = useState(true);
@@ -17,7 +17,6 @@ const useMonitorFetch = ({ page, rowsPerPage, updateTrigger }) => {
 		const fetchMonitors = async () => {
 			try {
 				const response = await networkService.getMonitorsByTeamId({
-					authToken,
 					teamId: user.teamId,
 					limit: 1,
 					types: ["hardware"],
@@ -37,7 +36,7 @@ const useMonitorFetch = ({ page, rowsPerPage, updateTrigger }) => {
 		};
 
 		fetchMonitors();
-	}, [page, rowsPerPage, authToken, user.teamId, updateTrigger]);
+	}, [page, rowsPerPage, user.teamId, updateTrigger]);
 
 	return { monitors, summary, isLoading, networkError };
 };

--- a/src/Pages/Maintenance/CreateMaintenance/index.jsx
+++ b/src/Pages/Maintenance/CreateMaintenance/index.jsx
@@ -113,7 +113,7 @@ const CreateMaintenance = () => {
 	const { maintenanceWindowId } = useParams();
 	const navigate = useNavigate();
 	const theme = useTheme();
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 	const [monitors, setMonitors] = useState([]);
 	const [search, setSearch] = useState("");
 	const [isLoading, setIsLoading] = useState(false);
@@ -133,7 +133,6 @@ const CreateMaintenance = () => {
 			setIsLoading(true);
 			try {
 				const response = await networkService.getMonitorsByTeamId({
-					authToken: authToken,
 					teamId: user.teamId,
 					limit: null,
 					types: ["http", "ping", "pagespeed"],
@@ -146,7 +145,6 @@ const CreateMaintenance = () => {
 				}
 
 				const res = await networkService.getMaintenanceWindowById({
-					authToken: authToken,
 					maintenanceWindowId: maintenanceWindowId,
 				});
 				const maintenanceWindow = res.data.data;
@@ -174,7 +172,7 @@ const CreateMaintenance = () => {
 			}
 		};
 		fetchMonitors();
-	}, [authToken, user]);
+	}, [user]);
 
 	const handleSearch = (value) => {
 		setSearch(value);
@@ -239,7 +237,7 @@ const CreateMaintenance = () => {
 			submit.expiry = end;
 		}
 
-		const requestConfig = { authToken: authToken, maintenanceWindow: submit };
+		const requestConfig = { maintenanceWindow: submit };
 
 		if (maintenanceWindowId !== undefined) {
 			requestConfig.maintenanceWindowId = maintenanceWindowId;

--- a/src/Pages/Maintenance/MaintenanceTable/ActionsMenu/index.jsx
+++ b/src/Pages/Maintenance/MaintenanceTable/ActionsMenu/index.jsx
@@ -13,7 +13,6 @@ import Dialog from "../../../../Components/Dialog";
 
 const ActionsMenu = ({ /* isAdmin, */ maintenanceWindow, updateCallback }) => {
 	maintenanceWindow;
-	const { authToken } = useSelector((state) => state.auth);
 	const [anchorEl, setAnchorEl] = useState(null);
 	const [isOpen, setIsOpen] = useState(false);
 	const [isLoading, setIsLoading] = useState(false);
@@ -26,7 +25,6 @@ const ActionsMenu = ({ /* isAdmin, */ maintenanceWindow, updateCallback }) => {
 		try {
 			setIsLoading(true);
 			await networkService.deleteMaintenanceWindow({
-				authToken,
 				maintenanceWindowId: maintenanceWindow._id,
 			});
 			updateCallback();
@@ -47,7 +45,6 @@ const ActionsMenu = ({ /* isAdmin, */ maintenanceWindow, updateCallback }) => {
 				active: !maintenanceWindow.active,
 			};
 			await networkService.editMaintenanceWindow({
-				authToken,
 				maintenanceWindowId: maintenanceWindow._id,
 				maintenanceWindow: data,
 			});

--- a/src/Pages/Maintenance/index.jsx
+++ b/src/Pages/Maintenance/index.jsx
@@ -13,7 +13,6 @@ import { useIsAdmin } from "../../Hooks/useIsAdmin";
 const Maintenance = () => {
 	const theme = useTheme();
 	const navigate = useNavigate();
-	const { authToken } = useSelector((state) => state.auth);
 	const { rowsPerPage } = useSelector((state) => state.ui.maintenance);
 	const isAdmin = useIsAdmin();
 	const [maintenanceWindows, setMaintenanceWindows] = useState([]);
@@ -30,7 +29,6 @@ const Maintenance = () => {
 		const fetchMaintenanceWindows = async () => {
 			try {
 				const response = await networkService.getMaintenanceWindowsByTeamId({
-					authToken: authToken,
 					page: page,
 					rowsPerPage: rowsPerPage,
 				});
@@ -42,7 +40,7 @@ const Maintenance = () => {
 			}
 		};
 		fetchMaintenanceWindows();
-	}, [authToken, page, rowsPerPage, updateTrigger]);
+	}, [page, rowsPerPage, updateTrigger]);
 
 	return (
 		<Box

--- a/src/Pages/PageSpeed/Configure/index.jsx
+++ b/src/Pages/PageSpeed/Configure/index.jsx
@@ -31,7 +31,7 @@ const PageSpeedConfigure = () => {
 	const navigate = useNavigate();
 	const dispatch = useDispatch();
 	const MS_PER_MINUTE = 60000;
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 	const { isLoading } = useSelector((state) => state.pageSpeedMonitors);
 	const { monitorId } = useParams();
 	const [monitor, setMonitor] = useState({});
@@ -59,7 +59,7 @@ const PageSpeedConfigure = () => {
 	useEffect(() => {
 		const fetchMonitor = async () => {
 			try {
-				const action = await dispatch(getPagespeedMonitorById({ authToken, monitorId }));
+				const action = await dispatch(getPagespeedMonitorById({ monitorId }));
 
 				if (getPagespeedMonitorById.fulfilled.match(action)) {
 					const monitor = action.payload.data;
@@ -73,7 +73,7 @@ const PageSpeedConfigure = () => {
 			}
 		};
 		fetchMonitor();
-	}, [dispatch, authToken, monitorId, navigate]);
+	}, [dispatch, monitorId, navigate]);
 
 	const handleChange = (event, name) => {
 		let { value, id } = event.target;
@@ -130,7 +130,7 @@ const PageSpeedConfigure = () => {
 
 	const handlePause = async () => {
 		try {
-			const action = await dispatch(pausePageSpeed({ authToken, monitorId }));
+			const action = await dispatch(pausePageSpeed({ monitorId }));
 			if (pausePageSpeed.fulfilled.match(action)) {
 				const monitor = action.payload.data;
 				setMonitor(monitor);
@@ -147,10 +147,10 @@ const PageSpeedConfigure = () => {
 
 	const handleSave = async (event) => {
 		event.preventDefault();
-		const action = await dispatch(updatePageSpeed({ authToken, monitor: monitor }));
+		const action = await dispatch(updatePageSpeed({ monitor: monitor }));
 		if (action.meta.requestStatus === "fulfilled") {
 			createToast({ body: "Monitor updated successfully!" });
-			dispatch(getPageSpeedByTeamId(authToken));
+			dispatch(getPageSpeedByTeamId());
 		} else {
 			createToast({ body: "Failed to update monitor." });
 		}
@@ -160,7 +160,7 @@ const PageSpeedConfigure = () => {
 	const handleRemove = async (event) => {
 		event.preventDefault();
 		setButtonLoading(true);
-		const action = await dispatch(deletePageSpeed({ authToken, monitor }));
+		const action = await dispatch(deletePageSpeed({ monitor }));
 		if (action.meta.requestStatus === "fulfilled") {
 			navigate("/pagespeed");
 		} else {

--- a/src/Pages/PageSpeed/Create/index.jsx
+++ b/src/Pages/PageSpeed/Create/index.jsx
@@ -54,7 +54,7 @@ const CreatePageSpeed = () => {
 
 	const [https, setHttps] = useState(true);
 	const [errors, setErrors] = useState({});
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 	const { isLoading } = useSelector((state) => state.pageSpeedMonitors);
 
 	// Setup
@@ -87,7 +87,7 @@ const CreatePageSpeed = () => {
 		}
 
 		const checkEndpointAction = await dispatch(
-			checkEndpointResolution({ authToken, monitorURL: form.url })
+			checkEndpointResolution({ monitorURL: form.url })
 		);
 
 		if (checkEndpointAction.meta.requestStatus === "rejected") {
@@ -106,7 +106,7 @@ const CreatePageSpeed = () => {
 			notifications: monitor.notifications,
 		};
 
-		const action = await dispatch(createPageSpeed({ authToken, monitor: form }));
+		const action = await dispatch(createPageSpeed({ monitor: form }));
 		if (action.meta.requestStatus === "fulfilled") {
 			createToast({ body: "Monitor created successfully!" });
 			navigate("/pagespeed");

--- a/src/Pages/PageSpeed/Details/Hooks/useMonitorFetch.jsx
+++ b/src/Pages/PageSpeed/Details/Hooks/useMonitorFetch.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { networkService } from "../../../../main";
 import { createToast } from "../../../../Utils/toastUtils";
 import { useNavigate } from "react-router-dom";
-const useMonitorFetch = ({ authToken, monitorId }) => {
+const useMonitorFetch = ({ monitorId }) => {
 	const navigate = useNavigate();
 
 	const [monitor, setMonitor] = useState(undefined);
@@ -13,7 +13,6 @@ const useMonitorFetch = ({ authToken, monitorId }) => {
 		const fetchMonitor = async () => {
 			try {
 				const res = await networkService.getStatsByMonitorId({
-					authToken: authToken,
 					monitorId: monitorId,
 					sortOrder: "desc",
 					limit: 50,
@@ -32,7 +31,7 @@ const useMonitorFetch = ({ authToken, monitorId }) => {
 		};
 
 		fetchMonitor();
-	}, [authToken, monitorId, navigate]);
+	}, [monitorId, navigate]);
 
 	return { monitor, audits, isLoading };
 };

--- a/src/Pages/PageSpeed/Details/index.jsx
+++ b/src/Pages/PageSpeed/Details/index.jsx
@@ -25,10 +25,8 @@ const PageSpeedDetails = () => {
 	const theme = useTheme();
 	const isAdmin = useIsAdmin();
 	const { monitorId } = useParams();
-	const { authToken } = useSelector((state) => state.auth);
 
 	const { monitor, audits, isLoading, networkError } = useMonitorFetch({
-		authToken,
 		monitorId,
 	});
 

--- a/src/Pages/PageSpeed/Monitors/Hooks/useMonitorsFetch.jsx
+++ b/src/Pages/PageSpeed/Monitors/Hooks/useMonitorsFetch.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { networkService } from "../../../../main";
 import { createToast } from "../../../../Utils/toastUtils";
 
-const useMonitorsFetch = ({ authToken, teamId }) => {
+const useMonitorsFetch = ({ teamId }) => {
 	const [isLoading, setIsLoading] = useState(true);
 	const [monitors, setMonitors] = useState([]);
 	const [summary, setSummary] = useState({});
@@ -13,7 +13,6 @@ const useMonitorsFetch = ({ authToken, teamId }) => {
 			try {
 				setIsLoading(true);
 				const res = await networkService.getMonitorsByTeamId({
-					authToken: authToken,
 					teamId: teamId,
 					limit: 10,
 					types: ["pagespeed"],
@@ -38,7 +37,7 @@ const useMonitorsFetch = ({ authToken, teamId }) => {
 		};
 
 		fetchMonitors();
-	}, [authToken, teamId]);
+	}, [teamId]);
 	return { isLoading, monitors, summary, networkError };
 };
 

--- a/src/Pages/PageSpeed/Monitors/index.jsx
+++ b/src/Pages/PageSpeed/Monitors/index.jsx
@@ -19,10 +19,9 @@ const BREADCRUMBS = [{ name: `pagespeed`, path: "/pagespeed" }];
 const PageSpeed = () => {
 	const theme = useTheme();
 	const isAdmin = useIsAdmin();
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	const { isLoading, monitors, summary, networkError } = useMonitorsFetch({
-		authToken: authToken,
 		teamId: user.teamId,
 	});
 

--- a/src/Pages/Settings/index.jsx
+++ b/src/Pages/Settings/index.jsx
@@ -39,7 +39,7 @@ const SECONDS_PER_DAY = 86400;
 const Settings = () => {
 	const theme = useTheme();
 	const isAdmin = useIsAdmin();
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 	const { checkTTL } = user;
 	const { isLoading } = useSelector((state) => state.uptimeMonitors);
 	const { isLoading: authIsLoading } = useSelector((state) => state.auth);
@@ -115,11 +115,10 @@ const Settings = () => {
 		try {
 			setChecksIsLoading(true);
 			await networkService.updateChecksTTL({
-				authToken: authToken,
 				ttl: form.ttl,
 			});
 			const updatedUser = { ...user, checkTTL: form.ttl };
-			const action = await dispatch(update({ authToken, localData: updatedUser }));
+			const action = await dispatch(update({ localData: updatedUser }));
 
 			if (action.payload.success) {
 				createToast({
@@ -149,7 +148,7 @@ const Settings = () => {
 	const handleClearStats = async () => {
 		try {
 			const action = await dispatch(
-				deleteMonitorChecksByTeamId({ teamId: user.teamId, authToken })
+				deleteMonitorChecksByTeamId({ teamId: user.teamId })
 			);
 
 			if (deleteMonitorChecksByTeamId.fulfilled.match(action)) {
@@ -167,7 +166,7 @@ const Settings = () => {
 
 	const handleInsertDemoMonitors = async () => {
 		try {
-			const action = await dispatch(addDemoMonitors({ authToken }));
+			const action = await dispatch(addDemoMonitors());
 			if (addDemoMonitors.fulfilled.match(action)) {
 				createToast({ body: "Successfully added demo monitors" });
 			} else {
@@ -181,7 +180,7 @@ const Settings = () => {
 
 	const handleDeleteAllMonitors = async () => {
 		try {
-			const action = await dispatch(deleteAllMonitors({ authToken }));
+			const action = await dispatch(deleteAllMonitors());
 			if (deleteAllMonitors.fulfilled.match(action)) {
 				createToast({ body: "Successfully deleted all monitors" });
 			} else {

--- a/src/Pages/StatusPage/Create/Hooks/useCreateStatusPage.jsx
+++ b/src/Pages/StatusPage/Create/Hooks/useCreateStatusPage.jsx
@@ -4,14 +4,14 @@ import { useSelector } from "react-redux";
 import { createToast } from "../../../../Utils/toastUtils";
 
 const useCreateStatusPage = (isCreate, url) => {
-	const { authToken, user } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	const [isLoading, setIsLoading] = useState(false);
 	const [networkError, setNetworkError] = useState(false);
 	const createStatusPage = async ({ form }) => {
 		setIsLoading(true);
 		try {
-			await networkService.createStatusPage({ authToken, user, form, isCreate, url });
+			await networkService.createStatusPage({ user, form, isCreate, url });
 			return true;
 		} catch (error) {
 			setNetworkError(true);

--- a/src/Pages/StatusPage/Create/Hooks/useMonitorsFetch.jsx
+++ b/src/Pages/StatusPage/Create/Hooks/useMonitorsFetch.jsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { createToast } from "../../../../Utils/toastUtils";
 
 const useMonitorsFetch = () => {
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	const [monitors, setMonitors] = useState(undefined);
 	const [isLoading, setIsLoading] = useState(true);
@@ -13,7 +13,6 @@ const useMonitorsFetch = () => {
 		const fetchMonitors = async () => {
 			try {
 				const response = await networkService.getMonitorsByTeamId({
-					authToken: authToken,
 					teamId: user.teamId,
 					limit: null, // donot return any checks for the monitors
 					types: ["http"], // status page is available only for the uptime type
@@ -27,7 +26,7 @@ const useMonitorsFetch = () => {
 			}
 		};
 		fetchMonitors();
-	}, [authToken, user]);
+	}, [user]);
 
 	return [monitors, isLoading, networkError];
 };

--- a/src/Pages/StatusPage/Status/Hooks/useStatusPageDelete.jsx
+++ b/src/Pages/StatusPage/Status/Hooks/useStatusPageDelete.jsx
@@ -5,11 +5,10 @@ import { createToast } from "../../../../Utils/toastUtils";
 
 const useStatusPageDelete = (fetchStatusPage, url) => {
 	const [isLoading, setIsLoading] = useState(false);
-	const { authToken } = useSelector((state) => state.auth);
 	const deleteStatusPage = async () => {
 		try {
 			setIsLoading(true);
-			await networkService.deleteStatusPage({ authToken, url });
+			await networkService.deleteStatusPage({ url });
 			fetchStatusPage?.();
 			return true;
 		} catch (error) {

--- a/src/Pages/StatusPage/Status/Hooks/useStatusPageFetch.jsx
+++ b/src/Pages/StatusPage/Status/Hooks/useStatusPageFetch.jsx
@@ -10,13 +10,11 @@ const useStatusPageFetch = (isCreate = false, url) => {
 	const [networkError, setNetworkError] = useState(false);
 	const [statusPage, setStatusPage] = useState(undefined);
 	const [monitors, setMonitors] = useState(undefined);
-	const { authToken } = useSelector((state) => state.auth);
 	const theme = useTheme();
 	const { getMonitorWithPercentage } = useMonitorUtils();
 	const fetchStatusPage = useCallback(async () => {
 		try {
 			const response = await networkService.getStatusPageByUrl({
-				authToken,
 				url,
 				type: "uptime",
 			});
@@ -40,7 +38,7 @@ const useStatusPageFetch = (isCreate = false, url) => {
 		} finally {
 			setIsLoading(false);
 		}
-	}, [authToken, theme, getMonitorWithPercentage, url]);
+	}, [theme, getMonitorWithPercentage, url]);
 
 	useEffect(() => {
 		if (isCreate === true) {

--- a/src/Pages/StatusPage/StatusPages/Hooks/useStatusPagesFetch.jsx
+++ b/src/Pages/StatusPage/StatusPages/Hooks/useStatusPagesFetch.jsx
@@ -4,7 +4,7 @@ import { useSelector } from "react-redux";
 import { createToast } from "../../../../Utils/toastUtils";
 
 const useStatusPagesFetch = () => {
-	const { authToken, user } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 
 	const [isLoading, setIsLoading] = useState(true);
 	const [networkError, setNetworkError] = useState(false);
@@ -14,7 +14,6 @@ const useStatusPagesFetch = () => {
 		const fetchStatusPages = async () => {
 			try {
 				const res = await networkService.getStatusPagesByTeamId({
-					authToken,
 					teamId: user.teamId,
 				});
 				setStatusPages(res?.data?.data);
@@ -28,7 +27,7 @@ const useStatusPagesFetch = () => {
 			}
 		};
 		fetchStatusPages();
-	}, [authToken, user]);
+	}, [user]);
 	return [isLoading, networkError, statusPages];
 };
 

--- a/src/Pages/Uptime/Configure/index.jsx
+++ b/src/Pages/Uptime/Configure/index.jsx
@@ -48,7 +48,7 @@ const Configure = () => {
 	const navigate = useNavigate();
 	const theme = useTheme();
 	const dispatch = useDispatch();
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 	const { isLoading } = useSelector((state) => state.uptimeMonitors);
 	const [monitor, setMonitor] = useState({});
 	const [errors, setErrors] = useState({});
@@ -76,7 +76,7 @@ const Configure = () => {
 	useEffect(() => {
 		const fetchMonitor = async () => {
 			try {
-				const action = await dispatch(getUptimeMonitorById({ authToken, monitorId }));
+				const action = await dispatch(getUptimeMonitorById({ monitorId }));
 
 				if (getUptimeMonitorById.fulfilled.match(action)) {
 					const monitor = action.payload.data;
@@ -90,7 +90,7 @@ const Configure = () => {
 			}
 		};
 		fetchMonitor();
-	}, [monitorId, authToken, navigate]);
+	}, [monitorId, navigate]);
 
 	const handleChange = (event, name) => {
 		let { value, id } = event.target;
@@ -147,7 +147,7 @@ const Configure = () => {
 
 	const handlePause = async () => {
 		try {
-			const action = await dispatch(pauseUptimeMonitor({ authToken, monitorId }));
+			const action = await dispatch(pauseUptimeMonitor({ monitorId }));
 			if (pauseUptimeMonitor.fulfilled.match(action)) {
 				const monitor = action.payload.data;
 				setMonitor(monitor);
@@ -164,7 +164,7 @@ const Configure = () => {
 
 	const handleSubmit = async (event) => {
 		event.preventDefault();
-		const action = await dispatch(updateUptimeMonitor({ authToken, monitor: monitor }));
+		const action = await dispatch(updateUptimeMonitor({ monitor: monitor }));
 		if (action.meta.requestStatus === "fulfilled") {
 			createToast({ body: "Monitor updated successfully!" });
 		} else {
@@ -175,7 +175,7 @@ const Configure = () => {
 	const [isOpen, setIsOpen] = useState(false);
 	const handleRemove = async (event) => {
 		event.preventDefault();
-		const action = await dispatch(deleteUptimeMonitor({ authToken, monitor }));
+		const action = await dispatch(deleteUptimeMonitor({ monitor }));
 		if (action.meta.requestStatus === "fulfilled") {
 			navigate("/uptime");
 		} else {

--- a/src/Pages/Uptime/Create/index.jsx
+++ b/src/Pages/Uptime/Create/index.jsx
@@ -68,7 +68,7 @@ const CreateMonitor = () => {
 		},
 	};
 
-	const { user, authToken } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 	const { isLoading } = useSelector((state) => state.uptimeMonitors);
 	const dispatch = useDispatch();
 	const navigate = useNavigate();
@@ -126,7 +126,7 @@ const CreateMonitor = () => {
 
 		if (monitor.type === "http") {
 			// const checkEndpointAction = await dispatch(
-			// 	checkEndpointResolution({ authToken, monitorURL: form.url })
+			// 	checkEndpointResolution({ monitorURL: form.url })
 			// );
 			// if (checkEndpointAction.meta.requestStatus === "rejected") {
 			// 	createToast({
@@ -144,7 +144,7 @@ const CreateMonitor = () => {
 			userId: user._id,
 			notifications: monitor.notifications,
 		};
-		const action = await dispatch(createUptimeMonitor({ authToken, monitor: form }));
+		const action = await dispatch(createUptimeMonitor({ monitor: form }));
 		if (action.meta.requestStatus === "fulfilled") {
 			createToast({ body: "Monitor created successfully!" });
 			navigate("/uptime");
@@ -205,7 +205,7 @@ const CreateMonitor = () => {
 	useEffect(() => {
 		const fetchMonitor = async () => {
 			if (monitorId) {
-				const action = await dispatch(getUptimeMonitorById({ authToken, monitorId }));
+				const action = await dispatch(getUptimeMonitorById({ monitorId }));
 
 				if (action.payload.success) {
 					const data = action.payload.data;
@@ -228,7 +228,7 @@ const CreateMonitor = () => {
 			}
 		};
 		fetchMonitor();
-	}, [monitorId, authToken, dispatch, navigate]);
+	}, [monitorId, dispatch, navigate]);
 
 	return (
 		<Box className="create-monitor">

--- a/src/Pages/Uptime/Details/Hooks/useCertificateFetch.jsx
+++ b/src/Pages/Uptime/Details/Hooks/useCertificateFetch.jsx
@@ -5,7 +5,6 @@ import { formatDateWithTz } from "../../../../Utils/timeUtils";
 
 const useCertificateFetch = ({
 	monitor,
-	authToken,
 	monitorId,
 	certificateDateFormat,
 	uiTimezone,
@@ -22,7 +21,6 @@ const useCertificateFetch = ({
 			try {
 				setIsLoading(true);
 				const res = await networkService.getCertificateExpiry({
-					authToken: authToken,
 					monitorId: monitorId,
 				});
 				if (res?.data?.data?.certificateDate) {
@@ -39,7 +37,7 @@ const useCertificateFetch = ({
 			}
 		};
 		fetchCertificate();
-	}, [authToken, monitorId, certificateDateFormat, uiTimezone, monitor]);
+	}, [monitorId, certificateDateFormat, uiTimezone, monitor]);
 	return [certificateExpiry, isLoading];
 };
 

--- a/src/Pages/Uptime/Details/Hooks/useChecksFetch.jsx
+++ b/src/Pages/Uptime/Details/Hooks/useChecksFetch.jsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { networkService } from "../../../../main";
 import { createToast } from "../../../../Utils/toastUtils";
 export const useChecksFetch = ({
-	authToken,
 	monitorId,
 	dateRange,
 	page,
@@ -19,7 +18,6 @@ export const useChecksFetch = ({
 			try {
 				setIsLoading(true);
 				const res = await networkService.getChecksByMonitor({
-					authToken: authToken,
 					monitorId: monitorId,
 					sortOrder: "desc",
 					limit: null,
@@ -38,7 +36,7 @@ export const useChecksFetch = ({
 			}
 		};
 		fetchChecks();
-	}, [authToken, monitorId, dateRange, page, rowsPerPage]);
+	}, [monitorId, dateRange, page, rowsPerPage]);
 
 	return [checks, checksCount, isLoading, networkError];
 };

--- a/src/Pages/Uptime/Details/Hooks/useMonitorFetch.jsx
+++ b/src/Pages/Uptime/Details/Hooks/useMonitorFetch.jsx
@@ -3,7 +3,7 @@ import { networkService } from "../../../../main";
 import { useNavigate } from "react-router-dom";
 import { createToast } from "../../../../Utils/toastUtils";
 
-export const useMonitorFetch = ({ authToken, monitorId, dateRange }) => {
+export const useMonitorFetch = ({ monitorId, dateRange }) => {
 	const [networkError, setNetworkError] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
 	const [monitor, setMonitor] = useState(undefined);
@@ -13,7 +13,6 @@ export const useMonitorFetch = ({ authToken, monitorId, dateRange }) => {
 		const fetchMonitors = async () => {
 			try {
 				const res = await networkService.getUptimeDetailsById({
-					authToken: authToken,
 					monitorId: monitorId,
 					dateRange: dateRange,
 					normalize: true,
@@ -27,7 +26,7 @@ export const useMonitorFetch = ({ authToken, monitorId, dateRange }) => {
 			}
 		};
 		fetchMonitors();
-	}, [authToken, dateRange, monitorId, navigate]);
+	}, [dateRange, monitorId, navigate]);
 	return [monitor, isLoading, networkError];
 };
 

--- a/src/Pages/Uptime/Details/index.jsx
+++ b/src/Pages/Uptime/Details/index.jsx
@@ -31,7 +31,6 @@ const certificateDateFormat = "MMM D, YYYY h A";
 
 const UptimeDetails = () => {
 	// Redux state
-	const { authToken } = useSelector((state) => state.auth);
 	const uiTimezone = useSelector((state) => state.ui.timezone);
 
 	// Local state
@@ -48,21 +47,18 @@ const UptimeDetails = () => {
 	const isAdmin = useIsAdmin();
 
 	const [monitor, monitorIsLoading, monitorNetworkError] = useMonitorFetch({
-		authToken,
 		monitorId,
 		dateRange,
 	});
 
 	const [certificateExpiry, certificateIsLoading] = useCertificateFetch({
 		monitor,
-		authToken,
 		monitorId,
 		certificateDateFormat,
 		uiTimezone,
 	});
 
 	const [checks, checksCount, checksAreLoading, checksNetworkError] = useChecksFetch({
-		authToken,
 		monitorId,
 		dateRange,
 		page,

--- a/src/Pages/Uptime/Monitors/Hooks/useMonitorsFetch.jsx
+++ b/src/Pages/Uptime/Monitors/Hooks/useMonitorsFetch.jsx
@@ -5,7 +5,6 @@ import { useTheme } from "@emotion/react";
 import { useMonitorUtils } from "../../../../Hooks/useMonitorUtils";
 
 export const useMonitorFetch = ({
-	authToken,
 	teamId,
 	limit,
 	page,
@@ -28,7 +27,6 @@ export const useMonitorFetch = ({
 			try {
 				setMonitorsAreLoading(true);
 				const res = await networkService.getMonitorsByTeamId({
-					authToken,
 					teamId,
 					limit,
 					types: ["http", "ping", "docker", "port"],
@@ -56,7 +54,6 @@ export const useMonitorFetch = ({
 		};
 		fetchMonitors();
 	}, [
-		authToken,
 		teamId,
 		limit,
 		field,

--- a/src/Pages/Uptime/Monitors/index.jsx
+++ b/src/Pages/Uptime/Monitors/index.jsx
@@ -54,7 +54,7 @@ CreateMonitorButton.propTypes = {
 
 const UptimeMonitors = () => {
 	// Redux state
-	const { authToken, user } = useSelector((state) => state.auth);
+	const { user } = useSelector((state) => state.auth);
 	const rowsPerPage = useSelector((state) => state.ui.monitors.rowsPerPage);
 
 	// Local state
@@ -96,7 +96,6 @@ const UptimeMonitors = () => {
 		monitorsSummary,
 		networkError,
 	} = useMonitorsFetch({
-		authToken,
 		teamId,
 		limit: 25,
 		page: page,

--- a/src/Utils/NetworkService.js
+++ b/src/Utils/NetworkService.js
@@ -75,7 +75,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.monitorId - The monitor ID to be sent in the param.
 	 * @returns {Promise<AxiosResponse>} The response from the axios GET request.
 	 */
@@ -83,7 +82,6 @@ class NetworkService {
 	async getMonitorById(config) {
 		return this.axiosInstance.get(`/monitors/${config.monitorId}`, {
 			headers: {
-				Authorization: `Bearer ${config.authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -97,19 +95,13 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {Object} config.monitor - The monitor object to be sent in the request body.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
 	 */
 	async createMonitor(config) {
-		const { authToken, monitor } = config;
+		const { monitor } = config;
 
-		return this.axiosInstance.post(`/monitors`, monitor, {
-			headers: {
-				Authorization: `Bearer ${authToken}`,
-				"Content-Type": "application/json",
-			},
-		});
+		return this.axiosInstance.post(`/monitors`, monitor);
 	}
 
 	/**
@@ -120,19 +112,17 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {Object} config.monitorURL - The monitor url to be sent in the request body.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
 	 */
 	async checkEndpointResolution(config) {
-		const { authToken, monitorURL } = config;
+		const { monitorURL } = config;
 		const params = new URLSearchParams();
 
 		if (monitorURL) params.append("monitorURL", monitorURL);
 
 		return this.axiosInstance.get(`/monitors/resolution/url?${params.toString()}`, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -146,7 +136,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.teamId - Team ID
 	 * @param {Array<string>} config.types - Array of monitor types
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
@@ -163,7 +152,6 @@ class NetworkService {
 			`/monitors/team/summary/${config.teamId}?${params.toString()}`,
 			{
 				headers: {
-					Authorization: `Bearer ${config.authToken}`,
 					"Content-Type": "application/json",
 				},
 			}
@@ -177,7 +165,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.teamId - The ID of the team whose monitors are to be retrieved.
 	 * @param {number} [config.limit] - The maximum number of checks to retrieve.  0 for all, -1 for none
 	 * @param {Array<string>} [config.types] - The types of monitors to retrieve.
@@ -190,7 +177,7 @@ class NetworkService {
 	 */
 
 	async getMonitorsByTeamId(config) {
-		const { authToken, teamId, limit, types, page, rowsPerPage, filter, field, order } =
+		const { teamId, limit, types, page, rowsPerPage, filter, field, order } =
 			config;
 		const params = new URLSearchParams();
 
@@ -208,7 +195,6 @@ class NetworkService {
 
 		return this.axiosInstance.get(`/monitors/team/${teamId}?${params.toString()}`, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -221,7 +207,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.monitorId - The ID of the monitor whose statistics are to be retrieved.
 	 * @param {string} config.sortOrder - The order in which to sort the retrieved statistics.
 	 * @param {number} config.limit - The maximum number of statistics to retrieve.
@@ -239,13 +224,7 @@ class NetworkService {
 		if (config.normalize) params.append("normalize", config.normalize);
 
 		return this.axiosInstance.get(
-			`/monitors/stats/${config.monitorId}?${params.toString()}`,
-			{
-				headers: {
-					Authorization: `Bearer ${config.authToken}`,
-				},
-			}
-		);
+			`/monitors/stats/${config.monitorId}?${params.toString()}`);
 	}
 
 	async getHardwareDetailsByMonitorId(config) {
@@ -253,13 +232,7 @@ class NetworkService {
 		if (config.dateRange) params.append("dateRange", config.dateRange);
 
 		return this.axiosInstance.get(
-			`/monitors/hardware/details/${config.monitorId}?${params.toString()}`,
-			{
-				headers: {
-					Authorization: `Bearer ${config.authToken}`,
-				},
-			}
-		);
+			`/monitors/hardware/details/${config.monitorId}?${params.toString()}`);
 	}
 	async getUptimeDetailsById(config) {
 		const params = new URLSearchParams();
@@ -267,13 +240,7 @@ class NetworkService {
 		if (config.normalize) params.append("normalize", config.normalize);
 
 		return this.axiosInstance.get(
-			`/monitors/uptime/details/${config.monitorId}?${params.toString()}`,
-			{
-				headers: {
-					Authorization: `Bearer ${config.authToken}`,
-				},
-			}
-		);
+			`/monitors/uptime/details/${config.monitorId}?${params.toString()}`);
 	}
 
 	/**
@@ -283,13 +250,12 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.monitorId - The ID of the monitor to be updated.
 	 * @param {Object} config.updatedFields - The fields to be updated for the monitor.
 	 * @returns {Promise<AxiosResponse>} The response from the axios PUT request.
 	 */
 	async updateMonitor(config) {
-		const { authToken, monitorId, monitor } = config;
+		const { monitorId, monitor } = config;
 		const updatedFields = {
 			name: monitor.name,
 			description: monitor.description,
@@ -298,7 +264,6 @@ class NetworkService {
 		};
 		return this.axiosInstance.put(`/monitors/${monitorId}`, updatedFields, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -311,14 +276,12 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.monitorId - The ID of the monitor to be deleted.
 	 * @returns {Promise<AxiosResponse>} The response from the axios DELETE request.
 	 */
 	async deleteMonitorById(config) {
 		return this.axiosInstance.delete(`/monitors/${config.monitorId}`, {
 			headers: {
-				Authorization: `Bearer ${config.authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -331,14 +294,12 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.teamId - The team ID of the monitors to be deleted.
 	 * @returns {Promise<AxiosResponse>} The response from the axios DELETE request.
 	 */
 	async deleteChecksByTeamId(config) {
 		return this.axiosInstance.delete(`/checks/team/${config.teamId}`, {
 			headers: {
-				Authorization: `Bearer ${config.authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -350,7 +311,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.monitorId - The ID of the monitor to be paused.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
 	 */
@@ -360,7 +320,6 @@ class NetworkService {
 			{},
 			{
 				headers: {
-					Authorization: `Bearer ${config.authToken}`,
 					"Content-Type": "application/json",
 				},
 			}
@@ -374,7 +333,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
 	 */
 	async addDemoMonitors(config) {
@@ -383,7 +341,6 @@ class NetworkService {
 			{},
 			{
 				headers: {
-					Authorization: `Bearer ${config.authToken}`,
 					"Content-Type": "application/json",
 				},
 			}
@@ -397,13 +354,11 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @returns {Promise<AxiosResponse>} The response from the axios DELETE request.
 	 */
 	async deleteAllMonitors(config) {
 		return this.axiosInstance.delete(`/monitors/`, {
 			headers: {
-				Authorization: `Bearer ${config.authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -416,17 +371,12 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.monitorId - The ID of the monitor whose certificate expiry is to be retrieved.
 	 * @returns {Promise<AxiosResponse>} The response from the axios GET request.
 	 *
 	 */
 	async getCertificateExpiry(config) {
-		return this.axiosInstance.get(`/monitors/certificate/${config.monitorId}`, {
-			headers: {
-				Authorization: `Bearer ${config.authToken}`,
-			},
-		});
+		return this.axiosInstance.get(`/monitors/certificate/${config.monitorId}`);
 	}
 
 	/**
@@ -463,18 +413,13 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.userId - The ID of the user to be updated.
 	 * @param {Object} config.form - The form data for the user to be updated.
 	 * @returns {Promise<AxiosResponse>} The response from the axios PUT request.
 	 *
 	 */
 	async updateUser(config) {
-		return this.axiosInstance.put(`/auth/user/${config.userId}`, config.form, {
-			headers: {
-				Authorization: `Bearer ${config.authToken}`,
-			},
-		});
+		return this.axiosInstance.put(`/auth/user/${config.userId}`, config.form);
 	}
 
 	/**
@@ -484,14 +429,11 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.userId - The ID of the user to be deleted.
 	 *
 	 **/
 	async deleteUser(config) {
-		return this.axiosInstance.delete(`/auth/user/${config.userId}`, {
-			headers: { Authorization: `Bearer ${config.authToken}` },
-		});
+		return this.axiosInstance.delete(`/auth/user/${config.userId}`);
 	}
 
 	/**
@@ -564,14 +506,11 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @returns {Promise<AxiosResponse>} The response from the axios GET request.
 	 *
 	 */
 	async getAllUsers(config) {
-		return this.axiosInstance.get("/auth/users", {
-			headers: { Authorization: `Bearer ${config.authToken}` },
-		});
+		return this.axiosInstance.get("/auth/users");
 	}
 
 	/**
@@ -581,7 +520,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.email - The email of the user to be invited.
 	 * @param {string} config.role - The role of the user to be invited.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
@@ -591,9 +529,6 @@ class NetworkService {
 		return this.axiosInstance.post(
 			`/invite`,
 			{ email: config.email, role: config.role },
-			{
-				headers: { Authorization: `Bearer ${config.authToken}` },
-			}
 		);
 	}
 
@@ -620,7 +555,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.monitorId - The ID of the monitor.
 	 * @param {string} config.sortOrder - The order in which to sort the checks.
 	 * @param {number} config.limit - The maximum number of checks to retrieve.
@@ -642,9 +576,7 @@ class NetworkService {
 		if (config.rowsPerPage) params.append("rowsPerPage", config.rowsPerPage);
 		if (config.status !== undefined) params.append("status", config.status);
 
-		return this.axiosInstance.get(`/checks/${config.monitorId}?${params.toString()}`, {
-			headers: { Authorization: `Bearer ${config.authToken}` },
-		});
+		return this.axiosInstance.get(`/checks/${config.monitorId}?${params.toString()}`);
 	}
 
 	/**
@@ -654,7 +586,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} config.userId - The ID of the user.
 	 * @param {string} config.sortOrder - The order in which to sort the checks.
 	 * @param {number} config.limit - The maximum number of checks to retrieve.
@@ -674,9 +605,7 @@ class NetworkService {
 		if (config.page) params.append("page", config.page);
 		if (config.rowsPerPage) params.append("rowsPerPage", config.rowsPerPage);
 		if (config.status !== undefined) params.append("status", config.status);
-		return this.axiosInstance.get(`/checks/team/${config.teamId}?${params.toString()}`, {
-			headers: { Authorization: `Bearer ${config.authToken}` },
-		});
+		return this.axiosInstance.get(`/checks/team/${config.teamId}?${params.toString()}`);
 	}
 
 	/**
@@ -686,7 +615,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {number} config.ttl - TTL for checks
 	 * @returns {Promise<AxiosResponse>} The response from the axios GET request.
 	 *
@@ -697,7 +625,6 @@ class NetworkService {
 			{ ttl: config.ttl },
 			{
 				headers: {
-					Authorization: `Bearer ${config.authToken}`,
 					"Content-Type": "application/json",
 				},
 			}
@@ -711,7 +638,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @returns {Promise<AxiosResponse>} The response from the axios GET request.
 	 *
 	 */
@@ -719,7 +645,6 @@ class NetworkService {
 	async getAppSettings(config) {
 		return this.axiosInstance.get("/settings", {
 			headers: {
-				Authorization: `Bearer ${config.authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -733,14 +658,12 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {Object} config.settings - The monitor object to be sent in the request body.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
 	 */
 	async updateAppSettings(config) {
 		return this.axiosInstance.put(`/settings`, config.settings, {
 			headers: {
-				Authorization: `Bearer ${config.authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -753,7 +676,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {Object} config.maintenanceWindow - The maintenance window object to be sent in the request body.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
 	 *
@@ -762,7 +684,6 @@ class NetworkService {
 	async createMaintenanceWindow(config) {
 		return this.axiosInstance.post(`/maintenance-window`, config.maintenanceWindow, {
 			headers: {
-				Authorization: `Bearer ${config.authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -775,7 +696,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {Object} config.maintenanceWindowId - The maintenance window id.
 	 * @param {Object} config.maintenanceWindow - The maintenance window object to be sent in the request body.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
@@ -788,7 +708,6 @@ class NetworkService {
 			config.maintenanceWindow,
 			{
 				headers: {
-					Authorization: `Bearer ${config.authToken}`,
 					"Content-Type": "application/json",
 				},
 			}
@@ -802,17 +721,15 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} [config.maintenanceWindowId] - The id of the maintenance window to delete.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
 	 *
 	 */
 
 	async getMaintenanceWindowById(config) {
-		const { authToken, maintenanceWindowId } = config;
+		const { maintenanceWindowId } = config;
 		return this.axiosInstance.get(`/maintenance-window/${maintenanceWindowId}`, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -825,7 +742,6 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} [config.active] - The status of the maintenance windows to retrieve.
 	 * @param {number} [config.page] - The page number for pagination.
 	 * @param {number} [config.rowsPerPage] - The number of rows per page for pagination.
@@ -836,7 +752,7 @@ class NetworkService {
 	 */
 
 	async getMaintenanceWindowsByTeamId(config) {
-		const { authToken, active, page, rowsPerPage, field, order } = config;
+		const { active, page, rowsPerPage, field, order } = config;
 		const params = new URLSearchParams();
 
 		if (active) params.append("status", active);
@@ -847,7 +763,6 @@ class NetworkService {
 
 		return this.axiosInstance.get(`/maintenance-window/team?${params.toString()}`, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -859,17 +774,15 @@ class NetworkService {
 	 *
 	 * @async
 	 * @param {Object} config - The configuration object.
-	 * @param {string} config.authToken - The authorization token to be used in the request header.
 	 * @param {string} [config.maintenanceWindowId] - The id of the maintenance window to delete.
 	 * @returns {Promise<AxiosResponse>} The response from the axios POST request.
 	 *
 	 */
 
 	async deleteMaintenanceWindow(config) {
-		const { authToken, maintenanceWindowId } = config;
+		const { maintenanceWindowId } = config;
 		return this.axiosInstance.delete(`/maintenance-window/${maintenanceWindowId}`, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
@@ -892,7 +805,6 @@ class NetworkService {
 
 	subscribeToDistributedUptimeMonitors(config) {
 		const {
-			authToken,
 			teamId,
 			onUpdate,
 			onError,
@@ -925,15 +837,13 @@ class NetworkService {
 		}
 
 		const url = `${this.axiosInstance.defaults.baseURL}/distributed-uptime/monitors/${teamId}?${params.toString()}`;
-		this.eventSource = new EventSource(url, {
-			headers: { Authorization: `Bearer ${authToken}` },
-		});
+		this.eventSource = new EventSource(url);
 
 		this.eventSource.onopen = () => {
 			onOpen?.();
 		};
 
-		this.eventSource.addEventListener("open", (e) => {});
+		this.eventSource.addEventListener("open", (e) => { });
 
 		this.eventSource.onmessage = (event) => {
 			const data = JSON.parse(event.data);
@@ -960,15 +870,13 @@ class NetworkService {
 
 	subscribeToDistributedUptimeDetails(config) {
 		const params = new URLSearchParams();
-		const { authToken, monitorId, onUpdate, onOpen, onError, dateRange, normalize } =
+		const { monitorId, onUpdate, onOpen, onError, dateRange, normalize } =
 			config;
 		if (dateRange) params.append("dateRange", dateRange);
 		if (normalize) params.append("normalize", normalize);
 
 		const url = `${this.axiosInstance.defaults.baseURL}/distributed-uptime/monitors/details/${monitorId}?${params.toString()}`;
-		this.eventSource = new EventSource(url, {
-			headers: { Authorization: `Bearer ${authToken}` },
-		});
+		this.eventSource = new EventSource(url);
 
 		this.eventSource.onopen = (e) => {
 			onOpen?.();
@@ -992,41 +900,37 @@ class NetworkService {
 		};
 	}
 
-	async getStatusPage(config) {
-		const { authToken } = config;
+	async getStatusPage() {
 		return this.axiosInstance.get(`/status-page`, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
 	}
 
 	async getStatusPageByUrl(config) {
-		const { authToken, url, type } = config;
+		const { url, type } = config;
 		const params = new URLSearchParams();
 		params.append("type", type);
 
 		return this.axiosInstance.get(`/status-page/${url}?${params.toString()}`, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
 	}
 
 	async getStatusPagesByTeamId(config) {
-		const { authToken, teamId } = config;
+		const { teamId } = config;
 		return this.axiosInstance.get(`/status-page/team/${teamId}`, {
 			headers: {
-				Authorization: `Bearer ${authToken}`,
 				"Content-Type": "application/json",
 			},
 		});
 	}
 
 	async createStatusPage(config) {
-		const { authToken, user, form, isCreate } = config;
+		const { user, form, isCreate } = config;
 
 		const fd = new FormData();
 		fd.append("teamId", user.teamId);
@@ -1055,29 +959,17 @@ class NetworkService {
 			}
 		}
 		if (isCreate) {
-			return this.axiosInstance.post(`/status-page`, fd, {
-				headers: {
-					Authorization: `Bearer ${authToken}`,
-				},
-			});
+			return this.axiosInstance.post(`/status-page`, fd);
 		}
 
-		return this.axiosInstance.put(`/status-page`, fd, {
-			headers: {
-				Authorization: `Bearer ${authToken}`,
-			},
-		});
+		return this.axiosInstance.put(`/status-page`, fd);
 	}
 
 	async deleteStatusPage(config) {
-		const { authToken, url } = config;
+		const { url } = config;
 		const encodedUrl = encodeURIComponent(url);
 
-		return this.axiosInstance.delete(`/status-page/${encodedUrl}`, {
-			headers: {
-				Authorization: `Bearer ${authToken}`,
-			},
-		});
+		return this.axiosInstance.delete(`/status-page/${encodedUrl}`);
 	}
 }
 

--- a/src/Utils/NetworkService.js
+++ b/src/Utils/NetworkService.js
@@ -28,9 +28,12 @@ class NetworkService {
 			(config) => {
 				const currentLanguage = i18next.language || "en";
 
+				const { authToken } = store.getState().auth;
+
 				config.headers = {
-					...config.headers,
+					Authorization: `Bearer ${authToken}`,
 					"Accept-Language": currentLanguage,
+					...config.headers,
 				};
 
 				return config;


### PR DESCRIPTION

## Describe your changes

Setting Authorization in axios interceptor instead of passing from UI component

- Read token from redux store and set Authorization header in axios request interceptor
- Remove authToken reading/passing in UI component, hooks, reducer thunks
- Remove setting Authorization in networkService api

### Why do this

- Reduce redundant code, eliminates manual Authorization header setting
- Removes prop-drilling across components, hooks, reducers and networkService
- Allows UI components to focus solely on rendering and business logic
- Improves maintainability: Adding refresh token functionality is now easier, as there's no need to modify code in multiple places.

## Issue number


## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [ ] (Do not skip this or your PR will be closed) I deployed the application locally.
- [ ] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have labelled the PR correctly.
- [ ] The issue I am working on is assigned to me.
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme.
- [ ] My PR is granular and targeted to one specific feature.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

