### PR TITLE
fix: set tablecell font size to base typography level, resolves #2237

### DIFF
--- a/client/src/Components/Table/index.jsx
+++ b/client/src/Components/Table/index.jsx
@@ -65,7 +65,6 @@ const DataTable = ({
 						backgroundColor: theme.palette.secondary.main,
 						color: theme.palette.secondary.contrastText,
 						fontWeight: 600,
-						fontSize: "13px",
 					},
 					"& :is(td)": {
 						backgroundColor: theme.palette.primary.main,

--- a/client/src/Utils/Theme/globalTheme.js
+++ b/client/src/Utils/Theme/globalTheme.js
@@ -253,6 +253,7 @@ const baseTheme = (palette) => ({
 		MuiTableCell: {
 			styleOverrides: {
 				root: ({ theme }) => ({
+					fontSize: typographyLevels.base,
 					borderBottomColor: theme.palette.primary.lowContrast,
 				}),
 			},


### PR DESCRIPTION
This PR sets the default font size of MUI table to typography base (13px).  The default value was `body2`.

- [x] Fix font size


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated table header styling to no longer enforce a fixed font size, allowing for more consistent appearance with the overall theme.
  - Standardized table cell font size across the application to match the base typography setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->