### PR TITLE
Fix: Translation Keys Missing

### DIFF
--- a/client/src/locales/gb.json
+++ b/client/src/locales/gb.json
@@ -130,7 +130,7 @@
 	"http": "HTTP",
 	"monitor": "monitor",
 	"aboutus": "About Us",
-
+	"state": "State",
 	"now": "Now",
 	"delete": "Delete",
 	"configure": "Configure",
@@ -387,6 +387,8 @@
 	"statusPageStatusNotPublic": "This status page is not public.",
 	"statusPageStatusNoPage": "There's no status page here.",
 	"statusPageStatusServiceStatus": "Service status",
+	"statusBreadCrumbsStatusPages": "Status Pages",
+	"statusBreadCrumbsDetails": "Details",
 	"deleteStatusPage": "Do you want to delete this status page?",
 	"deleteStatusPageConfirm": "Yes, delete status page",
 	"deleteStatusPageDescription": "Once deleted, your status page cannot be retrieved.",
@@ -456,8 +458,8 @@
 		"overview": "Here's an overview of your {{type}} monitors."
 	},
 	"monitorStatus": {
-		"up": "up",
-		"down": "down",
+		"up": "Up",
+		"down": "Down",
 		"paused": "paused"
 	},
 	"roles": {
@@ -490,9 +492,9 @@
 		}
 	},
 	"monitorState": {
-		"paused": "paused",
-		"resumed": "resumed",
-		"active": "active"
+		"paused": "Paused",
+		"resumed": "Resumed",
+		"active": "Active"
 	},
 	"menu": {
 		"uptime": "Uptime",


### PR DESCRIPTION
 ## Describe your changes

This PR address the missing keys from translations.

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new localized text for "State" and status page breadcrumbs.
- **Style**
  - Updated capitalization for monitor status and state labels for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->