### PR TITLE
feat: unified details header

### DIFF
--- a/client/src/Components/MonitorDetailsControlHeader/index.jsx
+++ b/client/src/Components/MonitorDetailsControlHeader/index.jsx
@@ -1,0 +1,80 @@
+import Stack from "@mui/material/Stack";
+import Status from "./status";
+import Skeleton from "./skeleton";
+import Button from "@mui/material/Button";
+import SettingsOutlinedIcon from "@mui/icons-material/SettingsOutlined";
+import PauseOutlinedIcon from "@mui/icons-material/PauseOutlined";
+import PlayArrowOutlinedIcon from "@mui/icons-material/PlayArrowOutlined";
+
+// Utils
+import PropTypes from "prop-types";
+import { useNavigate } from "react-router-dom";
+import { useTheme } from "@mui/material/styles";
+import { usePauseMonitor } from "../../Hooks/useMonitorControls";
+import { useEffect } from "react";
+const MonitorDetailsControlHeader = ({
+	path,
+	isLoading = false,
+	isAdmin = false,
+	monitor,
+	triggerUpdate,
+}) => {
+	const navigate = useNavigate();
+	const theme = useTheme();
+	const [pauseMonitor, updatedMonitor, isPausing, error] = usePauseMonitor({
+		monitorId: monitor?._id,
+		triggerUpdate,
+	});
+
+	if (isLoading) {
+		return <Skeleton />;
+	}
+
+	return (
+		<Stack
+			direction="row"
+			justifyContent="space-between"
+		>
+			<Status monitor={monitor} />
+
+			<Stack
+				direction="row"
+				gap={theme.spacing(2)}
+			>
+				<Button
+					variant="contained"
+					color="secondary"
+					startIcon={
+						monitor?.isActive ? <PauseOutlinedIcon /> : <PlayArrowOutlinedIcon />
+					}
+					onClick={() => {
+						pauseMonitor();
+					}}
+				>
+					{monitor?.isActive ? "Pause" : "Resume"}
+				</Button>
+
+				{isAdmin && (
+					<Button
+						variant="contained"
+						color="secondary"
+						startIcon={<SettingsOutlinedIcon />}
+						onClick={() => navigate(`/${path}/configure/${monitor._id}`)}
+					>
+						Configure
+					</Button>
+				)}
+			</Stack>
+		</Stack>
+	);
+};
+
+MonitorDetailsControlHeader.propTypes = {
+	path: PropTypes.string,
+	isLoading: PropTypes.bool,
+	isAdmin: PropTypes.bool,
+	monitor: PropTypes.object,
+	triggerUpdate: PropTypes.func,
+};
+
+export default MonitorDetailsControlHeader;

