### PR TITLE
Fix sidebar icons visibility when toggling

### DIFF
--- a/src/Components/Sidebar/index.css
+++ b/src/Components/Sidebar/index.css
@@ -82,12 +82,12 @@ aside .MuiListSubheader-root {
 .sidebar-delay-fade {
 	opacity: 0;
 	visibility: hidden;
+	transition: opacity 0.3s ease;
 }
 
 aside.expanded.sidebar-ready .sidebar-delay-fade {
 	opacity: 1;
 	visibility: visible;
-	transition: opacity 0.3s ease;
 }
 
 @keyframes fadeIn {

--- a/src/Components/Sidebar/index.css
+++ b/src/Components/Sidebar/index.css
@@ -82,12 +82,12 @@ aside .MuiListSubheader-root {
 .sidebar-delay-fade {
 	opacity: 0;
 	visibility: hidden;
-	transition: opacity 0.3s ease;
 }
 
-aside.sidebar-ready .sidebar-delay-fade {
+aside.expanded.sidebar-ready .sidebar-delay-fade {
 	opacity: 1;
 	visibility: visible;
+	transition: opacity 0.3s ease;
 }
 
 @keyframes fadeIn {

--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -128,7 +128,7 @@ function Sidebar() {
 		(state) => state.ui.distributedUptimeEnabled
 	);
 	const sidebarRef = useRef(null);
-	const [sidebarReady, setSidebarReady] = useState(!collapsed);
+	const [sidebarReady, setSidebarReady] = useState(false);
 
 	useEffect(() => {
 		if (!collapsed) {

--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -211,7 +211,7 @@ function Sidebar() {
 		<Stack
 			component="aside"
 			ref={sidebarRef}
-			className={collapsed ? "collapsed" : "expanded"}
+			className={`${collapsed ? "collapsed" : "expanded"} ${sidebarReady ? "sidebar-ready" : ""}`}
 			/* TODO general padding should be here */
 			py={theme.spacing(6)}
 			gap={theme.spacing(6)}

--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -129,13 +129,14 @@ function Sidebar() {
 	);
 	const sidebarRef = useRef(null);
 	const [sidebarReady, setSidebarReady] = useState(false);
+	const TRANSITION_DURATION = 200;
 
 	useEffect(() => {
 		if (!collapsed) {
 			setSidebarReady(false);
 			const timeout = setTimeout(() => {
 				setSidebarReady(true);
-			}, 200);
+			}, TRANSITION_DURATION);
 			return () => clearTimeout(timeout);
 		} else {
 			setSidebarReady(false);
@@ -205,13 +206,14 @@ function Sidebar() {
 	}, [location]);
 
 	const iconColor = theme.palette.primary.contrastTextTertiary;
+	const sidebarClassName = `${collapsed ? "collapsed" : "expanded"} ${sidebarReady ? "sidebar-ready" : ""}`;
 
 	/* TODO refactor this, there are a some ternaries and comments in the return  */
 	return (
 		<Stack
 			component="aside"
 			ref={sidebarRef}
-			className={`${collapsed ? "collapsed" : "expanded"} ${sidebarReady ? "sidebar-ready" : ""}`}
+			className={sidebarClassName}
 			/* TODO general padding should be here */
 			py={theme.spacing(6)}
 			gap={theme.spacing(6)}

--- a/src/Components/Sidebar/index.jsx
+++ b/src/Components/Sidebar/index.jsx
@@ -128,20 +128,17 @@ function Sidebar() {
 		(state) => state.ui.distributedUptimeEnabled
 	);
 	const sidebarRef = useRef(null);
+	const [sidebarReady, setSidebarReady] = useState(!collapsed);
 
 	useEffect(() => {
-		const el = sidebarRef.current;
-		if (!el) return;
-	
-		const TRANSITION_DURATION = 200;
-	
 		if (!collapsed) {
+			setSidebarReady(false);
 			const timeout = setTimeout(() => {
-				el.classList.add("sidebar-ready");
-			}, TRANSITION_DURATION);
+				setSidebarReady(true);
+			}, 200);
 			return () => clearTimeout(timeout);
 		} else {
-			el.classList.remove("sidebar-ready");
+			setSidebarReady(false);
 		}
 	}, [collapsed]);	
 


### PR DESCRIPTION
## Describe your changes

Fixed the icons visibility issue when toggling between themes

- We were using a CSS class `.sidebar-ready` that gets added after a delay (using setTimeout) to show the icons.
- But when the theme was toggled, the sidebar re-rendered and temporarily lost the .sidebar-ready class.

- Added a `sidebarReady` state to track readiness properly, independent of re-renders.
- Removed direct DOM manipulation (classList.add/remove) and instead used `sidebarReady` state to add the class through className.

## Write your issue number after "Fixes "

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

Before:
https://github.com/user-attachments/assets/98483bf9-2d0e-4071-b995-182f4e4df9c9

After:
https://github.com/user-attachments/assets/60e81309-5b87-47a4-9dfb-b8b0f9c519d3