### PR TITLE
hotfix: remove showurl validation

### DIFF
--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -23,7 +23,8 @@ const lastnameSchema = joi
 	.messages({
 		"string.empty": "Surname is required",
 		"string.max": "Surname must be less than 50 characters",
-		"string.pattern.base": "Surname must contain only letters, spaces, apostrophes, or hyphens"
+		"string.pattern.base":
+			"Surname must contain only letters, spaces, apostrophes, or hyphens",
 	});
 
 const passwordSchema = joi
@@ -103,70 +104,69 @@ const credentials = joi.object({
 });
 
 const monitorValidation = joi.object({
-	url: joi
-		.when("type", {
-			is: "docker",
-			then: joi
-				.string()
-				.trim()
-				.regex(/^[a-z0-9]{64}$/)
-				.messages({
-					"string.empty": "This field is required.",
-					"string.pattern.base": "Please enter a valid 64-character Docker container ID.",
-				}),
-			otherwise: joi
-				.string()
-				.trim()
-				.custom((value, helpers) => {
-					// Regex from https://gist.github.com/dperini/729294
-					var urlRegex = new RegExp(
-						"^" +
-							// protocol identifier (optional)
-							// short syntax // still required
-							"(?:(?:https?|ftp):\\/\\/)?" +
-							// user:pass BasicAuth (optional)
-							"(?:" +
-							// IP address dotted notation octets
-							// excludes loopback network 0.0.0.0
-							// excludes reserved space >= 224.0.0.0
-							// excludes network & broadcast addresses
-							// (first & last IP address of each class)
-							"(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
-							"(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
-							"(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
-							"|" +
-							// host & domain names, may end with dot
-							// can be replaced by a shortest alternative
-							// (?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.)+
-							"(?:" +
-							"(?:" +
-							"[a-z0-9\\u00a1-\\uffff]" +
-							"[a-z0-9\\u00a1-\\uffff_-]{0,62}" +
-							")?" +
-							"[a-z0-9\\u00a1-\\uffff]\\." +
-							")+" +
-							// TLD identifier name, may end with dot
-							"(?:[a-z\\u00a1-\\uffff]{2,}\\.?)" +
-							")" +
-							// port number (optional)
-							"(?::\\d{2,5})?" +
-							// resource path (optional)
-							"(?:[/?#]\\S*)?" +
-							"$",
-						"i"
-					);
-					if (!urlRegex.test(value)) {
-						return helpers.error("string.invalidUrl");
-					}
+	url: joi.when("type", {
+		is: "docker",
+		then: joi
+			.string()
+			.trim()
+			.regex(/^[a-z0-9]{64}$/)
+			.messages({
+				"string.empty": "This field is required.",
+				"string.pattern.base": "Please enter a valid 64-character Docker container ID.",
+			}),
+		otherwise: joi
+			.string()
+			.trim()
+			.custom((value, helpers) => {
+				// Regex from https://gist.github.com/dperini/729294
+				var urlRegex = new RegExp(
+					"^" +
+						// protocol identifier (optional)
+						// short syntax // still required
+						"(?:(?:https?|ftp):\\/\\/)?" +
+						// user:pass BasicAuth (optional)
+						"(?:" +
+						// IP address dotted notation octets
+						// excludes loopback network 0.0.0.0
+						// excludes reserved space >= 224.0.0.0
+						// excludes network & broadcast addresses
+						// (first & last IP address of each class)
+						"(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
+						"(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
+						"(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
+						"|" +
+						// host & domain names, may end with dot
+						// can be replaced by a shortest alternative
+						// (?![-_])(?:[-\\w\\u00a1-\\uffff]{0,63}[^-_]\\.)+
+						"(?:" +
+						"(?:" +
+						"[a-z0-9\\u00a1-\\uffff]" +
+						"[a-z0-9\\u00a1-\\uffff_-]{0,62}" +
+						")?" +
+						"[a-z0-9\\u00a1-\\uffff]\\." +
+						")+" +
+						// TLD identifier name, may end with dot
+						"(?:[a-z\\u00a1-\\uffff]{2,}\\.?)" +
+						")" +
+						// port number (optional)
+						"(?::\\d{2,5})?" +
+						// resource path (optional)
+						"(?:[/?#]\\S*)?" +
+						"$",
+					"i"
+				);
+				if (!urlRegex.test(value)) {
+					return helpers.error("string.invalidUrl");
+				}
 
-					return value;
-				})
-				.messages({
-					"string.empty": "This field is required.",
-					"string.uri": "The URL you provided is not valid.",
-					"string.invalidUrl": "Please enter a valid URL with optional port",
-				}),
-		}),
+				return value;
+			})
+			.messages({
+				"string.empty": "This field is required.",
+				"string.uri": "The URL you provided is not valid.",
+				"string.invalidUrl": "Please enter a valid URL with optional port",
+			}),
+	}),
 	port: joi
 		.number()
 		.integer()
@@ -277,7 +277,6 @@ const settingsValidation = joi.object({
 	}),
 	pagespeedApiKey: joi.string().allow("").optional(),
 	language: joi.string().required(),
-	showURL: joi.bool().required(),
 	systemEmailHost: joi.string().allow(""),
 	systemEmailPort: joi.number().allow(null, ""),
 	systemEmailAddress: joi.string().allow(""),


### PR DESCRIPTION
showURL was added to FE validation, but it's state in the for is not updated preventing form from being submitted.

There is also no error state that indicates the field needs to be selected.

This PR removes the front end validation for now until a proper implementation can be executed.