### PR TITLE
fix: add empty query object to fix default destructuring, resolves #2386

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -404,7 +404,8 @@ class AuthController {
 			// 1. Find all the monitors associated with the team ID if superadmin
 
 			const result = await this.db.getMonitorsByTeamId({
-				params: { teamId: user.teamId },
+				query: {},
+				params: { teamId: user.teamId.toString() },
 			});
 
 			if (user.role.includes("superadmin")) {


### PR DESCRIPTION
This PR fixes an issue related to a missing `query` parameter

- [x] Add missing query param