### PR TITLE
fix: maintenance window team

### DIFF
--- a/server/controllers/maintenanceWindowController.js
+++ b/server/controllers/maintenanceWindowController.js
@@ -7,8 +7,6 @@ import {
 	getMaintenanceWindowsByTeamIdQueryValidation,
 	deleteMaintenanceWindowByIdParamValidation,
 } from "../validation/joi.js";
-import jwt from "jsonwebtoken";
-import { getTokenFromHeaders } from "../utils/utils.js";
 import { handleValidationError, handleError } from "./controllerUtils.js";
 
 const SERVICE_NAME = "maintenanceWindowController";
@@ -28,9 +26,7 @@ class MaintenanceWindowController {
 			return;
 		}
 		try {
-			const token = getTokenFromHeaders(req.headers);
-			const { jwtSecret } = this.settingsService.getSettings();
-			const { teamId } = jwt.verify(token, jwtSecret);
+			const { teamId } = req.user;
 			const monitorIds = req.body.monitors;
 			const dbTransactions = monitorIds.map((monitorId) => {
 				return this.db.createMaintenanceWindow({
@@ -81,9 +77,7 @@ class MaintenanceWindowController {
 		}
 
 		try {
-			const token = getTokenFromHeaders(req.headers);
-			const { jwtSecret } = this.settingsService.getSettings();
-			const { teamId } = jwt.verify(token, jwtSecret);
+			const { teamId } = req.user;
 			const maintenanceWindows = await this.db.getMaintenanceWindowsByTeamId(
 				teamId,
 				req.query


### PR DESCRIPTION
This PR updates maintenance window controller methods to get teamId from `req.user` instead of decoding the token again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to pause monitors, allowing users to toggle monitor activity status.

- **Refactor**
  - Improved parameter handling and user context retrieval across the app for greater consistency and clarity.
  - Standardized how team and user identification are managed, now relying on authenticated user context.
  - Cleaned up unused imports and removed obsolete code for better maintainability.

- **Bug Fixes**
  - Notifications are now always fetched based on the authenticated user's team, ensuring correct data access.

- **Chores**
  - Updated notifications endpoint to use a query parameter instead of a path parameter for team identification.
  - Removed unused code and imports for improved codebase hygiene.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->