### PR TITLE
Added notification in configure page as well. Used useEffect to retrive the information if once added.

### DIFF
--- a/client/src/Pages/Uptime/Configure/index.jsx
+++ b/client/src/Pages/Uptime/Configure/index.jsx
@@ -25,6 +25,7 @@ import PulseDot from "../../../Components/Animated/PulseDot";
 import SkeletonLayout from "./skeleton";
 import "./index.css";
 import Dialog from "../../../Components/Dialog";
+import NotificationIntegrationModal from "../../../Components/NotificationIntegrationModal/Components/NotificationIntegrationModal";
 
 /**
  * Parses a URL string and returns a URL object.
@@ -195,6 +196,18 @@ const Configure = () => {
 	// Parse the URL
 	const parsedUrl = parseUrl(monitor?.url);
 	const protocol = parsedUrl?.protocol?.replace(":", "") || "";
+
+	// Notification modal state
+	const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
+
+	const handleOpenNotificationModal = () => {
+		setIsNotificationModalOpen(true);
+	};
+
+	const handleClosenNotificationModal = () => {
+		setIsNotificationModalOpen(false);
+	};
+
 
 	const statusColor = {
 		true: theme.palette.success.main,
@@ -424,6 +437,15 @@ const Configure = () => {
 									value={user?.email}
 									onChange={(event) => handleChange(event)}
 								/>
+								<Box mt={theme.spacing(2)}>
+									<Button
+										variant="contained"
+										color="accent"
+										onClick={handleOpenNotificationModal}
+									>
+										{t("notifications.integrationButton")}
+									</Button>
+								</Box>
 								{/* <Checkbox
 									id="notify-email"
 									label="Also notify via email to multiple addresses (coming soon)"
@@ -556,6 +578,13 @@ const Configure = () => {
 				confirmationButtonLabel="Delete"
 				onConfirm={handleRemove}
 				isLoading={isLoading}
+			/>
+
+			<NotificationIntegrationModal 
+				open={isNotificationModalOpen}
+				onClose={handleClosenNotificationModal}
+				monitor={monitor}
+				setMonitor={setMonitor}
 			/>
 		</Stack>
 	);


### PR DESCRIPTION
## Describe your changes
Added the notification button in configuration page as well. Also used Useeffect to retrive the changes from previously saved once.

## Write your issue number after "Fixes "
#1545 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

https://github.com/user-attachments/assets/a5e465ff-3bf9-47db-8eb1-9769001b5487




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a notification integration modal accessible from the configuration page, allowing users to manage and test notification platform settings.
  - Added a dedicated button to open the notification integration modal for easier access to notification configuration options.

- **Style**
  - Updated the layout and appearance of the notification integration modal for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->