### PR TITLE
Fix 1913 maintenance undefined in drop-downs

### DIFF
--- a/src/Components/Inputs/Search/index.jsx
+++ b/src/Components/Inputs/Search/index.jsx
@@ -167,7 +167,7 @@ const Search = ({
 								: {}
 						}
 					>
-						{option[filteredBy] + (secondaryLabel ? ` (${option[secondaryLabel]})` : "")}
+						{option[filteredBy] + (secondaryLabel && option[secondaryLabel] ? ` (${option[secondaryLabel]})` : "")}
 					</ListItem>
 				);
 			}}

--- a/src/Pages/Maintenance/CreateMaintenance/index.jsx
+++ b/src/Pages/Maintenance/CreateMaintenance/index.jsx
@@ -137,7 +137,7 @@ const CreateMaintenance = () => {
 					limit: null,
 					types: ["http", "ping", "pagespeed"],
 				});
-				const monitors = response.data.data.monitors;
+				const monitors = response.data.data.filteredMonitors;
 				setMonitors(monitors);
 
 				if (maintenanceWindowId === undefined) {


### PR DESCRIPTION
## Describe your changes
The dropdown values in maintenance page which consist the name of the monitor-(type) and if type is not defined then we don’t show them in drop to avoid the string "undefined"

## Issue number
#1913 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have labelled the PR correctly.
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

Before:

https://github.com/user-attachments/assets/d430f7a0-7261-40e0-bd5b-eeb181101d55

After:

https://github.com/user-attachments/assets/87f56aec-3163-4c15-8d22-216af2eafa1f