--- a/client/src/Components/MonitorDetailsControlHeader/index.jsx
+++ b/client/src/Components/MonitorDetailsControlHeader/index.jsx
@@ -21,7 +21,7 @@ const MonitorDetailsControlHeader = ({
 }) => {
 	const navigate = useNavigate();
 	const theme = useTheme();
-	const [pauseMonitor, updatedMonitor, isPausing, error] = usePauseMonitor({
+	const [pauseMonitor, isPausing, error] = usePauseMonitor({
 		monitorId: monitor?._id,
 		triggerUpdate,
 	});
@@ -44,6 +44,7 @@ const MonitorDetailsControlHeader = ({
 				<Button
 					variant="contained"
 					color="secondary"
+					loading={isPausing}
 					startIcon={
 						monitor?.isActive ? <PauseOutlinedIcon /> : <PlayArrowOutlinedIcon />
 					}

--- a/client/src/Components/MonitorDetailsControlHeader/index.jsx
+++ b/client/src/Components/MonitorDetailsControlHeader/index.jsx
@@ -11,7 +11,20 @@ import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import { useTheme } from "@mui/material/styles";
 import { usePauseMonitor } from "../../Hooks/useMonitorControls";
-import { useEffect } from "react";
+
+/**
+ * MonitorDetailsControlHeader component displays the control header for monitor details.
+ * It includes status display, pause/resume button, and a configure button for admins.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {string} props.path - The base path for navigation
+ * @param {boolean} [props.isLoading=false] - Flag indicating if the data is loading
+ * @param {boolean} [props.isAdmin=false] - Flag indicating if the user is an admin
+ * @param {Object} props.monitor - The monitor object containing details
+ * @param {Function} props.triggerUpdate - Function to trigger an update
+ * @returns {JSX.Element} The rendered component
+ */
 const MonitorDetailsControlHeader = ({
 	path,
 	isLoading = false,

--- a/client/src/Components/MonitorDetailsControlHeader/skeleton.jsx
+++ b/client/src/Components/MonitorDetailsControlHeader/skeleton.jsx
@@ -1,0 +1,23 @@
+import { Stack, Skeleton } from "@mui/material";
+
+const SkeletonLayout = () => {
+	return (
+		<Stack
+			direction="row"
+			justifyContent="space-between"
+		>
+			<Skeleton
+				height={40}
+				variant="rounded"
+				width="15%"
+			/>
+			<Skeleton
+				height={40}
+				variant="rounded"
+				width="15%"
+			/>
+		</Stack>
+	);
+};
+
+export default SkeletonLayout;

--- a/client/src/Components/MonitorDetailsControlHeader/status.jsx
+++ b/client/src/Components/MonitorDetailsControlHeader/status.jsx
@@ -1,0 +1,44 @@
+// Components
+import Stack from "@mui/material/Stack";
+import PulseDot from "../../Components/Animated/PulseDot";
+import Typography from "@mui/material/Typography";
+import Dot from "../../Components/Dot";
+// Utils
+import { formatDurationRounded } from "../../Utils/timeUtils";
+import PropTypes from "prop-types";
+import { useTheme } from "@emotion/react";
+import useUtils from "../../Pages/Uptime/Monitors/Hooks/useUtils";
+
+const Status = ({ monitor }) => {
+	const theme = useTheme();
+	const { statusColor, determineState } = useUtils();
+
+	return (
+		<Stack>
+			<Typography variant="h1">{monitor?.name}</Typography>
+			<Stack
+				direction="row"
+				alignItems={"center"}
+				gap={theme.spacing(4)}
+			>
+				<PulseDot color={statusColor[determineState(monitor)]} />
+				<Typography
+					variant="h2"
+					style={{ fontFamily: "monospace", fontWeight: "bolder" }}
+				>
+					{monitor?.url?.replace(/^https?:\/\//, "") || "..."}
+				</Typography>
+				<Dot />
+				<Typography>
+					Checking every {formatDurationRounded(monitor?.interval)}.
+				</Typography>
+			</Stack>
+		</Stack>
+	);
+};
+
+Status.propTypes = {
+	monitor: PropTypes.object,
+};
+
+export default Status;

--- a/client/src/Components/MonitorDetailsControlHeader/status.jsx
+++ b/client/src/Components/MonitorDetailsControlHeader/status.jsx
@@ -9,6 +9,18 @@ import PropTypes from "prop-types";
 import { useTheme } from "@emotion/react";
 import useUtils from "../../Pages/Uptime/Monitors/Hooks/useUtils";
 
+/**
+ * Status component displays the status information of a monitor.
+ * It includes the monitor's name, URL, and check interval.
+ *
+ * @component
+ * @param {Object} props - Component props
+ * @param {Object} props.monitor - The monitor object containing details
+ * @param {string} props.monitor.name - The name of the monitor
+ * @param {string} props.monitor.url - The URL of the monitor
+ * @param {number} props.monitor.interval - The interval at which the monitor checks
+ * @returns {JSX.Element} The rendered component
+ */
 const Status = ({ monitor }) => {
 	const theme = useTheme();
 	const { statusColor, determineState } = useUtils();

--- a/client/src/Hooks/useFetchUptimeMonitorDetails.js
+++ b/client/src/Hooks/useFetchUptimeMonitorDetails.js
@@ -3,13 +3,12 @@ import { networkService } from "../main";
 import { useNavigate } from "react-router-dom";
 import { createToast } from "../Utils/toastUtils";
 
-export const useFetchUptimeMonitorDetails = ({ monitorId, dateRange }) => {
+export const useFetchUptimeMonitorDetails = ({ monitorId, dateRange, trigger }) => {
 	const [networkError, setNetworkError] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
 	const [monitor, setMonitor] = useState(undefined);
 	const [monitorStats, setMonitorStats] = useState(undefined);
 	const navigate = useNavigate();
-
 	useEffect(() => {
 		const fetchMonitors = async () => {
 			try {
@@ -29,7 +28,7 @@ export const useFetchUptimeMonitorDetails = ({ monitorId, dateRange }) => {
 			}
 		};
 		fetchMonitors();
-	}, [dateRange, monitorId, navigate]);
+	}, [dateRange, monitorId, navigate, trigger]);
 	return [monitor, monitorStats, isLoading, networkError];
 };
 

--- a/client/src/Hooks/useMonitorControls.js
+++ b/client/src/Hooks/useMonitorControls.js
@@ -5,12 +5,10 @@ import { createToast } from "../Utils/toastUtils";
 const usePauseMonitor = ({ monitorId, triggerUpdate }) => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState(undefined);
-	const [monitor, setMonitor] = useState(undefined);
 	const pauseMonitor = async () => {
 		try {
-			setIsLoading(false);
+			setIsLoading(true);
 			const res = await networkService.pauseMonitorById({ monitorId });
-			setMonitor(res.data.data);
 			createToast({
 				body: res.data.data.isActive
 					? "Monitor resumed successfully"

--- a/client/src/Hooks/useMonitorControls.js
+++ b/client/src/Hooks/useMonitorControls.js
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { networkService } from "../main";
+import { createToast } from "../Utils/toastUtils";
+
+const usePauseMonitor = ({ monitorId, triggerUpdate }) => {
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState(undefined);
+	const [monitor, setMonitor] = useState(undefined);
+	const pauseMonitor = async () => {
+		try {
+			setIsLoading(false);
+			const res = await networkService.pauseMonitorById({ monitorId });
+			setMonitor(res.data.data);
+			createToast({
+				body: res.data.data.isActive
+					? "Monitor resumed successfully"
+					: "Monitor paused successfully",
+			});
+			triggerUpdate();
+		} catch (error) {
+			setError(error);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return [pauseMonitor, isLoading, error];
+};
+
+export { usePauseMonitor };

--- a/client/src/Pages/Uptime/Configure/index.jsx
+++ b/client/src/Pages/Uptime/Configure/index.jsx
@@ -158,23 +158,6 @@ const Configure = () => {
 		}
 	};
 
-	const handlePause = async () => {
-		try {
-			const action = await dispatch(pauseUptimeMonitor({ monitorId }));
-			if (pauseUptimeMonitor.fulfilled.match(action)) {
-				const monitor = action.payload.data;
-				setMonitor(monitor);
-				const state = action?.payload?.data.isActive === false ? "paused" : "resumed";
-				createToast({ body: `Monitor ${state} successfully.` });
-			} else if (pauseUptimeMonitor.rejected.match(action)) {
-				throw new Error(action.error.message);
-			}
-		} catch (error) {
-			logger.error("Error pausing monitor: " + monitorId);
-			createToast({ body: "Failed to pause monitor" });
-		}
-	};
-
 	const handleSubmit = async (event) => {
 		event.preventDefault();
 		const action = await dispatch(updateUptimeMonitor({ monitor: monitor }));
@@ -329,38 +312,6 @@ const Configure = () => {
 									ml: "auto",
 								}}
 							>
-								<Button
-									variant="contained"
-									color="secondary"
-									loading={isLoading}
-									sx={{
-										pl: theme.spacing(4),
-										pr: theme.spacing(6),
-										mr: theme.spacing(6),
-										"& svg": {
-											mr: theme.spacing(2),
-											width: 22,
-											height: 22,
-											"& path": {
-												stroke: theme.palette.primary.contrastTextTertiary,
-												strokeWidth: 1.7,
-											},
-										},
-									}}
-									onClick={handlePause}
-								>
-									{monitor?.isActive ? (
-										<>
-											<PauseIcon />
-											{t("pause")}
-										</>
-									) : (
-										<>
-											<ResumeIcon />
-											{t("resume")}
-										</>
-									)}
-								</Button>
 								<Button
 									loading={isLoading}
 									variant="contained"

--- a/client/src/Pages/Uptime/Details/index.jsx
+++ b/client/src/Pages/Uptime/Details/index.jsx
@@ -1,5 +1,6 @@
 // Components
 import Breadcrumbs from "../../../Components/Breadcrumbs";
+import MonitorDetailsControlHeader from "../../../Components/MonitorDetailsControlHeader";
 import MonitorStatusHeader from "../../../Components/MonitorStatusHeader";
 import MonitorTimeFrameHeader from "../../../Components/MonitorTimeFrameHeader";
 import ChartBoxes from "./Components/ChartBoxes";
@@ -36,9 +37,9 @@ const UptimeDetails = () => {
 
 	// Local state
 	const [dateRange, setDateRange] = useState("recent");
-
 	const [page, setPage] = useState(0);
 	const [rowsPerPage, setRowsPerPage] = useState(5);
+	const [trigger, setTrigger] = useState(false);
 
 	// Utils
 	const dateFormat =
@@ -52,6 +53,7 @@ const UptimeDetails = () => {
 		useFetchUptimeMonitorDetails({
 			monitorId,
 			dateRange,
+			trigger,
 		});
 
 	const monitor = monitorData?.monitor;
@@ -73,6 +75,11 @@ const UptimeDetails = () => {
 	});
 
 	// Handlers
+	const triggerUpdate = () => {
+		console.log("trigger update");
+		setTrigger(!trigger);
+	};
+
 	const handlePageChange = (_, newPage) => {
 		setPage(newPage);
 	};
@@ -101,11 +108,12 @@ const UptimeDetails = () => {
 		return (
 			<Stack gap={theme.spacing(10)}>
 				<Breadcrumbs list={BREADCRUMBS} />
-				<MonitorStatusHeader
+				<MonitorDetailsControlHeader
 					path={"uptime"}
 					isAdmin={isAdmin}
-					shouldRender={!monitorIsLoading}
+					isLoading={monitorIsLoading}
 					monitor={monitor}
+					triggerUpdate={triggerUpdate}
 				/>
 				<GenericFallback>
 					<Typography>{t("distributedUptimeDetailsNoMonitorHistory")}</Typography>
@@ -117,11 +125,12 @@ const UptimeDetails = () => {
 	return (
 		<Stack gap={theme.spacing(10)}>
 			<Breadcrumbs list={BREADCRUMBS} />
-			<MonitorStatusHeader
+			<MonitorDetailsControlHeader
 				path={"uptime"}
 				isAdmin={isAdmin}
 				isLoading={monitorIsLoading}
 				monitor={monitor}
+				triggerUpdate={triggerUpdate}
 			/>
 			<UptimeStatusBoxes
 				isLoading={monitorIsLoading}

--- a/client/src/Pages/Uptime/Details/index.jsx
+++ b/client/src/Pages/Uptime/Details/index.jsx
@@ -76,7 +76,6 @@ const UptimeDetails = () => {
 
 	// Handlers
 	const triggerUpdate = () => {
-		console.log("trigger update");
 		setTrigger(!trigger);
 	};
 

--- a/server/controllers/monitorController.js
+++ b/server/controllers/monitorController.js
@@ -595,8 +595,8 @@ class MonitorController {
 				{ new: true }
 			);
 			monitor.isActive === true
-				? await this.jobQueue.deleteJob(monitor)
-				: await this.jobQueue.addJob(monitor._id, monitor);
+				? await this.jobQueue.addJob(monitor._id, monitor)
+				: await this.jobQueue.deleteJob(monitor);
 
 			return res.success({
 				msg: monitor.isActive


### PR DESCRIPTION
This PR is the first in a series to implement a unified control header for all monitor details pages.  It implements the pause button.

![image](https://github.com/user-attachments/assets/1727ea57-fe1d-46ba-a0d1-805baee8c6be)

- [x] Create a new unified header component
- [x] Add pause and config buttons
- [x] Add a hook for monitor controls.  Currently contains pausing, will eventualyl contain deleting
- [x] Fix backwards job addition/deletion during pausing on server side   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new monitor details control header with status display and pause/resume functionality.
  - Added a loading skeleton for the monitor details control header.
  - Added a status indicator component for monitors.
  - Implemented the ability to pause or resume monitors directly from the details view.

- **Improvements**
  - Enhanced monitor details page to allow real-time data refresh after pausing or resuming a monitor.

- **Bug Fixes**
  - Corrected the behavior of job queue operations when toggling a monitor's active state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->