### PR TITLE
fix: update TextInput border color to match dropdown (#2406)

### DIFF
--- a/client/src/Utils/Theme/globalTheme.js
+++ b/client/src/Utils/Theme/globalTheme.js
@@ -302,63 +302,63 @@ const baseTheme = (palette) => ({
 		},
 
 		MuiTextField: {
-  			styleOverrides: {
-    			root: ({ theme }) => ({
-      				"& fieldset": {
-        				borderColor: theme.palette.primary.lowContrast,
-        				borderRadius: theme.shape.borderRadius,
-      				},
+			styleOverrides: {
+				root: ({ theme }) => ({
+					"& fieldset": {
+						borderColor: theme.palette.primary.lowContrast,
+						borderRadius: theme.shape.borderRadius,
+					},
 
-					 "& .MuiInputBase-input": {
-        				padding: ".75em",
-        				minHeight: "var(--env-var-height-2)",
-        				fontSize: "var(--env-var-font-size-medium)",
-        				fontWeight: 400,
-        				color: palette.primary.contrastTextSecondary,
-        				"&.Mui-disabled": {
-          					opacity: 0.3,
-          					WebkitTextFillColor: "unset",
-        				},
-        				"& .Mui-focused": {
-          					/* color: "#ff0000", */
-          					/* borderColor: theme.palette.primary.contrastText, */
-        				},
-      				},
+					"& .MuiInputBase-input": {
+						padding: ".75em",
+						minHeight: "var(--env-var-height-2)",
+						fontSize: "var(--env-var-font-size-medium)",
+						fontWeight: 400,
+						color: palette.primary.contrastTextSecondary,
+						"&.Mui-disabled": {
+							opacity: 0.3,
+							WebkitTextFillColor: "unset",
+						},
+						"& .Mui-focused": {
+							/* color: "#ff0000", */
+							/* borderColor: theme.palette.primary.contrastText, */
+						},
+					},
 
-      				"& .MuiInputBase-input:-webkit-autofill": {
-        				transition: "background-color 5000s ease-in-out 0s",
-        				WebkitBoxShadow: `0 0 0px 1000px ${theme.palette.primary.main} inset`,
-        				WebkitTextFillColor: theme.palette.primary.contrastText,
-      				},
+					"& .MuiInputBase-input:-webkit-autofill": {
+						transition: "background-color 5000s ease-in-out 0s",
+						WebkitBoxShadow: `0 0 0px 1000px ${theme.palette.primary.main} inset`,
+						WebkitTextFillColor: theme.palette.primary.contrastText,
+					},
 
-      				"& .MuiInputBase-input.MuiOutlinedInput-input": {
-        				padding: "0 var(--env-var-spacing-1-minus) !important",
-      				},
+					"& .MuiInputBase-input.MuiOutlinedInput-input": {
+						padding: "0 var(--env-var-spacing-1-minus) !important",
+					},
 
-      				"& .MuiOutlinedInput-root": {
-        				color: theme.palette.primary.contrastTextSecondary,
-        				borderRadius: 4,
-      				},
+					"& .MuiOutlinedInput-root": {
+						color: theme.palette.primary.contrastTextSecondary,
+						borderRadius: 4,
+					},
 
-      				"& .MuiOutlinedInput-notchedOutline": {
-        				borderRadius: 4,
-      				},
+					"& .MuiOutlinedInput-notchedOutline": {
+						borderRadius: 4,
+					},
 
-      				"& .MuiFormHelperText-root": {
-        				color: palette.error.main,
-        				opacity: 0.8,
-        				fontSize: "var(--env-var-font-size-medium)",
-        				marginLeft: 0,
-      				},
+					"& .MuiFormHelperText-root": {
+						color: palette.error.main,
+						opacity: 0.8,
+						fontSize: "var(--env-var-font-size-medium)",
+						marginLeft: 0,
+					},
 
-      				"& .MuiFormHelperText-root.Mui-error": {
-      					opacity: 0.8,
-      					fontSize: "var(--env-var-font-size-medium)",
-      					color: palette.error.main,
-      					whiteSpace: "nowrap",
-      				},
-      			}),
-      		},
+					"& .MuiFormHelperText-root.Mui-error": {
+						opacity: 0.8,
+						fontSize: "var(--env-var-font-size-medium)",
+						color: palette.error.main,
+						whiteSpace: "nowrap",
+					},
+				}),
+			},
 		},
 
 		MuiOutlinedInput: {

--- a/client/src/Utils/Theme/globalTheme.js
+++ b/client/src/Utils/Theme/globalTheme.js
@@ -302,59 +302,65 @@ const baseTheme = (palette) => ({
 		},
 
 		MuiTextField: {
-			styleOverrides: {
-				root: ({ theme }) => ({
-					"& fieldset": {
-						borderColor: theme.palette.primary.contrastBorder,
-						borderRadius: theme.shape.borderRadius,
-					},
+  			styleOverrides: {
+    			root: ({ theme }) => ({
+      				"& fieldset": {
+        				borderColor: theme.palette.primary.lowContrast,
+        				borderRadius: theme.shape.borderRadius,
+      				},
 
-					"& .MuiInputBase-input": {
-						padding: ".75em",
-						minHeight: "var(--env-var-height-2)",
-						fontSize: "var(--env-var-font-size-medium)",
-						fontWeight: 400,
-						color: palette.primary.contrastTextSecondary,
-						"&.Mui-disabled": {
-							opacity: 0.3,
-							WebkitTextFillColor: "unset",
-						},
-						"& .Mui-focused": {
-							/* color: "#ff0000", */
-							/* borderColor: theme.palette.primary.contrastText, */
-						},
-					},
-					"& .MuiInputBase-input:-webkit-autofill": {
-						transition: "background-color 5000s ease-in-out 0s",
-						WebkitBoxShadow: `0 0 0px 1000px ${theme.palette.primary.main} inset`,
-						WebkitTextFillColor: theme.palette.primary.contrastText,
-					},
-					"& .MuiInputBase-input.MuiOutlinedInput-input": {
-						padding: "0 var(--env-var-spacing-1-minus) !important",
-					},
-					"& .MuiOutlinedInput-root": {
-						color: theme.palette.primary.contrastTextSecondary,
-						borderRadius: 4,
-					},
-					"& .MuiOutlinedInput-notchedOutline": {
-						borderRadius: 4,
-					},
+					 "& .MuiInputBase-input": {
+        				padding: ".75em",
+        				minHeight: "var(--env-var-height-2)",
+        				fontSize: "var(--env-var-font-size-medium)",
+        				fontWeight: 400,
+        				color: palette.primary.contrastTextSecondary,
+        				"&.Mui-disabled": {
+          					opacity: 0.3,
+          					WebkitTextFillColor: "unset",
+        				},
+        				"& .Mui-focused": {
+          					/* color: "#ff0000", */
+          					/* borderColor: theme.palette.primary.contrastText, */
+        				},
+      				},
 
-					"& .MuiFormHelperText-root": {
-						color: palette.error.main,
-						opacity: 0.8,
-						fontSize: "var(--env-var-font-size-medium)",
-						marginLeft: 0,
-					},
-					"& .MuiFormHelperText-root.Mui-error": {
-						opacity: 0.8,
-						fontSize: "var(--env-var-font-size-medium)",
-						color: palette.error.main,
-						whiteSpace: "nowrap",
-					},
-				}),
-			},
+      				"& .MuiInputBase-input:-webkit-autofill": {
+        				transition: "background-color 5000s ease-in-out 0s",
+        				WebkitBoxShadow: `0 0 0px 1000px ${theme.palette.primary.main} inset`,
+        				WebkitTextFillColor: theme.palette.primary.contrastText,
+      				},
+
+      				"& .MuiInputBase-input.MuiOutlinedInput-input": {
+        				padding: "0 var(--env-var-spacing-1-minus) !important",
+      				},
+
+      				"& .MuiOutlinedInput-root": {
+        				color: theme.palette.primary.contrastTextSecondary,
+        				borderRadius: 4,
+      				},
+
+      				"& .MuiOutlinedInput-notchedOutline": {
+        				borderRadius: 4,
+      				},
+
+      				"& .MuiFormHelperText-root": {
+        				color: palette.error.main,
+        				opacity: 0.8,
+        				fontSize: "var(--env-var-font-size-medium)",
+        				marginLeft: 0,
+      				},
+
+      				"& .MuiFormHelperText-root.Mui-error": {
+      					opacity: 0.8,
+      					fontSize: "var(--env-var-font-size-medium)",
+      					color: palette.error.main,
+      					whiteSpace: "nowrap",
+      				},
+      			}),
+      		},
 		},
+
 		MuiOutlinedInput: {
 			styleOverrides: {
 				root: {
@@ -365,12 +371,12 @@ const baseTheme = (palette) => ({
 						borderColor: palette.primary.contrastBorderDisabled,
 					},
 					"&:hover .MuiOutlinedInput-notchedOutline": {
-						borderColor: palette.primary.contrastText, // Adjust hover border color
+						borderColor: palette.primary.lowContrast, // Adjust hover border color
 					},
 					"&.Mui-focused .MuiOutlinedInput-notchedOutline": {
 						borderColor: palette.accent.main, // Adjust focus border color
 					},
-					color: palette.primary.contrastTextTertiary,
+					color: palette.primary.contrastText,
 				},
 			},
 		},


### PR DESCRIPTION
I have updated the MuiTextField border color in the theme configuration to theme.palette.primary.lowContrast, ensuring the text field border matches the dropdown for UI consistency.

Changes:-
client/src/Utils/Theme/globalTheme.js configuration file: Changed borderColor to theme.palette.primary.lowContrast.
Fixes #2406 

Before:
![image](https://github.com/user-attachments/assets/96efb4bf-0aba-4fcc-a5d3-90cefb4f610c)
After:
![Screenshot from 2025-06-12 04-57-44](https://github.com/user-attachments/assets/eae9b578-a4b1-45cf-85b9-819233e2cf57)

- [x] I deployed the application locally.
- [x] I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (not applicable since no strings modified).
- [x] I have **not** included any files that are not related to my pull request.
- [x] I didn't use any hardcoded values.
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats the code.
- [x] I took a screenshot and attached to this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated input component styles for improved color consistency, including adjustments to border and text colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->