### PR TITLE
Fix: Uptime Create Monitor General Settings Text

### DIFF
--- a/client/src/Pages/Uptime/Create/index.jsx
+++ b/client/src/Pages/Uptime/Create/index.jsx
@@ -350,7 +350,7 @@ const CreateMonitor = () => {
 				<ConfigBox>
 					<Box>
 						<Typography component="h2">{t("settingsGeneralSettings")}</Typography>
-						<Typography component="p">{t("distributedUptimeCreateSelectURL")}</Typography>
+						<Typography component="p">{t("uptimeCreateSelectURL")}</Typography>
 					</Box>
 					<Stack gap={theme.spacing(15)}>
 						<TextInput

--- a/client/src/locales/gb.json
+++ b/client/src/locales/gb.json
@@ -131,6 +131,7 @@
   "distributedStatusServerMonitors": "Server Monitors",
   "distributedStatusServerMonitorsDescription": "Monitor status of related servers",
   "distributedUptimeCreateSelectURL": "Here you can select the URL of the host, together with the type of monitor.",
+  "uptimeCreateSelectURL": "Here you can select the host address/container ID, together with the display name.",
   "distributedUptimeCreateChecks": "Checks to perform",
   "distributedUptimeCreateChecksDescription": "You can always add or remove checks after adding your site.",
   "distributedUptimeCreateIncidentNotification": "Incident notifications",


### PR DESCRIPTION
## Describe your changes

This PR changes the general settings text visible when creating a uptime monitor.

## Write your issue number after "Fixes "

Fixes #2114 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the displayed text in the monitor creation form's general settings section for improved clarity.
- **Documentation**
  - Added a new localization string for the updated text in the monitor creation form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->