### PR TITLE
Quick fix for settings save page api call

### DIFF
--- a/src/Features/Settings/settingsSlice.js
+++ b/src/Features/Settings/settingsSlice.js
@@ -30,7 +30,9 @@ export const getAppSettings = createAsyncThunk(
 export const updateAppSettings = createAsyncThunk(
 	"settings/updateSettings",
 	async ({ settings }, thunkApi) => {
-		networkService.setBaseUrl(settings.apiBaseUrl);
+ 		// The reason for commenting is that, previously, we had the flexibility to set the API base. 
+  		// However, now this could lead to an issue where it gets set to undefined.
+		// networkService.setBaseUrl(settings.apiBaseUrl);
 		try {
 			const parsedSettings = {
 				apiBaseUrl: settings.apiBaseUrl,


### PR DESCRIPTION
## Describe your changes
The set base url was causing a problem in settings page due to which it was sending the api to client url instead of base url which set in env or in network service

## Issue number
No issue as this is a quick fix for now

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
Before:
<img width="1337" alt="Screenshot 2025-03-20 at 10 02 14 PM" src="https://github.com/user-attachments/assets/0019719c-c38f-4692-a798-3c7035f4ea52" />

After:

<img width="1501" alt="Screenshot 2025-03-20 at 11 11 30 PM" src="https://github.com/user-attachments/assets/c1326652-3dba-4a13-b747-764f558c7bf8" />
