### PR TITLE
fix: breadcrumbs, resolves #1829

### DIFF
--- a/src/Pages/DistributedUptime/Create/index.jsx
+++ b/src/Pages/DistributedUptime/Create/index.jsx
@@ -42,8 +42,9 @@ const CreateDistributedUptime = () => {
 	const { monitorId } = useParams();
 	const isCreate = typeof monitorId === "undefined";
 
-	const BREADCRUMBS = [
+	let BREADCRUMBS = [
 		{ name: `distributed uptime`, path: "/distributed-uptime" },
+		...(isCreate ? [] : [{ name: "details", path: `/distributed-uptime/${monitorId}` }]),
 		{ name: isCreate ? "create" : "configure", path: `` },
 	];
 
@@ -182,7 +183,7 @@ const CreateDistributedUptime = () => {
 						component="span"
 						fontSize="inherit"
 					>
-						Create your{" "}
+						{isCreate ? "Create your" : "Edit your"}{" "}
 					</Typography>
 					<Typography
 						component="span"

--- a/src/Pages/DistributedUptimeStatus/Create/index.jsx
+++ b/src/Pages/DistributedUptimeStatus/Create/index.jsx
@@ -40,7 +40,10 @@ const CreateStatus = () => {
 
 	const BREADCRUMBS = [
 		{ name: "distributed uptime", path: "/distributed-uptime" },
-		{ name: "details", path: `/distributed-uptime/${monitorId}` },
+		{
+			name: "details",
+			path: `/distributed-uptime/${isCreate ? monitorId : statusPage?.monitors[0]}`,
+		},
 		{ name: isCreate ? "create status page" : "edit status page", path: `` },
 	];
 	// Local state
@@ -173,7 +176,7 @@ const CreateStatus = () => {
 					component="span"
 					fontSize="inherit"
 				>
-					Create your{" "}
+					{isCreate ? "Create your" : "Edit your"}{" "}
 				</Typography>
 				<Typography
 					component="span"


### PR DESCRIPTION
This PR fixes the issue presented in #1829

A variable was not updated after switching to a different hook.

Breadcrumbs are also updated to reflect proper location.