### PR TITLE
fix: add separate URL for public status pages

### DIFF
--- a/src/Hooks/useSubscribeToDepinDetails.js
+++ b/src/Hooks/useSubscribeToDepinDetails.js
@@ -27,6 +27,7 @@ const useSubscribeToDepinDetails = ({ monitorId, isPublic, isPublished, dateRang
 					monitorId,
 					dateRange: dateRange,
 					normalize: true,
+					isPublic,
 				});
 				const responseData = res?.data?.data;
 

--- a/src/Utils/NetworkService.js
+++ b/src/Utils/NetworkService.js
@@ -926,10 +926,15 @@ class NetworkService {
 
 	getDistributedUptimeDetails(config) {
 		const params = new URLSearchParams();
-		const { monitorId, onUpdate, onOpen, onError, dateRange, normalize } = config;
+		const { monitorId, dateRange, normalize, isPublic } = config;
 		if (dateRange) params.append("dateRange", dateRange);
 		if (normalize) params.append("normalize", normalize);
-		const url = `${this.axiosInstance.defaults.baseURL}/distributed-uptime/monitors/details/${monitorId}/initial?${params.toString()}`;
+		let url;
+		if (isPublic) {
+			url = `${this.axiosInstance.defaults.baseURL}/distributed-uptime/monitors/details/public/${monitorId}/initial?${params.toString()}`;
+		} else {
+			url = `${this.axiosInstance.defaults.baseURL}/distributed-uptime/monitors/details/${monitorId}/initial?${params.toString()}`;
+		}
 		return this.axiosInstance.get(url);
 	}
 


### PR DESCRIPTION
Status pages need a separate unsecure route