### PR TITLE
hotfix: safe rowsPerPage access

### DIFF
--- a/client/src/Pages/Infrastructure/Monitors/index.jsx
+++ b/client/src/Pages/Infrastructure/Monitors/index.jsx
@@ -23,7 +23,7 @@ const BREADCRUMBS = [{ name: `infrastructure`, path: "/infrastructure" }];
 
 const InfrastructureMonitors = () => {
 	// Redux state
-	const rowsPerPage = useSelector((state) => state.ui.infrastructure.rowsPerPage);
+	const rowsPerPage = useSelector((state) => state.ui?.infrastructure?.rowsPerPage ?? 5);
 	const dispatch = useDispatch();
 
 	// Local state

--- a/client/src/Pages/Maintenance/MaintenanceTable/index.jsx
+++ b/client/src/Pages/Maintenance/MaintenanceTable/index.jsx
@@ -34,7 +34,7 @@ const MaintenanceTable = ({
 	maintenanceWindowCount,
 	updateCallback,
 }) => {
-	const { rowsPerPage } = useSelector((state) => state.ui.maintenance);
+	const rowsPerPage = useSelector((state) => state?.ui?.maintenance?.rowsPerPage ?? 5);
 	const dispatch = useDispatch();
 
 	const handleChangePage = (event, newPage) => {

--- a/client/src/Pages/Maintenance/index.jsx
+++ b/client/src/Pages/Maintenance/index.jsx
@@ -17,7 +17,7 @@ const Maintenance = () => {
 	const theme = useTheme();
 	const { t } = useTranslation();
 	const navigate = useNavigate();
-	const { rowsPerPage } = useSelector((state) => state.ui.maintenance);
+	const rowsPerPage = useSelector((state) => state?.ui?.maintenance?.rowsPerPage ?? 5);
 	const isAdmin = useIsAdmin();
 	const [maintenanceWindows, setMaintenanceWindows] = useState([]);
 	const [maintenanceWindowCount, setMaintenanceWindowCount] = useState(0);

--- a/client/src/Pages/Uptime/Monitors/index.jsx
+++ b/client/src/Pages/Uptime/Monitors/index.jsx
@@ -64,7 +64,7 @@ CreateMonitorButton.propTypes = {
 
 const UptimeMonitors = () => {
 	// Redux state
-	const rowsPerPage = useSelector((state) => state.ui.monitors.rowsPerPage);
+	const rowsPerPage = useSelector((state) => state.ui?.monitors?.rowsPerPage ?? 10);
 
 	// Local state
 	const [search, setSearch] = useState(undefined);


### PR DESCRIPTION
The `rowsPerPage` var is not safely extracted form the redux state.  Add optional chaining and defautl value to safely access a `rowsPerPage` value on load.