### PR TITLE
Add Port field edit support for Port Monitors Configure screen

### DIFF
--- a/client/src/Pages/Uptime/Configure/index.jsx
+++ b/client/src/Pages/Uptime/Configure/index.jsx
@@ -372,6 +372,17 @@ const Configure = () => {
 									disabled={true}
 								/>
 								<TextInput
+									type="number"
+									id="monitor-port"
+									label={t("portToMonitor")}
+									placeholder="5173"
+									value={monitor.port || ""}
+									onChange={(event) => handleChange(event, "port")}
+									error={errors["port"] ? true : false}
+									helperText={errors["port"]}
+									hidden={monitor.type !== "port"}
+								/>
+								<TextInput
 									type="text"
 									id="monitor-name"
 									label={t("displayName")}

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -266,6 +266,7 @@ class NetworkService {
 			matchMethod: monitor.matchMethod,
 			expectedValue: monitor.expectedValue,
 			jsonPath: monitor.jsonPath,
+			...(monitor.type === "port" && { port: monitor.port }),
 		};
 		return this.axiosInstance.put(`/monitors/${monitorId}`, payload, {
 			headers: {

--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -159,7 +159,20 @@ const monitorValidation = joi.object({
 			"string.invalidUrl": "Please enter a valid URL with optional port",
 			"string.pattern.base": "Please enter a valid container ID.",
 		}),
-	port: joi.number(),
+	port: joi.number()
+	.integer()
+	.min(1)
+	.max(65535)
+	.when("type", {
+		is: "port",
+		then: joi.required().messages({
+			"number.base": "Port must be a number.",
+			"number.min": "Port must be at least 1.",
+			"number.max": "Port must be at most 65535.",
+			"any.required": "Port is required for port monitors.",
+		}),
+		otherwise: joi.optional(),
+	}),
 	name: joi.string().trim().max(50).allow("").messages({
 		"string.max": "This field should not exceed the 50 characters limit.",
 	}),

--- a/server/validation/joi.js
+++ b/server/validation/joi.js
@@ -210,6 +210,7 @@ const editMonitorBodyValidation = joi.object({
 	jsonPath: joi.string().allow(""),
 	expectedValue: joi.string().allow(""),
 	matchMethod: joi.string(),
+	port: joi.number().min(1).max(65535),
 	thresholds: joi.object().keys({
 		usage_cpu: joi.number(),
 		usage_memory: joi.number(),


### PR DESCRIPTION
## Describe your changes

- Displayed the port input field when monitor type is port in Configure page

- Updated `updateUptimeMonitor` to include the port field in the monitor payload

- Extended `editMonitorBodyValidation` schema to allow and validate the port field

## Write your issue number after "Fixes "

Fixes #2132 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

Recording: 
https://github.com/user-attachments/assets/024352ea-6990-479a-b432-4bbc3b5e92af


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a numeric input field for specifying the port when configuring a "port" monitor.
- **Bug Fixes**
  - Improved validation to ensure the port number is within the valid range (1 to 65535) when editing monitor settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->