### PR TITLE
hotfix: duplicate strings, remove uptime percentage

### DIFF
--- a/client/src/Pages/Infrastructure/Details/Components/StatusBoxes/index.jsx
+++ b/client/src/Pages/Infrastructure/Details/Components/StatusBoxes/index.jsx
@@ -14,7 +14,7 @@ const InfraStatBoxes = ({ shouldRender, monitor }) => {
 	const { determineState } = useUtils();
 	const { t } = useTranslation();
 
-	const { stats, uptimePercentage } = monitor ?? {};
+	const { stats } = monitor ?? {};
 	const latestCheck = stats?.aggregateData?.latestCheck;
 
 	// Get data from latest check
@@ -95,7 +95,7 @@ const InfraStatBoxes = ({ shouldRender, monitor }) => {
 				heading={t("disk")}
 				subHeading={formatBytes(diskTotalBytes)}
 			/>
-			<StatBox
+			{/* <StatBox
 				heading={t("uptime")}
 				subHeading={
 					<>
@@ -103,7 +103,7 @@ const InfraStatBoxes = ({ shouldRender, monitor }) => {
 						<Typography component="span">%</Typography>
 					</>
 				}
-			/>
+			/> */}
 			<StatBox
 				key={8}
 				heading={t("os")}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -614,7 +614,9 @@
 	"monitorStatus": {
 		"up": "up",
 		"down": "down",
-		"paused": "paused"
+		"paused": "paused",
+		"checkingEvery": "Checking every {{interval}}",
+		"withCaptureAgent": "with Capture agent {{version}}"
 	},
 	"roles": {
 		"superAdmin": "Super admin",
@@ -723,9 +725,5 @@
 		"ping": "Enter the IP address or hostname to ping (e.g., 192.168.1.100 or example.com) and add a clear display name that appears on the dashboard.",
 		"docker": "Enter the Docker ID of your container. Docker IDs must be the full 64 char Docker ID. You can run docker inspect <short_id> to get the full container ID.",
 		"port": "Enter the URL or IP of the server, the port number and a clear display name that appears on the dashboard."
-	},
-	"monitorStatus": {
-		"checkingEvery": "Checking every {{interval}}",
-		"withCaptureAgent": "with Capture agent {{version}}"
 	}
 }


### PR DESCRIPTION
There was a duplicate `monitorStatus` objet in the locale file leading to a render problem on the uptime page.

- [x] Dedpulicate strings
- [x] Remove uptime percentage from Infra monitors page, it is no longer calculated in the Monitor object 