### PR TITLE
fix: properly load log level from ENV, add debug log level

### DIFF
--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,4 +1,6 @@
 import { createLogger, format, transports } from "winston";
+import dotenv from "dotenv";
+dotenv.config();
 
 class Logger {
 	constructor() {
@@ -40,8 +42,11 @@ class Logger {
 			}
 		);
 
+		const logLevel = process.env.LOG_LEVEL || "info";
+		console.log(logLevel);
+
 		this.logger = createLogger({
-			level: "info",
+			level: logLevel,
 			format: format.combine(format.timestamp()),
 			transports: [
 				new transports.Console({
@@ -101,6 +106,22 @@ class Logger {
 	 */
 	error(config) {
 		this.logger.error(config.message, {
+			service: config.service,
+			method: config.method,
+			details: config.details,
+			stack: config.stack,
+		});
+	}
+	/**
+	 * Logs a debug message.
+	 * @param {Object} config - The configuration object.
+	 * @param {string} config.message - The message to log.
+	 * @param {string} config.service - The service name.
+	 * @param {string} config.method - The method name.
+	 * @param {Object} config.details - Additional details.
+	 */
+	debug(config) {
+		this.logger.debug(config.message, {
 			service: config.service,
 			method: config.method,
 			details: config.details,

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -43,7 +43,6 @@ class Logger {
 		);
 
 		const logLevel = process.env.LOG_LEVEL || "info";
-		console.log(logLevel);
 
 		this.logger = createLogger({
 			level: logLevel,


### PR DESCRIPTION
This PR implements loading of `LOG_LEVEL` from env file and also adds a debug log level to the logger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for debug-level logging, enabling more detailed log messages.
- **Chores**
  - Log level can now be configured via an environment variable, with the current log level displayed at startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->