### PR TITLE
feat: add row click handling to notificaitons table

### DIFF
--- a/client/src/Hooks/useNotifications.js
+++ b/client/src/Hooks/useNotifications.js
@@ -131,7 +131,7 @@ const useEditNotification = () => {
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState(null);
 	const { t } = useTranslation();
-
+	const navigate = useNavigate();
 	const editNotification = async (id, notification) => {
 		try {
 			setIsLoading(true);
@@ -139,6 +139,7 @@ const useEditNotification = () => {
 			createToast({
 				body: t("notifications.edit.success"),
 			});
+			navigate(`/notifications`);
 		} catch (error) {
 			setError(error);
 			createToast({

--- a/client/src/Pages/Notifications/index.jsx
+++ b/client/src/Pages/Notifications/index.jsx
@@ -119,6 +119,16 @@ const Notifications = () => {
 			</Stack>
 			<Typography variant="h1">{t("notifications.createTitle")}</Typography>
 			<DataTable
+				config={{
+					onRowClick: (row) => navigate(`/notifications/${row._id}`),
+					rowSX: {
+						cursor: "pointer",
+						"&:hover td": {
+							backgroundColor: theme.palette.tertiary.main,
+							transition: "background-color .3s ease",
+						},
+					},
+				}}
 				headers={headers}
 				data={notifications}
 			/>


### PR DESCRIPTION
This PR adds a row click handler to the notificaitons channel table. 

- [x]  Add row click handler and styles to Notificaitons channel data table
- [x]  Redirect to `/notifications` after editing a notification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - After editing a notification, users are now automatically redirected to the notifications list page.
  - Clicking on a notification row in the notifications table now navigates directly to the detailed view for that notification.

- **Style**
  - Notification table rows now display a pointer cursor and highlight with a smooth background color transition on hover for improved interactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->