### PR TITLE
feat: settings test email endpoint

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -241,11 +241,12 @@ const startApp = async () => {
 		ServiceRegistry.get(EmailService.SERVICE_NAME)
 	);
 
-	const settingsController = new SettingsController(
-		ServiceRegistry.get(MongoDB.SERVICE_NAME),
-		ServiceRegistry.get(SettingsService.SERVICE_NAME),
-		ServiceRegistry.get(StringService.SERVICE_NAME)
-	);
+	const settingsController = new SettingsController({
+		db: ServiceRegistry.get(MongoDB.SERVICE_NAME),
+		settingsService: ServiceRegistry.get(SettingsService.SERVICE_NAME),
+		stringService: ServiceRegistry.get(StringService.SERVICE_NAME),
+		emailService: ServiceRegistry.get(EmailService.SERVICE_NAME),
+	});
 
 	const checkController = new CheckController(
 		ServiceRegistry.get(MongoDB.SERVICE_NAME),

--- a/server/routes/monitorRoute.js
+++ b/server/routes/monitorRoute.js
@@ -4,8 +4,8 @@ import multer from "multer";
 import { fetchMonitorCertificate } from "../controllers/controllerUtils.js";
 
 const upload = multer({
-	storage: multer.memoryStorage() // Store file in memory as Buffer
-  });
+	storage: multer.memoryStorage(), // Store file in memory as Buffer
+});
 
 class MonitorRoutes {
 	constructor(monitorController) {

--- a/server/routes/settingsRoute.js
+++ b/server/routes/settingsRoute.js
@@ -15,6 +15,11 @@ class SettingsRoutes {
 			isAllowed(["admin", "superadmin"]),
 			this.settingsController.updateAppSettings
 		);
+		this.router.post(
+			"/test-email",
+			isAllowed(["admin", "superadmin"]),
+			this.settingsController.sendTestEmail
+		);
 	}
 
 	getRouter() {

--- a/server/service/emailService.js
+++ b/server/service/emailService.js
@@ -89,8 +89,16 @@ class EmailService {
 	 * @param {string} subject - The subject of the email.
 	 * @returns {Promise<string>} A promise that resolves to the messageId of the sent email.
 	 */
-	buildAndSendEmail = async (template, context, to, subject) => {
+	buildAndSendEmail = async (template, context, to, subject, transportConfig) => {
 		// TODO - Consider an update transporter method so this only needs to be recreated when smtp settings change
+		let config;
+
+		if (typeof transportConfig !== "undefined") {
+			config = transportConfig;
+		} else {
+			config = this.settingsService.getDBSettings();
+		}
+
 		const {
 			systemEmailHost,
 			systemEmailPort,
@@ -98,7 +106,7 @@ class EmailService {
 			systemEmailAddress,
 			systemEmailPassword,
 			systemEmailConnectionHost,
-		} = await this.settingsService.getDBSettings();
+		} = config;
 
 		const baseEmailConfig = {
 			host: systemEmailHost,

--- a/server/validation/joi.js
+++ b/server/validation/joi.js
@@ -591,6 +591,16 @@ const createAnnouncementValidation = joi.object({
 	userId: joi.string().required(),
 });
 
+const sendTestEmailBodyValidation = joi.object({
+	to: joi.string().required(),
+	systemEmailHost: joi.string(),
+	systemEmailPort: joi.number(),
+	systemEmailAddress: joi.string(),
+	systemEmailPassword: joi.string(),
+	systemEmailUser: joi.string(),
+	systemEmailConnectionHost: joi.string(),
+});
+
 export {
 	roleValidatior,
 	loginValidation,
@@ -654,4 +664,5 @@ export {
 	triggerNotificationBodyValidation,
 	webhookConfigValidation,
 	createAnnouncementValidation,
+	sendTestEmailBodyValidation,
 };


### PR DESCRIPTION
This PR creates a new endpoint to allow sending test emails from the settings page without first saving to db

- [x] Add a new route to settings router `POST /api/v1/settings/test-email`
- [x] Add a controller method for handling settings page test email
- [x] Add optional transport config params to build and send email methods
- [x] Add validation for test email request body

Requests should be formatted as follows:

```
curl --request POST \
  --url http://localhost:52345/api/v1/settings/test-email \
  --header 'Authorization: Bearer <token> \
  --header 'Content-Type: application/json' \
  --data '{
	"to": "ajhollid@gmail.com",
	"systemEmailHost": "smtp.gmail.com",
	"systemEmailPort": 465,
	"systemEmailAddress": "bluewaveuptime@gmail.com",
	"systemEmailPassword": <password>
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint to send a test email from the settings page, allowing admins and superadmins to verify email configuration.
- **Bug Fixes**
  - Improved validation for test email requests to ensure correct input before sending.
- **Chores**
  - Updated internal dependency injection and configuration handling for email services to enhance flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->