### PR TITLE
Added a new HOC in status bar in order to make sure it works on both …

### DIFF
--- a/src/Components/Charts/StatusPageBarChart/index.jsx
+++ b/src/Components/Charts/StatusPageBarChart/index.jsx
@@ -24,6 +24,21 @@ const StatusPageBarChart = ({ checks = [] }) => {
 		checks = [...checks, ...placeholders];
 	}
 
+	const BarBox = ({ width, height, backgroundColor, borderRadius, children }) => (
+		<Box
+			marginRight="5px"
+			position="relative"
+			width={width}
+			height={height}
+			backgroundColor={backgroundColor}
+			sx={{
+				borderRadius: borderRadius || theme.spacing(1.5),
+			}}
+		>
+			{children}
+		</Box>
+	);
+
 	return (
 		<Stack
 			direction="row"
@@ -41,15 +56,11 @@ const StatusPageBarChart = ({ checks = [] }) => {
 					/* TODO what is the purpose of this box? 	*/
 					// CAIO_REVIEW the purpose of this box is to make sure there are always at least 25 bars
 					// even if there are less than 25 checks
-					<Box
+					<BarBox
 						key={`${check}-${index}`}
-						position="relative"
-						width="calc(30vw / 25)"
+						width="calc(30rem / 25)"
 						height="100%"
 						backgroundColor={theme.palette.primary.lowContrast}
-						sx={{
-							borderRadius: theme.spacing(1.5),
-						}}
 					/>
 				) : (
 					<Tooltip
@@ -140,14 +151,10 @@ const StatusPageBarChart = ({ checks = [] }) => {
 							},
 						}}
 					>
-						<Box
-							position="relative"
-							width="calc(30vw / 25)"
+						<BarBox
+							width="calc(30rem / 25)"
 							height="100%"
-							backgroundColor={theme.palette.primary.lowContrast} // CAIO_REVIEW
-							sx={{
-								borderRadius: theme.spacing(1.5),
-							}}
+							backgroundColor={theme.palette.primary.lowContrast}
 						>
 							<Box
 								position="absolute"
@@ -164,7 +171,7 @@ const StatusPageBarChart = ({ checks = [] }) => {
 									transition: "height 600ms cubic-bezier(0.4, 0, 0.2, 1)",
 								}}
 							/>
-						</Box>
+						</BarBox>
 					</Tooltip>
 				)
 			)}


### PR DESCRIPTION
…the resolution, high and low.
## Describe your changes
Changes done in status bar in order to accommodate the resolution issue with styles in width of single bars.

## Issue number
FE - Status Page graph not displaying well on high resolution screens #1729

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x ] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x ] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x ] I have included the issue # in the PR.
- [x ] I have labelled the PR correctly.
- [x ] The issue I am working on is assigned to me.
- [x ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x ] I made sure font sizes, color choices etc are all referenced from the theme.
- [x ] My PR is granular and targeted to one specific feature.
- [x ] I took a screenshot or a video and attached to this PR if there is a UI change.
- Before
<img width="937" alt="Screenshot 2025-02-28 at 9 22 42 AM" src="https://github.com/user-attachments/assets/99ed0d17-69a5-4510-93ed-b68bc17438e2" />

- After
<img width="823" alt="Screenshot 2025-02-28 at 9 22 54 AM" src="https://github.com/user-attachments/assets/e2420d49-e18d-4b89-9c83-9978dddfb790" />
<img width="1021" alt="Screenshot 2025-02-28 at 9 33 06 AM" src="https://github.com/user-attachments/assets/ba84909e-8a52-4735-8a95-8fff340064d7" />
<img width="374" alt="Screenshot 2025-02-28 at 9 33 19 AM" src="https://github.com/user-attachments/assets/655ab9fa-6726-4747-984b-527dbaa1ee25" />

