### PR TITLE
Fix: Dialog Component Center to Parent

### DIFF
--- a/src/Components/Dialog/genericDialog.jsx
+++ b/src/Components/Dialog/genericDialog.jsx
@@ -13,14 +13,18 @@ const GenericDialog = ({ title, description, open, onClose, theme, children }) =
 			open={open}
 			onClose={onClose}
 			onClick={(e) => e.stopPropagation()}
+			sx={{
+				position: 'absolute',
+				display: 'flex',
+				left: "20%",
+				alignItems: 'center',
+				justifyContent: 'center',
+			}}
 		>
 			<Stack
 				gap={theme.spacing(2)}
 				sx={{
-					position: "absolute",
-					top: "50%",
-					left: "50%",
-					transform: "translate(-50%, -50%)",
+					position: "relative",
 					width: 400,
 					bgcolor: theme.palette.primary.main,
 					border: 1,


### PR DESCRIPTION
## Describe your changes

This PR addresses the issue where the dialog was always centered in the viewport due to MUI's default `Modal` behavior. The problem occurred because MUI automatically positions modals in the center using `transform: translate(-50%, -50%)`.
To resolve this, I adjusted the `left` property to "20%", ensuring the dialog appears slightly off-center while maintaining a consistent and expected position across different screen sizes.

## Issue number

#1705 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


<img width="1678" alt="Screenshot 2025-03-18 at 1 39 55 AM" src="https://github.com/user-attachments/assets/68d58fd2-a546-4ccc-8366-13a7d4501948" />
<img width="1677" alt="Screenshot 2025-03-18 at 1 39 45 AM" src="https://github.com/user-attachments/assets/52860445-d756-4649-92d2-f0867f48b825" />
<img width="1678" alt="Screenshot 2025-03-18 at 1 39 35 AM" src="https://github.com/user-attachments/assets/0c795e12-249b-4e32-a9aa-b36952ed792a" />
<img width="1673" alt="Screenshot 2025-03-18 at 1 39 24 AM" src="https://github.com/user-attachments/assets/eb3f5107-f4c4-4dc8-a95a-3a69fda7c71d" />
