### PR TITLE
fix: implement delete cascade

### DIFF
--- a/client/src/Components/Charts/ChartBox/index.jsx
+++ b/client/src/Components/Charts/ChartBox/index.jsx
@@ -43,7 +43,6 @@ const ChartBox = ({
 		>
 			<Stack
 				flex={1}
-
 				sx={{
 					padding: theme.spacing(8),
 					justifyContent,

--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -414,9 +414,6 @@ class AuthController {
 					(await Promise.all(
 						result.monitors.map(async (monitor) => {
 							await this.jobQueue.deleteJob(monitor);
-							await this.db.deleteChecks(monitor._id);
-							await this.db.deletePageSpeedChecksByMonitorId(monitor._id);
-							await this.db.deleteNotificationsByMonitorId(monitor._id);
 						})
 					));
 


### PR DESCRIPTION
This PR uses MongoDB middleware to implement a casdade-like delete functionality for monitors.  When a monitor is deleted, related documents like `checks` and `monitorStats` are also deleted.

- [x] Implement predelete middleware
- [x] Remove explicit deleting of related documents, allow middleware to handle 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined the deletion process for monitors and users by relocating associated data removal to the database layer for better consistency.
- **Bug Fixes**
	- Improved data integrity by ensuring related check and stats records are deleted automatically when monitors are removed.
- **Chores**
	- Cleaned up redundant and complex deletion logic from user and monitor management workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->