### PR TITLE
Fix 1936 dark bg

### DIFF
--- a/src/Components/Dialog/index.jsx
+++ b/src/Components/Dialog/index.jsx
@@ -30,12 +30,8 @@ const Dialog = ({
 			>
 				<Button
 					variant="contained"
+					color="secondary"
 					onClick={onCancel}
-					sx={{
-						"&:hover": {
-							backgroundColor: theme.palette.primary.lowContrast,
-						},
-					}}
 				>
 					Cancel
 				</Button>

--- a/src/Components/Dialog/index.jsx
+++ b/src/Components/Dialog/index.jsx
@@ -29,9 +29,13 @@ const Dialog = ({
 				justifyContent="flex-end"
 			>
 				<Button
-					variant="text"
-					color="info"
+					variant="contained"
 					onClick={onCancel}
+					sx={{
+						"&:hover": {
+							backgroundColor: theme.palette.primary.lowContrast,
+						},
+					}}
 				>
 					Cancel
 				</Button>


### PR DESCRIPTION
## Describe your changes
The cancel option on multiple popups are like link instead of buttons, need to be a like button for better UI. I have made is like a button with gray bg.

## Feature number
#1936 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

Before:
<img width="684" alt="Screenshot 2025-03-15 at 12 45 11 AM" src="https://github.com/user-attachments/assets/7196db56-cab0-42ff-8141-8c88970172a5" />

After:
https://github.com/user-attachments/assets/0959bb86-6a9a-4404-afda-e926a904d08a

