### PR TITLE
fix: TypeError in hardware notifications for null disk values

### DIFF
--- a/server/service/notificationService.js
+++ b/server/service/notificationService.js
@@ -257,7 +257,7 @@ class NotificationService {
 		const alerts = {
 			cpu: cpuThreshold !== -1 && cpuUsage > cpuThreshold ? true : false,
 			memory: memoryThreshold !== -1 && memoryUsage > memoryThreshold ? true : false,
-			disk: disk?.some(d => diskThreshold !== -1 && d.usage_percent > diskThreshold) ?? false,
+			disk: disk?.some(d => diskThreshold !== -1 && typeof d?.usage_percent === "number" && d?.usage_percent > diskThreshold) ?? false,
 		};
 
 		const notifications = await this.db.getNotificationsByMonitorId(

--- a/server/service/notificationService.js
+++ b/server/service/notificationService.js
@@ -257,9 +257,7 @@ class NotificationService {
 		const alerts = {
 			cpu: cpuThreshold !== -1 && cpuUsage > cpuThreshold ? true : false,
 			memory: memoryThreshold !== -1 && memoryUsage > memoryThreshold ? true : false,
-			disk: disk.some((d) => diskThreshold !== -1 && d.usage_percent > diskThreshold)
-				? true
-				: false,
+			disk: disk?.some(d => diskThreshold !== -1 && d.usage_percent > diskThreshold) ?? false,
 		};
 
 		const notifications = await this.db.getNotificationsByMonitorId(


### PR DESCRIPTION
## Describe your changes

Fixed a TypeError that occurs in the hardware notification handling when disk values are null. Used optional chaining (?.) and nullish coalescing (??) operators to safely handle null disk values when checking disk usage thresholds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of disk usage alerts by preventing errors when disk data is missing or unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->