### PR TITLE
Fix: Infra Monitor Filter UI Position

### DIFF
--- a/client/src/Pages/Infrastructure/Monitors/Components/Filters/index.jsx
+++ b/client/src/Pages/Infrastructure/Monitors/Components/Filters/index.jsx
@@ -52,7 +52,12 @@ const Filter = ({
 	}, [selectedStatus]);
 
 	return (
-		<Box>
+		<Box
+		sx={{
+			m: theme.spacing(2),
+			ml: theme.spacing(4),
+		}}
+		>
 			<FilterHeader
 				header={t("status")}
 				options={statusOptions}

--- a/client/src/Pages/Infrastructure/Monitors/index.jsx
+++ b/client/src/Pages/Infrastructure/Monitors/index.jsx
@@ -97,16 +97,18 @@ const InfrastructureMonitors = () => {
 				shouldRender={!isLoading}
 				path="/infrastructure/create"
 			/>
-			<MonitorCountHeader
-				shouldRender={!isLoading}
-				monitorCount={summary?.totalMonitors ?? 0}
-			/>
-			<Filter
-				selectedStatus={selectedStatus}
-				setSelectedStatus={setSelectedStatus}
-				setToFilterStatus={setToFilterStatus}
-				handleReset={handleReset}
-			/>
+			<Stack direction={"row"}>
+				<MonitorCountHeader
+					shouldRender={!isLoading}
+					monitorCount={summary?.totalMonitors ?? 0}
+				/>
+				<Filter
+					selectedStatus={selectedStatus}
+					setSelectedStatus={setSelectedStatus}
+					setToFilterStatus={setToFilterStatus}
+					handleReset={handleReset}
+				/>
+			</Stack>
 			<MonitorsTable
 				shouldRender={!isLoading}
 				monitors={monitors}


### PR DESCRIPTION
## Describe your changes

This PR address the new position of filters in infra pages to match the uptime page.

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1354" alt="Screenshot 2025-04-27 at 12 45 13 PM" src="https://github.com/user-attachments/assets/c7e35e65-1583-4147-b430-8648abe52b6f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing and alignment of filter UI components for a cleaner layout.
  - Updated layout to display the monitor count header and filters side-by-side.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->