### PR TITLE
fix: move style to global theme

### DIFF
--- a/client/src/Components/Inputs/Search/index.jsx
+++ b/client/src/Components/Inputs/Search/index.jsx
@@ -102,27 +102,7 @@ const Search = ({
 								...(endAdornment && { endAdornment: endAdornment }),
 							},
 						}}
-						sx={{
-							"& fieldset": {
-								borderColor: theme.palette.primary.lowContrast,
-								borderRadius: theme.shape.borderRadius,
-							},
-							"& .MuiOutlinedInput-root:hover:not(:has(input:focus)):not(:has(textarea:focus)) fieldset":
-								{
-									borderColor: theme.palette.primary.lowContrast,
-								},
-							"& .MuiOutlinedInput-root": {
-								paddingY: 0,
-							},
-							"& .MuiAutocomplete-tag": {
-								// CAIO_REVIEW
-								color: theme.palette.primary.contrastText,
-								backgroundColor: theme.palette.primary.lowContrast,
-							},
-							"& .MuiChip-deleteIcon": {
-								color: theme.palette.primary.contrastText, // CAIO_REVIEW
-							},
-						}}
+						sx={{}}
 					/>
 					{error && (
 						<Typography

--- a/client/src/Utils/Theme/globalTheme.js
+++ b/client/src/Utils/Theme/globalTheme.js
@@ -380,6 +380,33 @@ const baseTheme = (palette) => ({
 				},
 			},
 		},
+
+		MuiAutocomplete: {
+			styleOverrides: {
+				root: ({ theme }) => ({
+					"& .MuiOutlinedInput-root": {
+						paddingTop: 0,
+						paddingBottom: 0,
+					},
+					"& fieldset": {
+						borderColor: theme.palette.primary.lowContrast,
+						borderRadius: theme.shape.borderRadius,
+					},
+					"& .MuiOutlinedInput-root:hover:not(:has(input:focus)):not(:has(textarea:focus)) fieldset":
+						{
+							borderColor: theme.palette.primary.lowContrast,
+						},
+
+					"& .MuiAutocomplete-tag": {
+						color: theme.palette.primary.contrastText,
+						backgroundColor: theme.palette.primary.lowContrast,
+					},
+					"& .MuiChip-deleteIcon": {
+						color: theme.palette.primary.contrastText, // CAIO_REVIEW
+					},
+				}),
+			},
+		},
 		MuiTab: {
 			styleOverrides: {
 				root: ({ theme }) => ({


### PR DESCRIPTION
The style at the component level for Autocomplete was not being applied consistently.

Moving the style to the global theme resolves the issues, likely due to indeterminate style load order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the appearance of autocomplete fields, including input padding, border color, border radius, tag colors, and delete icon color, for a more consistent and visually appealing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->