### PR TITLE
fix: add fixed max logo height to DePIN status page

### DIFF
--- a/src/Pages/StatusPage/Status/Components/ControlsHeader/index.jsx
+++ b/src/Pages/StatusPage/Status/Components/ControlsHeader/index.jsx
@@ -102,6 +102,7 @@ const ControlsHeader = ({
 					shouldRender={statusPage?.logo?.data ? true : false}
 					alt={"Company logo"}
 					maxWidth={"300px"}
+					maxHeight={"50px"}
 					base64={statusPage?.logo?.data}
 				/>
 				<Typography variant="h2">{statusPage?.companyName}</Typography>


### PR DESCRIPTION
This PR adds a fixed height of 50px to the DePIN logo