### PR TITLE
fix: remove team id from notifications

### DIFF
--- a/client/src/Hooks/useNotifications.js
+++ b/client/src/Hooks/useNotifications.js
@@ -37,15 +37,12 @@ const useGetNotificationsByTeamId = (updateTrigger) => {
 	const [notifications, setNotifications] = useState([]);
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState(null);
-	const { user } = useSelector((state) => state.auth);
 	const { t } = useTranslation();
 
 	const getNotifications = useCallback(async () => {
 		try {
 			setIsLoading(true);
-			const response = await networkService.getNotificationsByTeamId({
-				teamId: user.teamId,
-			});
+			const response = await networkService.getNotificationsByTeamId();
 			setNotifications(response?.data?.data ?? []);
 		} catch (error) {
 			setError(error);
@@ -55,7 +52,7 @@ const useGetNotificationsByTeamId = (updateTrigger) => {
 		} finally {
 			setIsLoading(false);
 		}
-	}, [user.teamId]);
+	}, [t]);
 
 	useEffect(() => {
 		getNotifications();

--- a/client/src/Pages/Notifications/index.jsx
+++ b/client/src/Pages/Notifications/index.jsx
@@ -17,7 +17,6 @@ import {
 	useDeleteNotification,
 } from "../../Hooks/useNotifications";
 import { useTranslation } from "react-i18next";
-import { useParams } from "react-router-dom";
 
 const Notifications = () => {
 	const navigate = useNavigate();

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -996,8 +996,7 @@ class NetworkService {
 	}
 
 	async getNotificationsByTeamId(config) {
-		const { teamId } = config;
-		return this.axiosInstance.get(`/notifications/team/${teamId}`);
+		return this.axiosInstance.get(`/notifications/team`);
 	}
 
 	async deleteNotificationById(config) {


### PR DESCRIPTION
This PR updates notificaiton methods to use team ID from JWT instead of accepting a parameter