### PR TITLE
fix: add <StatusLabel> on "status pages" table

### DIFF
--- a/src/Components/Label/index.jsx
+++ b/src/Components/Label/index.jsx
@@ -114,7 +114,7 @@ ColoredLabel.propTypes = {
 /**
  * @component
  * @param {Object} props
- * @param { 'up' | 'down' | 'cannot resolve'} props.status - The status for the label
+ * @param {'up' | 'down' | 'paused' | 'pending' | 'cannot resolve' | 'published' | 'unpublished'} props.status - The status for the label
  * @param {string} props.text - The text of the label
  * @returns {JSX.Element}
  * @example

--- a/src/Components/Label/index.jsx
+++ b/src/Components/Label/index.jsx
@@ -128,6 +128,8 @@ const statusToTheme = {
 	paused: "warning",
 	pending: "warning",
 	"cannot resolve": "error",
+	published: "success",
+	unpublished: "error",
 };
 
 const StatusLabel = ({ status, text, customStyles }) => {
@@ -156,7 +158,7 @@ const StatusLabel = ({ status, text, customStyles }) => {
 };
 
 StatusLabel.propTypes = {
-	status: PropTypes.oneOf(["up", "down", "paused", "pending", "cannot resolve"]),
+	status: PropTypes.oneOf(["up", "down", "paused", "pending", "cannot resolve", "published", "unpublished"]),
 	text: PropTypes.string,
 	customStyles: PropTypes.object,
 };

--- a/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
+++ b/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
@@ -66,7 +66,7 @@ const StatusPagesTable = ({ data }) => {
 			id: "status",
 			content: "Status",
 			render: (row) => {
-				const status = row.isPublished ? "up" : "down";
+				const status = row.isPublished ? "published" : "unpublished";
 				return (
 					<StatusLabel
 						status={status}

--- a/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
+++ b/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
@@ -1,7 +1,7 @@
 import DataTable from "../../../../../Components/Table";
 import { useTheme } from "@emotion/react";
 import { useNavigate } from "react-router-dom";
-import { ColoredLabel } from "../../../../../Components/Label";
+import { StatusLabel } from "../../../../../Components/Label";
 import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
 import { Stack, Typography } from "@mui/material";
 const StatusPagesTable = ({ data }) => {
@@ -66,12 +66,11 @@ const StatusPagesTable = ({ data }) => {
 			id: "status",
 			content: "Status",
 			render: (row) => {
+				const status = row.isPublished ? "up" : "down";
 				return (
-					<ColoredLabel
-						label={row.isPublished ? "Published" : "Unpublished"}
-						color={
-							row.isPublished ? theme.palette.success.main : theme.palette.warning.main
-						}
+					<StatusLabel
+						status={status}
+						text={row.isPublished ? "Published" : "Unpublished"}
 					/>
 				);
 			},


### PR DESCRIPTION
## Describe your changes

Replaced <ColoredLabel> component from "Status pages" with <StatusLabel> component as it was not being used anywhere else besides there.

## Issue number

https://github.com/bluewave-labs/Checkmate/issues/1892

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

