### PR TITLE
Feature: URL links on infrastructure page

### DIFF
--- a/client/src/Components/MonitorStatusHeader/index.jsx
+++ b/client/src/Components/MonitorStatusHeader/index.jsx
@@ -40,7 +40,17 @@ const MonitorStatusHeader = ({ path, isLoading = false, isAdmin, monitor }) => {
 						component="h2"
 						variant="monitorUrl"
 					>
-						{monitor?.url?.replace(/^https?:\/\//, "") || "..."}
+						{monitor?.link?.url ? (
+							<a
+								href={monitor.link.url}
+								target="_blank"
+								rel="noreferrer"
+							>
+								{monitor?.url?.replace(/^https?:\/\//, "") || "..."}
+							</a>
+						) : (
+							monitor?.url?.replace(/^https?:\/\//, "") || "..."
+						)}
 					</Typography>
 					<Dot />
 					<Typography>

--- a/client/src/Hooks/monitorHooks.js
+++ b/client/src/Hooks/monitorHooks.js
@@ -334,6 +334,7 @@ const useUpdateMonitor = () => {
 				...(monitor.type === "hardware" && {
 					thresholds: monitor.thresholds,
 					secret: monitor.secret,
+					...(monitor.link ? { link: monitor.link } : {}),
 				}),
 			};
 			await networkService.updateMonitor({

--- a/client/src/Pages/Infrastructure/Create/index.jsx
+++ b/client/src/Pages/Infrastructure/Create/index.jsx
@@ -71,6 +71,7 @@ const CreateInfrastructureMonitor = () => {
 	const [infrastructureMonitor, setInfrastructureMonitor] = useState({
 		url: "",
 		name: "",
+		linkUrl: "",
 		notifications: [],
 		notify_email: false,
 		interval: 0.25,
@@ -92,6 +93,7 @@ const CreateInfrastructureMonitor = () => {
 		setInfrastructureMonitor({
 			url: monitor.url.replace(/^https?:\/\//, ""),
 			name: monitor.name || "",
+			linkUrl: monitor.link?.url || "",
 			notifications: monitor.notifications,
 			interval: monitor.interval / MS_PER_MINUTE,
 			cpu: monitor.thresholds?.usage_cpu !== undefined,
@@ -127,6 +129,7 @@ const CreateInfrastructureMonitor = () => {
 				infrastructureMonitor.name === ""
 					? infrastructureMonitor.url
 					: infrastructureMonitor.name,
+			linkUrl: infrastructureMonitor.linkUrl,
 			interval: infrastructureMonitor.interval * MS_PER_MINUTE,
 			cpu: infrastructureMonitor.cpu,
 			...(infrastructureMonitor.cpu
@@ -172,6 +175,7 @@ const CreateInfrastructureMonitor = () => {
 			usage_disk,
 			temperature,
 			usage_temperature,
+			linkUrl,
 			...rest
 		} = form;
 
@@ -185,6 +189,7 @@ const CreateInfrastructureMonitor = () => {
 		form = {
 			...(isCreate ? {} : { _id: monitorId }),
 			...rest,
+			...(linkUrl ? { link: { url: linkUrl } } : {}),
 			description: form.name,
 			type: "hardware",
 			notifications: infrastructureMonitor.notifications,
@@ -329,6 +334,17 @@ const CreateInfrastructureMonitor = () => {
 							value={infrastructureMonitor.name}
 							onChange={onChange}
 							error={errors["name"]}
+						/>
+						<TextInput
+							type="text"
+							id="linkUrl"
+							name="linkUrl"
+							label={t("infrastructureLinkUrlLabel")}
+							placeholder="https://example.com"
+							isOptional={true}
+							value={infrastructureMonitor.linkUrl}
+							onChange={onChange}
+							error={errors["linkUrl"]}
 						/>
 						<TextInput
 							type="text"

--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -374,6 +374,9 @@ const infrastructureMonitorValidation = joi.object({
 	name: joi.string().trim().max(50).allow("").messages({
 		"string.max": "This field should not exceed the 50 characters limit.",
 	}),
+	linkUrl: joi.string().uri().allow("").messages({
+		"string.uri": "The link URL is not valid.",
+	}),
 	secret: joi.string().trim().messages({ "string.empty": "This field is required." }),
 	usage_cpu: joi.number().messages({
 		"number.base": THRESHOLD_COMMON_BASE_MSG,

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -434,6 +434,7 @@
 	"infrastructureServerUrlLabel": "Server URL",
 	"infrastructureDisplayNameLabel": "Display name",
 	"infrastructureAuthorizationSecretLabel": "Authorization secret",
+	"infrastructureLinkUrlLabel": "Link URL",
 	"gb": "GB",
 	"mb": "MB",
 	"mem": "Mem",

--- a/server/db/models/Monitor.js
+++ b/server/db/models/Monitor.js
@@ -87,6 +87,12 @@ const MonitorSchema = mongoose.Schema(
 		secret: {
 			type: String,
 		},
+		link: {
+			type: {
+				url: { type: String },
+			},
+			_id: false,
+		},
 	},
 	{
 		timestamps: true,

--- a/server/validation/joi.js
+++ b/server/validation/joi.js
@@ -181,6 +181,9 @@ const createMonitorBodyValidation = joi.object({
 	}),
 	notifications: joi.array().items(joi.string()),
 	secret: joi.string(),
+	link: joi.object({
+		url: joi.string(),
+	}),
 	jsonPath: joi.string().allow(""),
 	expectedValue: joi.string().allow(""),
 	matchMethod: joi.string(),
@@ -199,6 +202,9 @@ const editMonitorBodyValidation = joi.object({
 	interval: joi.number(),
 	notifications: joi.array().items(joi.string()),
 	secret: joi.string(),
+	link: joi.object({
+		url: joi.string(),
+	}),
 	ignoreTlsErrors: joi.boolean(),
 	jsonPath: joi.string().allow(""),
 	expectedValue: joi.string().allow(""),


### PR DESCRIPTION
## Describe your changes

I made it so that you can add an optional URL on the Infrastructure Create or Modify pages, which would then become a clickable link on the status page for that monitor.

## Write your issue number after "Fixes "

#2454 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

Here are some screen shots of the changes to the UI:

The infrastructure screen has not changed:

![image](https://github.com/user-attachments/assets/4f6db033-44d3-4971-9515-70d6779ce127)

This is what it looks like if you do not add an additional URL:

![image](https://github.com/user-attachments/assets/97cf73c8-576e-4476-a5c2-ff371c3a121d)

This is what it looks like if you edit the monitor that you have:

![image](https://github.com/user-attachments/assets/570f2761-a245-47eb-88ae-b4e9f40ec8c4)

Add a "url" for your application:

![image](https://github.com/user-attachments/assets/7b6dbede-9d12-40b1-b9e9-893e2cf8627f)

How it looks after you add it:

![image](https://github.com/user-attachments/assets/b2f27f26-09f2-472d-bbfa-fc584d5dc525)

This link opens up your application on a new page.

I feel the same could be added to the  Uptime page too, but wanted to try and keep this rather large change as direct as possible.  The monitor.link.url now exists though, so could be added elsewhere?