### PR TITLE
fix: status box alignment

### DIFF
--- a/client/src/Components/StatusBoxes/index.jsx
+++ b/client/src/Components/StatusBoxes/index.jsx
@@ -20,8 +20,8 @@ const StatusBoxes = ({ shouldRender, flexWrap = "nowrap", children }) => {
 			direction="row"
 			flexWrap={flexWrap}
 			gap={theme.spacing(8)}
-			justifyContent="space-between"
-            display="flex"
+			justifyContent="flex-start"
+			display="flex"
 		>
 			{children}
 		</Stack>
@@ -30,6 +30,7 @@ const StatusBoxes = ({ shouldRender, flexWrap = "nowrap", children }) => {
 
 StatusBoxes.propTypes = {
 	shouldRender: PropTypes.bool,
+	flexWrap: PropTypes.string,
 	children: PropTypes.node,
 };
 


### PR DESCRIPTION
This PR fixes status box alignment on the uptime details page

- [x] Set alignment to `flex-start` instead of `space-between` to left align items
- [x] Add missing prop type

![Screenshot from 2025-05-07 11-30-36](https://github.com/user-attachments/assets/732f2005-fbe1-48e2-a0ba-d222449f5cc2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the alignment of elements in the status boxes for improved layout consistency.

- **Documentation**
  - Updated component documentation to clarify accepted properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->