### PR TITLE
Fixed calendar disabled date colour

### DIFF
--- a/src/Pages/Maintenance/CreateMaintenance/index.jsx
+++ b/src/Pages/Maintenance/CreateMaintenance/index.jsx
@@ -409,7 +409,7 @@ const CreateMaintenance = () => {
 														backgroundColor: theme.palette.accent.light, // Hover background
 													},
 													"&.Mui-disabled": {
-														color: theme.palette.primary.ContrastTextTertiary, // Disabled day color
+														color: theme.palette.secondary.main, // Disabled day color
 													},
 												},
 												"& .MuiDayCalendar-weekDayLabel": {


### PR DESCRIPTION
## Describe your changes
The colour (text) of disabled dates is dark in colour when the theme is dark.

## Issue number
#1935 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
Before:
<img width="528" alt="Screenshot 2025-03-14 at 4 20 02 PM" src="https://github.com/user-attachments/assets/e22dec05-6a2c-4ada-9de7-6518a50963e3" />

After:
<img width="444" alt="Screenshot 2025-03-15 at 5 36 20 PM" src="https://github.com/user-attachments/assets/ac2212cb-4811-4fec-b780-17d29a05357b" />

