### PR TITLE
feat: status table onclick

### DIFF
--- a/src/Components/Table/index.jsx
+++ b/src/Components/Table/index.jsx
@@ -15,6 +15,8 @@ import { useTheme } from "@emotion/react";
  * @typedef {Object} Header
  * @property {number|string} id - The unique identifier for the header.
  * @property {React.ReactNode} content - The content to display in the header cell.
+ * @property {Function} onClick - A function to be called when this cell is clicked, receiving the event and row data as an argument.
+ * @property {Object} getCellSx - Function that takes a row and returns a style object for the table cell.
  * @property {Function} render - A function to render the cell content for a given row.
  */
 
@@ -107,6 +109,8 @@ const DataTable = ({
 											<TableCell
 												align={index === 0 ? "left" : "center"}
 												key={header.id}
+												onClick={header.onClick ? (e) => header.onClick(e, row) : null}
+												sx={header.getCellSx ? header.getCellSx(row) : {}}
 											>
 												{header.render(row)}
 											</TableCell>

--- a/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
+++ b/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
@@ -28,17 +28,6 @@ const StatusPagesTable = ({ data }) => {
 					navigate(url);
 				}
 			},
-			getCellSx: (row) => {
-				return {
-					...(row.isPublished && {
-						"&.MuiTableCell-root:hover": {
-							backgroundColor: `${theme.palette.primary.light}`,
-							cursor: "pointer",
-							borderRadius: 1,
-						},
-					}),
-				};
-			},
 			render: (row) => {
 				const content = row.isPublished ? `/${row.url}` : "Unpublished";
 				return (
@@ -46,6 +35,18 @@ const StatusPagesTable = ({ data }) => {
 						direction="row"
 						alignItems="center"
 						gap={theme.spacing(2)}
+						paddingLeft={theme.spacing(2)}
+						paddingRight={theme.spacing(2)}
+						borderRadius={theme.spacing(4)}
+						sx={{
+							...(row.isPublished && {
+								":hover": {
+									backgroundColor: `${theme.palette.primary.light}`,
+									cursor: "pointer",
+									borderRadius: 1,
+								},
+							}),
+						}}
 					>
 						<Typography>{content}</Typography>
 						{row.isPublished && <ArrowOutwardIcon />}

--- a/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
+++ b/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
@@ -17,16 +17,38 @@ const StatusPagesTable = ({ data }) => {
 		},
 		{
 			id: "url",
-			content: "URL",
+			content: "Public URL",
+			onClick: (e, row) => {
+				if (row.isPublished) {
+					e.stopPropagation();
+					const url =
+						row.type === "distributed"
+							? `/status/distributed/public/${row.url}`
+							: `/status/uptime/public/${row.url}`;
+					navigate(url);
+				}
+			},
+			getCellSx: (row) => {
+				return {
+					...(row.isPublished && {
+						"&.MuiTableCell-root:hover": {
+							backgroundColor: `${theme.palette.primary.light}`,
+							cursor: "pointer",
+							borderRadius: 1,
+						},
+					}),
+				};
+			},
 			render: (row) => {
+				const content = row.isPublished ? `/${row.url}` : "Unpublished";
 				return (
 					<Stack
 						direction="row"
 						alignItems="center"
 						gap={theme.spacing(2)}
 					>
-						<Typography>{`/${row.url}`}</Typography>
-						<ArrowOutwardIcon />
+						<Typography>{content}</Typography>
+						{row.isPublished && <ArrowOutwardIcon />}
 					</Stack>
 				);
 			},

--- a/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
+++ b/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
@@ -34,6 +34,7 @@ const StatusPagesTable = ({ data }) => {
 					<Stack
 						direction="row"
 						alignItems="center"
+						justifyContent="center"
 						gap={theme.spacing(2)}
 						paddingLeft={theme.spacing(2)}
 						paddingRight={theme.spacing(2)}


### PR DESCRIPTION
This PR adds a configurable `onClick` listener and styling for specifc cells in the `DataTable` component.

It adds an `onClick` listener to the status page table that opens the public status page if it is published.

![image](https://github.com/user-attachments/assets/3634eaac-a469-4786-9d1a-c7bb5d970867)
