### PR TITLE
fix: infra monitor id

### DIFF
--- a/src/Pages/Infrastructure/Monitors/Components/MonitorsTable/index.jsx
+++ b/src/Pages/Infrastructure/Monitors/Components/MonitorsTable/index.jsx
@@ -126,7 +126,7 @@ const MonitorsTable = ({ shouldRender, monitors, isAdmin, handleActionMenuDelete
 						transition: "background-color .3s ease",
 					},
 				},
-				onRowClick: (row) => openDetails(row._id),
+				onRowClick: (row) => openDetails(row.id),
 			}}
 		/>
 	);


### PR DESCRIPTION
This PR fixes a reference in the Infra monitors page:

`_id` -> `id`

for correct ID access