### PR TITLE
Fix/discussion icon stroke width

### DIFF
--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -38,7 +38,7 @@ import ChangeLog from "../../assets/icons/changeLog.svg?react";
 import Docs from "../../assets/icons/docs.svg?react";
 import Folder from "../../assets/icons/folder.svg?react";
 import StatusPages from "../../assets/icons/status-pages.svg?react";
-import ChatBubbleOutlineRoundedIcon from "@mui/icons-material/ChatBubbleOutlineRounded";
+import Discussions from "../../assets/icons/discussions.svg?react";
 import DistributedUptimeIcon from "../../assets/icons/distributed-uptime.svg?react";
 import "./index.css";
 
@@ -86,7 +86,7 @@ const menu = [
 			{
 				name: "Discussions",
 				path: "discussions",
-				icon: <ChatBubbleOutlineRoundedIcon />,
+				icon: <Discussions />,
 			},
 			{ name: "Docs", path: "docs", icon: <Docs /> },
 			{ name: "Changelog", path: "changelog", icon: <ChangeLog /> },

--- a/src/assets/icons/discussions.svg
+++ b/src/assets/icons/discussions.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 13.9021 3.5901 15.6665 4.59721 17.1199C4.70168 17.2707 4.7226 17.4653 4.64529 17.6317L3.42556 20.2519C3.23082 20.6399 3.57262 21.0754 3.97992 20.9193L7.0988 19.7595C7.25727 19.7007 7.44031 19.7151 7.58838 19.7985C8.9427 20.5534 10.4987 21 12 21Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<svg width="24" height="24" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M11 20C15.9706 20 20 15.9706 20 11C20 6.02944 15.9706 2 11 2C6.02944 2 2 6.02944 2 11C2 12.9021 2.5901 14.6665 3.59721 16.1199C3.70168 16.2707 3.7226 16.4653 3.64529 16.6317L2.42556 19.2519C2.23082 19.6399 2.57262 20.0754 2.97992 19.9193L6.0988 18.7595C6.25727 18.7007 6.44031 18.7151 6.58838 18.7985C7.9427 19.5534 9.4987 20 11 20Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     <path d="M7 8.5H17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     <path d="M7 12.5H13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
     <path d="M7 16.5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/assets/icons/discussions.svg
+++ b/src/assets/icons/discussions.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 13.9021 3.5901 15.6665 4.59721 17.1199C4.70168 17.2707 4.7226 17.4653 4.64529 17.6317L3.42556 20.2519C3.23082 20.6399 3.57262 21.0754 3.97992 20.9193L7.0988 19.7595C7.25727 19.7007 7.44031 19.7151 7.58838 19.7985C8.9427 20.5534 10.4987 21 12 21Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7 8.5H17" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7 12.5H13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7 16.5H11" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Discussion icon stroke width

- replace Material-UI chat icon with custom SVG" --body "- Created custom discussions.svg icon with 1.5px stroke width
- Replaced ChatBubbleOutlineRoundedIcon with custom icon
- Ensures consistent styling with other sidebar icons


#1810

- [X] (Do not skip this or your PR will be closed) I deployed the application locally.
- [X] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [X] I have included the issue # in the PR.
- [X] I have labelled the PR correctly.
- [X] The issue I am working on is assigned to me.
- [X] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [X] I made sure font sizes, color choices etc are all referenced from the theme.
- [X] My PR is granular and targeted to one specific feature.
- [X] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="396" alt="Screenshot 2025-02-25 at 12 13 50 PM" src="https://github.com/user-attachments/assets/091dff9f-a147-41db-8e35-50d3c42b4088" />

