### PR TITLE
Fix sidebar menu icons appearing before full expansion

### DIFF
--- a/src/Components/Sidebar/index.css
+++ b/src/Components/Sidebar/index.css
@@ -79,6 +79,17 @@ aside .MuiListSubheader-root {
 	transition: padding 200ms ease;
 }
 
+.sidebar-delay-fade {
+	opacity: 0;
+	visibility: hidden;
+	transition: opacity 0.3s ease;
+}
+
+aside.sidebar-ready .sidebar-delay-fade {
+	opacity: 1;
+	visibility: visible;
+}
+
 @keyframes fadeIn {
 	0% {
 		opacity: 0;

--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -129,6 +129,21 @@ function Sidebar() {
 	);
 	const sidebarRef = useRef(null);
 
+	useEffect(() => {
+		const el = sidebarRef.current;
+		if (!el) return;
+	
+		const TRANSITION_DURATION = 650;
+	
+		if (!collapsed) {
+			const timeout = setTimeout(() => {
+				el.classList.add("sidebar-ready");
+			}, TRANSITION_DURATION);
+			return () => clearTimeout(timeout);
+		} else {
+			el.classList.remove("sidebar-ready");
+		}
+	}, [collapsed]);	
 
 	const renderAccountMenuItems = () => {
 		let filteredAccountMenuItems = [...accountMenuItems];

--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import {
 	Box,
 	Collapse,
@@ -127,6 +127,8 @@ function Sidebar() {
 	const distributedUptimeEnabled = useSelector(
 		(state) => state.ui.distributedUptimeEnabled
 	);
+	const sidebarRef = useRef(null);
+
 
 	const renderAccountMenuItems = () => {
 		let filteredAccountMenuItems = [...accountMenuItems];
@@ -196,6 +198,7 @@ function Sidebar() {
 	return (
 		<Stack
 			component="aside"
+			ref={sidebarRef}
 			className={collapsed ? "collapsed" : "expanded"}
 			/* TODO general padding should be here */
 			py={theme.spacing(6)}

--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -133,7 +133,7 @@ function Sidebar() {
 		const el = sidebarRef.current;
 		if (!el) return;
 	
-		const TRANSITION_DURATION = 650;
+		const TRANSITION_DURATION = 200;
 	
 		if (!collapsed) {
 			const timeout = setTimeout(() => {

--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -743,6 +743,7 @@ function Sidebar() {
 							</Typography>
 						</Box>
 						<Stack
+							className="sidebar-delay-fade"
 							flexDirection={"row"}
 							marginLeft={"auto"}
 							columnGap={theme.spacing(2)}


### PR DESCRIPTION
## Describe your changes

- Fixed the issue where sidebar icons appeared before the sidebar finished expanding.
- Introduced a delayed `.sidebar-ready` class that's added only after the sidebar finishes expanding.
- Used this class to control the visibility of icons using CSS transition.

## Write your issue number after "Fixes "

Fixes #1987 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

Before:
https://github.com/user-attachments/assets/cd40aedd-60c6-42e8-9188-0a68785cbe39

After:
https://github.com/user-attachments/assets/fbb5427b-2c64-438b-941c-e5b5f7256b68
