### PR TITLE
fix: monitors remove team ID parameters

### DIFF
--- a/client/src/Hooks/useBulkMonitors.js
+++ b/client/src/Hooks/useBulkMonitors.js
@@ -9,8 +9,6 @@ export const useBulkMonitors = () => {
 
 		const formData = new FormData();
 		formData.append("csvFile", file);
-		formData.append("userId", user._id);
-		formData.append("teamId", user.teamId);
 
 		try {
 			const response = await networkService.createBulkMonitors(formData);

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -140,7 +140,7 @@ class NotificationController {
 
 	getNotificationsByTeamId = async (req, res, next) => {
 		try {
-			const notifications = await this.db.getNotificationsByTeamId(req.params.teamId);
+			const notifications = await this.db.getNotificationsByTeamId(req.user.teamId);
 			return res.success({
 				msg: "Notifications fetched successfully",
 				data: notifications,

--- a/server/db/mongo/modules/diagnosticModule.js
+++ b/server/db/mongo/modules/diagnosticModule.js
@@ -6,10 +6,7 @@ import {
 	buildMonitorSummaryByTeamIdPipeline,
 	buildMonitorsByTeamIdPipeline,
 	buildFilteredMonitorsByTeamIdPipeline,
-	buildDePINDetailsByDateRange,
-	buildDePINLatestChecks,
 } from "./monitorModuleQueries.js";
-import { getDateRange } from "./monitorModule.js";
 
 const getMonitorsByTeamIdExecutionStats = async (req) => {
 	try {

--- a/server/db/mongo/modules/monitorModule.js
+++ b/server/db/mongo/modules/monitorModule.js
@@ -3,7 +3,6 @@ import MonitorStats from "../../models/MonitorStats.js";
 import Check from "../../models/Check.js";
 import PageSpeedCheck from "../../models/PageSpeedCheck.js";
 import HardwareCheck from "../../models/HardwareCheck.js";
-import Notification from "../../models/Notification.js";
 import { NormalizeData, NormalizeDataUptimeDetails } from "../../../utils/dataUtils.js";
 import ServiceRegistry from "../../../service/serviceRegistry.js";
 import StringService from "../../../service/stringService.js";
@@ -15,14 +14,11 @@ import { ObjectId } from "mongodb";
 import {
 	buildUptimeDetailsPipeline,
 	buildHardwareDetailsPipeline,
-	buildMonitorStatsPipeline,
 	buildMonitorSummaryByTeamIdPipeline,
 	buildMonitorsByTeamIdPipeline,
 	buildMonitorsAndSummaryByTeamIdPipeline,
 	buildMonitorsWithChecksByTeamIdPipeline,
 	buildFilteredMonitorsByTeamIdPipeline,
-	buildDePINDetailsByDateRange,
-	buildDePINLatestChecks,
 } from "./monitorModuleQueries.js";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -335,11 +331,9 @@ const calculateGroupStats = (group) => {
  * @returns {Promise<Monitor>}
  * @throws {Error}
  */
-const getUptimeDetailsById = async (req) => {
+const getUptimeDetailsById = async ({ monitorId, dateRange, normalize }) => {
 	const stringService = ServiceRegistry.get(StringService.SERVICE_NAME);
 	try {
-		const { monitorId } = req.params;
-		const { dateRange, normalize } = req.query;
 		const dates = getDateRange(dateRange);
 		const formatLookup = {
 			recent: "%Y-%m-%dT%H:%M:00Z",
@@ -392,11 +386,16 @@ const getUptimeDetailsById = async (req) => {
  * @returns {Promise<Monitor>}
  * @throws {Error}
  */
-const getMonitorStatsById = async (req) => {
+const getMonitorStatsById = async ({
+	monitorId,
+	limit,
+	sortOrder,
+	dateRange,
+	numToDisplay,
+	normalize,
+}) => {
 	const stringService = ServiceRegistry.get(StringService.SERVICE_NAME);
 	try {
-		const { monitorId } = req.params;
-
 		// Get monitor, if we can't find it, abort with error
 		const monitor = await Monitor.findById(monitorId);
 		if (monitor === null || monitor === undefined) {
@@ -404,7 +403,6 @@ const getMonitorStatsById = async (req) => {
 		}
 
 		// Get query params
-		let { limit, sortOrder, dateRange, numToDisplay, normalize } = req.query;
 		const sort = sortOrder === "asc" ? 1 : -1;
 
 		// Get Checks for monitor in date range requested
@@ -454,10 +452,8 @@ const getMonitorStatsById = async (req) => {
 	}
 };
 
-const getHardwareDetailsById = async (req) => {
+const getHardwareDetailsById = async ({ monitorId, dateRange }) => {
 	try {
-		const { monitorId } = req.params;
-		const { dateRange } = req.query;
 		const monitor = await Monitor.findById(monitorId);
 		const dates = getDateRange(dateRange);
 		const formatLookup = {
@@ -509,8 +505,16 @@ const getMonitorById = async (monitorId) => {
 	}
 };
 
-const getMonitorsByTeamId = async (req) => {
-	let { limit, type, page, rowsPerPage, filter, field, order } = req.query;
+const getMonitorsByTeamId = async ({
+	limit,
+	type,
+	page,
+	rowsPerPage,
+	filter,
+	field,
+	order,
+	teamId,
+}) => {
 	limit = parseInt(limit);
 	page = parseInt(page);
 	rowsPerPage = parseInt(rowsPerPage);
@@ -519,7 +523,6 @@ const getMonitorsByTeamId = async (req) => {
 		order = "asc";
 	}
 	// Build match stage
-	const teamId = req.user.teamId;
 	const matchStage = { teamId: ObjectId.createFromHexString(teamId) };
 	if (type !== undefined) {
 		matchStage.type = Array.isArray(type) ? { $in: type } : type;
@@ -558,16 +561,15 @@ const getMonitorsByTeamId = async (req) => {
 	return { summary, monitors, filteredMonitors: normalizedFilteredMonitors };
 };
 
-const getMonitorsAndSummaryByTeamId = async (req) => {
+const getMonitorsAndSummaryByTeamId = async ({ type, explain, teamId }) => {
 	try {
-		const { type } = req.query;
-		const teamId = ObjectId.createFromHexString(req.user.teamId);
-		const matchStage = { teamId };
+		const parsedTeamId = ObjectId.createFromHexString(teamId);
+		const matchStage = { teamId: parsedTeamId };
 		if (type !== undefined) {
 			matchStage.type = Array.isArray(type) ? { $in: type } : type;
 		}
 
-		if (req.explain === true) {
+		if (explain === true) {
 			return Monitor.aggregate(
 				buildMonitorsAndSummaryByTeamIdPipeline({ matchStage })
 			).explain("executionStats");
@@ -585,9 +587,18 @@ const getMonitorsAndSummaryByTeamId = async (req) => {
 	}
 };
 
-const getMonitorsWithChecksByTeamId = async (req) => {
+const getMonitorsWithChecksByTeamId = async ({
+	limit,
+	type,
+	page,
+	rowsPerPage,
+	filter,
+	field,
+	order,
+	teamId,
+	explain,
+}) => {
 	try {
-		let { limit, type, page, rowsPerPage, filter, field, order } = req.query;
 		limit = parseInt(limit);
 		page = parseInt(page);
 		rowsPerPage = parseInt(rowsPerPage);
@@ -595,14 +606,14 @@ const getMonitorsWithChecksByTeamId = async (req) => {
 			field = "name";
 			order = "asc";
 		}
-		const teamId = ObjectId.createFromHexString(req.user.teamId);
+		const parsedTeamId = ObjectId.createFromHexString(teamId);
 		// Build match stage
-		const matchStage = { teamId };
+		const matchStage = { teamId: parsedTeamId };
 		if (type !== undefined) {
 			matchStage.type = Array.isArray(type) ? { $in: type } : type;
 		}
 
-		if (req.explain === true) {
+		if (explain === true) {
 			return Monitor.aggregate(
 				buildMonitorsWithChecksByTeamIdPipeline({
 					matchStage,
@@ -654,9 +665,9 @@ const getMonitorsWithChecksByTeamId = async (req) => {
  * @returns {Promise<Monitor>}
  * @throws {Error}
  */
-const createMonitor = async (req, res) => {
+const createMonitor = async (body) => {
 	try {
-		const monitor = new Monitor({ ...req.body });
+		const monitor = new Monitor({ ...body });
 		const saved = await monitor.save();
 		return saved;
 	} catch (error) {
@@ -695,10 +706,8 @@ const createBulkMonitors = async (req) => {
  * @returns {Promise<Monitor>}
  * @throws {Error}
  */
-const deleteMonitor = async (req, res) => {
+const deleteMonitor = async ({ monitorId }) => {
 	const stringService = ServiceRegistry.get(StringService.SERVICE_NAME);
-
-	const monitorId = req.params.monitorId;
 	try {
 		const monitor = await Monitor.findByIdAndDelete(monitorId);
 		if (!monitor) {
@@ -789,6 +798,29 @@ const addDemoMonitors = async (userId, teamId) => {
 	}
 };
 
+const pauseMonitor = async ({ monitorId }) => {
+	try {
+		const monitor = await Monitor.findOneAndUpdate(
+			{ _id: monitorId },
+			[
+				{
+					$set: {
+						isActive: { $not: "$isActive" },
+						status: "$$REMOVE",
+					},
+				},
+			],
+			{ new: true }
+		);
+
+		return monitor;
+	} catch (error) {
+		error.service = SERVICE_NAME;
+		error.method = "pauseMonitor";
+		throw error;
+	}
+};
+
 export {
 	getAllMonitors,
 	getAllMonitorsWithUptimeStats,
@@ -806,6 +838,7 @@ export {
 	editMonitor,
 	addDemoMonitors,
 	getHardwareDetailsById,
+	pauseMonitor,
 };
 
 // Helper functions

--- a/server/db/mongo/modules/monitorModuleQueries.js
+++ b/server/db/mongo/modules/monitorModuleQueries.js
@@ -902,102 +902,6 @@ const buildGetMonitorsByTeamIdPipeline = (req) => {
 	];
 };
 
-const buildDePINDetailsByDateRange = (monitor, dates, dateString) => {
-	return [
-		{
-			$match: {
-				monitorId: monitor._id,
-				updatedAt: { $gte: dates.start, $lte: dates.end },
-			},
-		},
-		{
-			$project: {
-				_id: 0,
-				city: 1,
-				updatedAt: 1,
-				"location.lat": 1,
-				"location.lng": 1,
-				responseTime: 1,
-			},
-		},
-		{
-			$facet: {
-				groupedMapChecks: [
-					{
-						$group: {
-							_id: {
-								city: "$city",
-								lat: "$location.lat",
-								lng: "$location.lng",
-							},
-
-							avgResponseTime: {
-								$avg: "$responseTime",
-							},
-						},
-					},
-				],
-				groupedChecks: [
-					{
-						$group: {
-							_id: {
-								date: {
-									$dateToString: {
-										format: dateString,
-										date: "$updatedAt",
-									},
-								},
-							},
-							avgResponseTime: {
-								$avg: "$responseTime",
-							},
-						},
-					},
-					{
-						$sort: {
-							"_id.date": 1,
-						},
-					},
-				],
-			},
-		},
-		{
-			$project: {
-				groupedMapChecks: "$groupedMapChecks",
-				groupedChecks: "$groupedChecks",
-			},
-		},
-	];
-};
-
-const buildDePINLatestChecks = (monitor) => {
-	return [
-		{
-			$match: {
-				monitorId: monitor._id,
-			},
-		},
-		{
-			$sort: { updatedAt: -1 },
-		},
-		{
-			$limit: 5,
-		},
-		{
-			$project: {
-				responseTime: 1,
-				city: 1,
-				countryCode: 1,
-				uptBurnt: {
-					$toString: {
-						$ifNull: ["$uptBurnt", 0],
-					},
-				},
-			},
-		},
-	];
-};
-
 export {
 	buildUptimeDetailsPipeline,
 	buildHardwareDetailsPipeline,
@@ -1008,6 +912,4 @@ export {
 	buildMonitorsAndSummaryByTeamIdPipeline,
 	buildMonitorsWithChecksByTeamIdPipeline,
 	buildFilteredMonitorsByTeamIdPipeline,
-	buildDePINDetailsByDateRange,
-	buildDePINLatestChecks,
 };

--- a/server/routes/notificationRoute.js
+++ b/server/routes/notificationRoute.js
@@ -17,10 +17,7 @@ class NotificationRoutes {
 
 		this.router.post("/", this.notificationController.createNotification);
 
-		this.router.get(
-			"/team/:teamId",
-			this.notificationController.getNotificationsByTeamId
-		);
+		this.router.get("/team", this.notificationController.getNotificationsByTeamId);
 
 		this.router.delete("/:id", this.notificationController.deleteNotification);
 


### PR DESCRIPTION
This PR removes team ID parameters from FE requests and instead fetches teamID from the user's token

It also standardizes parameters used in access DB layer instead of passing the whole request object.