### PR TITLE
Fix Maintenance Placeholder Flash (#2286)

### DIFF
--- a/client/src/Pages/Maintenance/index.jsx
+++ b/client/src/Pages/Maintenance/index.jsx
@@ -25,6 +25,7 @@ const Maintenance = () => {
 	const [sort, setSort] = useState({});
 	const [updateTrigger, setUpdateTrigger] = useState(false);
 	const [networkError, setNetworkError] = useState(false);
+	const [isDataFetched, setIsDataFetched] = useState(false);
 
 	const handleActionMenuDelete = () => {
 		setUpdateTrigger((prev) => !prev);
@@ -42,6 +43,8 @@ const Maintenance = () => {
 				setMaintenanceWindowCount(maintenanceWindowCount);
 			} catch (error) {
 				setNetworkError(true);
+			} finally {
+				setIsDataFetched(true);
 			}
 		};
 		fetchMaintenanceWindows();
@@ -61,7 +64,8 @@ const Maintenance = () => {
 			</GenericFallback>
 		);
 	}
-	if (maintenanceWindows.length === 0) {
+	// Only show the fallback if we've fetched data and there are no maintenance windows
+	if (isDataFetched && maintenanceWindows.length === 0) {
 		return (
 			<Fallback
 				title="maintenance window"


### PR DESCRIPTION
## Describe your changes

### Issue
When the Maintenance menu is clicked, the placeholder is shown for less than 1 second, even when there is at least 1 Maintenance item in the table.

### Solution
Added an `isDataFetched ` flag to track when data fetching completes
Modified the conditional rendering to only show the Fallback component when:
- Data has been fetched (`isDataFetched` is `true` )
- AND there are no maintenance windows (`maintenanceWindows.length === 0` )
## Write your issue number after "Fixes "

Fixes #2286 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I have no hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

https://github.com/user-attachments/assets/af2485f8-944b-49a9-b70f-5a7a11cdf3fe



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display of the fallback message on the Maintenance page so it only appears after maintenance data has finished loading, preventing premature fallback messages before data is fetched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->