### PR TITLE
fix: disallow reserved chars from status page valiation, resolves #1826

### DIFF
--- a/src/Pages/StatusPage/Create/Components/Tabs/Settings.jsx
+++ b/src/Pages/StatusPage/Create/Components/Tabs/Settings.jsx
@@ -73,6 +73,8 @@ const TabSettings = ({
 							label="Your status page address"
 							value={form.url}
 							onChange={handleFormChange}
+							helperText={errors["url"]}
+							error={errors["url"] ? true : false}
 						/>
 					</Stack>
 				</ConfigBox>

--- a/src/Validation/validation.js
+++ b/src/Validation/validation.js
@@ -222,7 +222,14 @@ const statusPageValidation = joi.object({
 		.string()
 		.trim()
 		.messages({ "string.empty": "Company name is required." }),
-	url: joi.string().trim().messages({ "string.empty": "URL is required." }),
+	url: joi
+		.string()
+		.pattern(/^[a-zA-Z0-9_-]+$/) // Only allow alphanumeric, underscore, and hyphen
+		.required()
+		.messages({
+			"string.pattern.base":
+				"URL can only contain letters, numbers, underscores, and hyphens",
+		}),
 	timezone: joi.string().trim().messages({ "string.empty": "Timezone is required." }),
 	color: joi.string().trim().messages({ "string.empty": "Color is required." }),
 	theme: joi.string(),


### PR DESCRIPTION
This PR adds further validation to the `url` field in Create Status Page to disallow reserved characters that can break routing.

![image](https://github.com/user-attachments/assets/13d8c886-0b78-4fe0-93fe-9fc080ba55d4)
