### PR TITLE
fix: don't expose redis and mongo ports

### DIFF
--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -24,8 +24,6 @@ services:
   redis:
     image: uptime_redis:latest
     restart: always
-    ports:
-      - "6379:6379"
     volumes:
       - ./redis/data:/data
     healthcheck:
@@ -38,8 +36,6 @@ services:
     image: uptime_mongo:latest
     restart: always
     command: ["mongod", "--quiet", "--replSet", "rs0", "--bind_ip_all"]
-    ports:
-      - "27017:27017"
     volumes:
       - ./mongo/data:/data/db
     healthcheck:

--- a/docker/dist/docker-compose.yaml
+++ b/docker/dist/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
     image: ghcr.io/bluewave-labs/checkmate:backend-dist
     restart: always
     ports:
-      - "5000:5000"
+      - "52345:52345"
     depends_on:
       - redis
       - mongodb
@@ -27,8 +27,6 @@ services:
   redis:
     image: ghcr.io/bluewave-labs/checkmate:redis-dist
     restart: always
-    ports:
-      - "6379:6379"
     volumes:
       - ./redis/data:/data
     healthcheck:
@@ -43,8 +41,6 @@ services:
     volumes:
       - ./mongo/data:/data/db
     command: ["mongod", "--quiet", "--replSet", "rs0", "--bind_ip_all"]
-    ports:
-      - "27017:27017"
     healthcheck:
       test: echo "try { rs.status() } catch (err) { rs.initiate({_id:'rs0',members:[{_id:0,host:'mongodb:27017'}]}) }" | mongosh --port 27017 --quiet
       interval: 5s

--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -36,8 +36,6 @@ services:
   redis:
     image: ghcr.io/bluewave-labs/checkmate:redis-demo
     restart: always
-    ports:
-      - "6379:6379"
     volumes:
       - ./redis/data:/data
     healthcheck:
@@ -50,8 +48,6 @@ services:
     image: ghcr.io/bluewave-labs/checkmate:mongo-demo
     restart: always
     command: ["mongod", "--quiet", "--replSet", "rs0", "--bind_ip_all"]
-    ports:
-      - "27017:27017"
     volumes:
       - ./mongo/data:/data/db
       # - ./mongo/init/init.js:/docker-entrypoint-initdb.d/init.js // No longer needed


### PR DESCRIPTION
There is no need to expose redis and mongo ports in docker compose