### PR TITLE
Fix: Infra Monitors Filters

### DIFF
--- a/client/src/Pages/Infrastructure/Monitors/Components/MonitorsTable/index.jsx
+++ b/client/src/Pages/Infrastructure/Monitors/Components/MonitorsTable/index.jsx
@@ -68,8 +68,16 @@ const MonitorsTable = ({ shouldRender, monitors, isAdmin, handleActionMenuDelete
 			),
 		},
 		{ id: "cpu", content: t("cpu"), render: (row) => <CustomGauge progress={row.cpu} /> },
-		{ id: "memory", content: t("memory"), render: (row) => <CustomGauge progress={row.mem} /> },
-		{ id: "disk", content: t("disk"), render: (row) => <CustomGauge progress={row.disk} /> },
+		{
+			id: "memory",
+			content: t("memory"),
+			render: (row) => <CustomGauge progress={row.mem} />,
+		},
+		{
+			id: "disk",
+			content: t("disk"),
+			render: (row) => <CustomGauge progress={row.disk} />,
+		},
 		{
 			id: "actions",
 			content: t("actions"),
@@ -129,6 +137,7 @@ const MonitorsTable = ({ shouldRender, monitors, isAdmin, handleActionMenuDelete
 					},
 				},
 				onRowClick: (row) => openDetails(row.id),
+				emptyView: "No monitors found",
 			}}
 		/>
 	);

--- a/client/src/Pages/Infrastructure/Monitors/index.jsx
+++ b/client/src/Pages/Infrastructure/Monitors/index.jsx
@@ -73,7 +73,7 @@ const InfrastructureMonitors = () => {
 		);
 	}
 
-	if (!isLoading && monitors?.length === 0) {
+	if (!isLoading && summary?.totalMonitors === undefined) {
 		return (
 			<Fallback
 				vowelStart={true}

--- a/client/src/Pages/Infrastructure/Monitors/index.jsx
+++ b/client/src/Pages/Infrastructure/Monitors/index.jsx
@@ -73,7 +73,7 @@ const InfrastructureMonitors = () => {
 		);
 	}
 
-	if (!isLoading && summary?.totalMonitors === undefined) {
+	if (!isLoading && typeof summary?.totalMonitors === "undefined" ) {
 		return (
 			<Fallback
 				vowelStart={true}


### PR DESCRIPTION
## Describe your changes

This PR addresses a bug on the infrastructure monitors page. Previously, selecting a filter that was the opposite of the available monitors would lead to a placeholder screen being displayed.

Fixes #2233 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

![Screenshot 2025-05-12 144257](https://github.com/user-attachments/assets/ad687cb7-6b72-451f-b3f3-0736c332700d)
![Screenshot 2025-05-12 144403](https://github.com/user-attachments/assets/9a41eb2e-32cb-498e-b30d-64cfcfb2271e)
![Screenshot 2025-05-12 144534](https://github.com/user-attachments/assets/414125b4-bd47-4c16-a403-6ec3cc709460)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a message "No monitors found" to be displayed when the monitors table is empty.

- **Refactor**
  - Improved the logic for displaying fallback content when no monitors are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->