### PR TITLE
Fix: Infra Page Actions Button Disabled for Members

### DIFF
--- a/client/src/Pages/Infrastructure/Monitors/Components/MonitorsTableMenu/index.jsx
+++ b/client/src/Pages/Infrastructure/Monitors/Components/MonitorsTableMenu/index.jsx
@@ -75,6 +75,7 @@ const InfrastructureMenu = ({ monitor, isAdmin, updateCallback }) => {
 			<IconButton
 				aria-label="monitor actions"
 				onClick={openMenu}
+				disabled={!isAdmin}
 				sx={{
 					"&:focus": {
 						outline: "none",


### PR DESCRIPTION
## Describe your changes

This PR disables the action menu button in infrastructure monitors page for members. Once we have enough options to showcase for members we can remove this logic.

Fixes #2172 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] The issue I am working on is assigned to me.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

![Screenshot 2025-05-05 151524](https://github.com/user-attachments/assets/a6081053-d7e8-4a04-8d45-2c440ababf54)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The menu for infrastructure monitor actions is now disabled for non-admin users, preventing unauthorized access to menu options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->