### PR TITLE
Fix Open public url in new Tab(#1864)

### DIFF
--- a/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
+++ b/src/Pages/StatusPage/StatusPages/Components/StatusPagesTable/index.jsx
@@ -25,7 +25,7 @@ const StatusPagesTable = ({ data }) => {
 						row.type === "distributed"
 							? `/status/distributed/public/${row.url}`
 							: `/status/uptime/public/${row.url}`;
-					navigate(url);
+						window.open(url, "_blank", "noopener,noreferrer")
 				}
 			},
 			render: (row) => {


### PR DESCRIPTION
## Changes

Changed     navigate(url) --> window.open(url, "_blank", "noopener,noreferrer") at line number 28.
 _blank: Opens in a new tab.
 "noopener,noreferrer": Security best practice to prevent access to the parent page.
 
 
 Reason to change was that public url link should not have any option of redirecting into other pages of the application.
 
 ## UI Changes 
 

https://github.com/user-attachments/assets/1718a875-056c-41a0-997e-5fc362124182


## Issue number   1864

---

### ✅ **Checklist**
- [ x ] I deployed the application locally.
- [ x ] I have performed a self-review and testing of my code.
- [ x ] I have included the issue # in the PR.
- [ x ] I have labelled the PR correctly.
- [ x ] The issue I am working on is assigned to me.
- [ x ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ x ] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [ x ] My PR is granular and targeted to one specific feature.
- [ x ] I took a screenshot or a video and attached to this PR if there is a UI change.

