### PR TITLE
Better URL Handling on Infrastructure Create Page

### DIFF
--- a/client/src/Pages/Infrastructure/Create/index.jsx
+++ b/client/src/Pages/Infrastructure/Create/index.jsx
@@ -89,8 +89,17 @@ const CreateInfrastructureMonitor = () => {
 	useEffect(() => {
 		if (isCreate || !monitor) return;
 
+		// Clean URL including any trailing slashes
+		let urlFixed = monitor.url.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+
+		// Create default port if none included
+		if (!/:\d+(\/|$)/.test(urlFixed)) urlFixed += ":59232";
+
+		// Ensure path is exactly /api/v1/metrics
+		urlFixed = urlFixed.replace(/\/.*$/, "") + "/api/v1/metrics";
+
 		setInfrastructureMonitor({
-			url: monitor.url.replace(/^https?:\/\//, ""),
+			url: urlFixed,
 			name: monitor.name || "",
 			notifications: monitor.notifications,
 			interval: monitor.interval / MS_PER_MINUTE,
@@ -231,9 +240,9 @@ const CreateInfrastructureMonitor = () => {
 					...(isCreate
 						? [{ name: "Create", path: "/infrastructure/create" }]
 						: [
-								{ name: "Details", path: `/infrastructure/${monitorId}` },
-								{ name: "Configure", path: `/infrastructure/configure/${monitorId}` },
-							]),
+							{ name: "Details", path: `/infrastructure/${monitorId}` },
+							{ name: "Configure", path: `/infrastructure/configure/${monitorId}` },
+						]),
 				]}
 			/>
 			<Stack
@@ -289,7 +298,7 @@ const CreateInfrastructureMonitor = () => {
 							id="url"
 							name="url"
 							startAdornment={<HttpAdornment https={https} />}
-							placeholder={"localhost:59232/api/v1/metrics"}
+							placeholder={"e.g. localhost or 192.168.1.100"}
 							label={t("infrastructureServerUrlLabel")}
 							https={https}
 							value={infrastructureMonitor.url}


### PR DESCRIPTION
This is a simple string manipulation involving 4 lines of code:

Clean the URL (already done but also removes any trailing "/")
Add the default Port Number if one does not exist already (:59232) - leaves the ability to have a non-default value.
Append 'api/v1/metrics' to the URL
Changing the default placeholder text to be "e.g. localhost or 192.168.1.100"

The code is designed to discard anything after a "/" so as to enforce the correct "/api/v1/metrics" - so even if it is there, it just discards it and adds it again.

I felt this was a very small change, string manipulation, that would make life easier for people like me running 20 different VMs, I already have to go install Capture on them all, might as well save a few minutes not having to type or copy a default value that never changes.

I know I have not completed the whole rebuild steps - but its 4 lines of string manipulation code, it can't break anything as it is simply a replace function, if its not there, it doesn't do it.