### PR TITLE
Fix: Port Validation Uptime

### DIFF
--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -171,7 +171,7 @@ const monitorValidation = joi.object({
 		.max(65535)
 		.when("type", {
 			is: "port",
-			then: joi.required().messages({
+			then: joi.number().messages({
 				"number.base": "Port must be a number.",
 				"number.min": "Port must be at least 1.",
 				"number.max": "Port must be at most 65535.",


### PR DESCRIPTION
## Describe your changes

This PR fixes a validation issue for creating Port Uptime Monitors.

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The port field is now optional when configuring monitors of type "port", allowing users to leave this field blank if desired. Error messages for invalid port numbers remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->