### PR TITLE
hide certificate expiry box for non-http uptimes

### DIFF
--- a/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
+++ b/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
@@ -61,18 +61,20 @@ const UptimeStatusBoxes = ({
 					</>
 				}
 			/>
-			<StatBox
-				heading="certificate expiry"
-				subHeading={
-					<Typography
-						component="span"
-						fontSize={13}
-						color={theme.palette.primary.contrastText}
-					>
-						{certificateExpiry}
-					</Typography>
-				}
-			/>
+			{monitor?.type === "http" && (
+				<StatBox
+					heading="certificate expiry"
+					subHeading={
+						<Typography
+							component="span"
+							fontSize={13}
+							color={theme.palette.primary.contrastText}
+						>
+							{certificateExpiry}
+						</Typography>
+					}
+				/>
+			)}
 		</StatusBoxes>
 	);
 };

--- a/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
+++ b/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
@@ -68,7 +68,7 @@ const UptimeStatusBoxes = ({
 					</>
 				}
 			/>
-			{monitor?.type === "http" && (
+			{MONITOR_TYPES.WEB.includes(monitor?.type) && (
 				<StatBox
 					heading="certificate expiry"
 					subHeading={

--- a/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
+++ b/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
@@ -7,6 +7,13 @@ import { useTheme } from "@mui/material/styles";
 import { Typography } from "@mui/material";
 import useUtils from "../../../Monitors/Hooks/useUtils";
 
+const MONITOR_TYPES = {
+	WEB: ["http", "https"],
+	PING: ["ping"],
+	DOCKER: ["docker"],
+	PORT: ["port"],
+};
+
 const UptimeStatusBoxes = ({
 	isLoading = false,
 	monitor,

--- a/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
+++ b/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
@@ -61,7 +61,7 @@ const UptimeStatusBoxes = ({
 					</>
 				}
 			/>
-			{MONITOR_TYPES.WEB.includes(monitor?.type) && (
+			{monitor?.type === "http" && (
 				<StatBox
 					heading="certificate expiry"
 					subHeading={

--- a/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
+++ b/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
@@ -7,13 +7,6 @@ import { useTheme } from "@mui/material/styles";
 import { Typography } from "@mui/material";
 import useUtils from "../../../Monitors/Hooks/useUtils";
 
-const MONITOR_TYPES = {
-	WEB: ["http", "https"],
-	PING: ["ping"],
-	DOCKER: ["docker"],
-	PORT: ["port"],
-};
-
 const UptimeStatusBoxes = ({
 	isLoading = false,
 	monitor,


### PR DESCRIPTION
## Describe your changes

In uptimes page, certificate expiry box is now hidden for non HTTP uptimes.

## Write your issue number after "Fixes "

Fixes #2169 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [*] (Do not skip this or your PR will be closed) I deployed the application locally.
- [*] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [*] I have included the issue # in the PR.
- [*] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [*] The issue I am working on is assigned to me.
- [*] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [*] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [*] My PR is granular and targeted to one specific feature.
- [*] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1649" alt="certificate expiry is hidden for non-http uptimes" src="https://github.com/user-attachments/assets/c3dd3768-8b2f-42cc-b242-19da79806cff" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The "certificate expiry" status box now only appears for HTTP monitors, ensuring more accurate and relevant information is displayed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->