### PR TITLE
fix: uptime refactor

### DIFF
--- a/src/Components/Charts/BarChart/index.jsx
+++ b/src/Components/Charts/BarChart/index.jsx
@@ -58,7 +58,7 @@ const BarChart = ({ checks = [] }) => {
 							<>
 								<Typography>
 									{formatDateWithTz(
-										check.createdAt,
+										check.updatedAt,
 										"ddd, MMMM D, YYYY, HH:mm A",
 										uiTimezone
 									)}

--- a/src/Hooks/useFetchMonitorsWithChecks.js
+++ b/src/Hooks/useFetchMonitorsWithChecks.js
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { networkService } from "../main";
+import { createToast } from "../Utils/toastUtils";
+import { useTheme } from "@emotion/react";
+import { useMonitorUtils } from "./useMonitorUtils";
+
+export const useFetchMonitorsWithChecks = ({
+	teamId,
+	types,
+	limit,
+	page,
+	rowsPerPage,
+	filter,
+	field,
+	order,
+	triggerUpdate,
+}) => {
+	const [isLoading, setIsLoading] = useState(false);
+	const [count, setCount] = useState(undefined);
+	const [monitors, setMonitors] = useState(undefined);
+	const [networkError, setNetworkError] = useState(false);
+
+	const theme = useTheme();
+	const { getMonitorWithPercentage } = useMonitorUtils();
+	useEffect(() => {
+		const fetchMonitors = async () => {
+			try {
+				setIsLoading(true);
+				const res = await networkService.getMonitorsWithChecksByTeamId({
+					teamId,
+					limit,
+					types,
+					page,
+					rowsPerPage,
+					filter,
+					field,
+					order,
+				});
+				const { count, monitors } = res?.data?.data ?? {};
+				const mappedMonitors = monitors.map((monitor) =>
+					getMonitorWithPercentage(monitor, theme)
+				);
+				setMonitors(mappedMonitors);
+				setCount(count?.monitorsCount ?? 0);
+			} catch (error) {
+				console.error(error);
+				setNetworkError(true);
+				createToast({
+					body: error.message,
+				});
+			} finally {
+				setIsLoading(false);
+			}
+		};
+		fetchMonitors();
+	}, [
+		field,
+		filter,
+		getMonitorWithPercentage,
+		limit,
+		order,
+		page,
+		rowsPerPage,
+		teamId,
+		theme,
+		types,
+	]);
+	return [monitors, count, isLoading, networkError];
+};
+
+export default useFetchMonitorsWithChecks;

--- a/src/Hooks/useFetchMonitorsWithSummary.js
+++ b/src/Hooks/useFetchMonitorsWithSummary.js
@@ -20,6 +20,7 @@ export const useFetchMonitorsWithSummary = ({ teamId, types }) => {
 				setMonitors(monitors);
 				setMonitorsSummary(summary);
 			} catch (error) {
+				console.error(error);
 				setNetworkError(true);
 				createToast({
 					body: error.message,

--- a/src/Hooks/useFetchMonitorsWithSummary.js
+++ b/src/Hooks/useFetchMonitorsWithSummary.js
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import { networkService } from "../main";
+import { createToast } from "../Utils/toastUtils";
+
+export const useFetchMonitorsWithSummary = ({ teamId, types }) => {
+	const [isLoading, setIsLoading] = useState(false);
+	const [monitors, setMonitors] = useState(undefined);
+	const [monitorsSummary, setMonitorsSummary] = useState(undefined);
+	const [networkError, setNetworkError] = useState(false);
+
+	useEffect(() => {
+		const fetchMonitors = async () => {
+			try {
+				setIsLoading(true);
+				const res = await networkService.getMonitorsWithSummaryByTeamId({
+					teamId,
+					types,
+				});
+				const { monitors, summary } = res?.data?.data ?? {};
+				setMonitors(monitors);
+				setMonitorsSummary(summary);
+			} catch (error) {
+				setNetworkError(true);
+				createToast({
+					body: error.message,
+				});
+			} finally {
+				setIsLoading(false);
+			}
+		};
+		fetchMonitors();
+	}, [teamId, types]);
+	return [monitors, monitorsSummary, isLoading, networkError];
+};
+
+export default useFetchMonitorsWithSummary;

--- a/src/Utils/NetworkService.js
+++ b/src/Utils/NetworkService.js
@@ -1033,6 +1033,29 @@ class NetworkService {
 
 		return this.axiosInstance.delete(`/status-page/${encodedUrl}`, {});
 	}
+
+	// ************************************
+	// Fetch monitors with summary by TeamID
+	// ************************************
+	async getMonitorsWithSummaryByTeamId(config) {
+		const { teamId, types } = config;
+		const params = new URLSearchParams();
+
+		if (types) {
+			types.forEach((type) => {
+				params.append("type", type);
+			});
+		}
+
+		return this.axiosInstance.get(
+			`/monitors/summary/team/${teamId}?${params.toString()}`,
+			{
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+	}
 }
 
 export default NetworkService;

--- a/src/Utils/NetworkService.js
+++ b/src/Utils/NetworkService.js
@@ -1056,6 +1056,35 @@ class NetworkService {
 			}
 		);
 	}
+
+	// ************************************
+	// Fetch monitors with checks by TeamID
+	// ************************************
+	async getMonitorsWithChecksByTeamId(config) {
+		const { teamId, limit, types, page, rowsPerPage, filter, field, order } = config;
+		const params = new URLSearchParams();
+
+		if (limit) params.append("limit", limit);
+		if (types) {
+			types.forEach((type) => {
+				params.append("type", type);
+			});
+		}
+		if (page) params.append("page", page);
+		if (rowsPerPage) params.append("rowsPerPage", rowsPerPage);
+		if (filter) params.append("filter", filter);
+		if (field) params.append("field", field);
+		if (order) params.append("order", order);
+
+		return this.axiosInstance.get(
+			`/monitors/team/${teamId}/with-checks?${params.toString()}`,
+			{
+				headers: {
+					"Content-Type": "application/json",
+				},
+			}
+		);
+	}
 }
 
 export default NetworkService;


### PR DESCRIPTION
This PR adds two new top level hooks:

1.  Hook for fetching list of monitors with summary.  This is useful for showing a summary of all monitors as well as providing a full list for searching through

2.  Hook for fetching a list of monitors with checks

Previously these two operations were combined in one hook, so the entire page would need to re-render when either set of data changes.

Now we can rerender only the necessary components.