### PR TITLE
feat: discord notification channel

### DIFF
--- a/client/src/Pages/Notifications/create/index.jsx
+++ b/client/src/Pages/Notifications/create/index.jsx
@@ -130,7 +130,7 @@ const CreateNotifications = () => {
 			(type) => type._id === newNotification.type
 		).value;
 
-		if (newNotification.type === "email") {
+		if (type === "email") {
 			newNotification.config = null;
 		} else if (type === "slack" || type === "webhook" || type === "discord") {
 			newNotification.address = "";

--- a/client/src/Pages/Notifications/create/index.jsx
+++ b/client/src/Pages/Notifications/create/index.jsx
@@ -10,7 +10,6 @@ import TextInput from "../../../Components/Inputs/TextInput";
 
 // Utils
 import { useState } from "react";
-import { useSelector } from "react-redux";
 import { useTheme } from "@emotion/react";
 import {
 	useCreateNotification,
@@ -44,7 +43,6 @@ const CreateNotifications = () => {
 	];
 
 	// Redux state
-	const { user } = useSelector((state) => state.auth);
 
 	// local state
 	const [notification, setNotification] = useState({
@@ -73,7 +71,7 @@ const CreateNotifications = () => {
 			type: NOTIFICATION_TYPES.find((type) => type._id === notification.type).value,
 		};
 
-		if (notification.type === 2) {
+		if (form.type === "slack" || form.type === "discord") {
 			form.type = "webhook";
 		}
 
@@ -128,27 +126,33 @@ const CreateNotifications = () => {
 
 		// Handle config/platform initialization if type is webhook
 
-		if (newNotification.type === 1) {
+		const type = NOTIFICATION_TYPES.find(
+			(type) => type._id === newNotification.type
+		).value;
+
+		if (newNotification.type === "email") {
 			newNotification.config = null;
-		} else if (newNotification.type === 2) {
+		} else if (type === "slack" || type === "webhook" || type === "discord") {
 			newNotification.address = "";
 			newNotification.config = newNotification.config || {};
 			if (name === "config") {
 				newNotification.config = value;
 			}
-			newNotification.config.platform = "slack";
-		} else if (newNotification.type === 3) {
+			if (type === "webhook") {
+				newNotification.config.platform = "webhook";
+			}
+			if (type === "slack") {
+				newNotification.config.platform = "slack";
+			}
+			if (type === "discord") {
+				newNotification.config.platform = "discord";
+			}
+		} else if (type === "pager_duty") {
 			newNotification.config = newNotification.config || {};
 			if (name === "config") {
 				newNotification.config = value;
 			}
 			newNotification.config.platform = "pager_duty";
-		} else if (newNotification.type === 4) {
-			newNotification.config = newNotification.config || {};
-			if (name === "config") {
-				newNotification.config = value;
-			}
-			newNotification.config.platform = "webhook";
 		}
 
 		// Field-level validation
@@ -159,12 +163,15 @@ const CreateNotifications = () => {
 			fieldError = error?.message;
 		}
 
-		if (newNotification.type === 1 && name === "address") {
+		if (type === "email" && name === "address") {
 			const { error } = notificationEmailValidation.extract(name).validate(value);
 			fieldError = error?.message;
 		}
 
-		if (newNotification.type === 2 && name === "config") {
+		if (
+			(type === "slack" || type === "webhook" || type === "discord") &&
+			name === "config"
+		) {
 			// Validate only webhookUrl inside config
 			const { error } = notificationWebhookValidation.extract("config").validate(value);
 			fieldError = error?.message;
@@ -185,7 +192,7 @@ const CreateNotifications = () => {
 			type: NOTIFICATION_TYPES.find((type) => type._id === notification.type).value,
 		};
 
-		if (notification.type === 2) {
+		if (form.type === "slack" || form.type === "discord") {
 			form.type = "webhook";
 		}
 
@@ -385,6 +392,39 @@ const CreateNotifications = () => {
 						<Stack gap={theme.spacing(12)}>
 							<TextInput
 								label={t("createNotifications.genericWebhookSettings.webhookLabel")}
+								value={notification.config.webhookUrl || ""}
+								error={Boolean(errors.config)}
+								helperText={errors["config"]}
+								onChange={(e) => {
+									const updatedConfig = {
+										...notification.config,
+										webhookUrl: e.target.value,
+									};
+
+									onChange({
+										target: {
+											name: "config",
+											value: updatedConfig,
+										},
+									});
+								}}
+							/>
+						</Stack>
+					</ConfigBox>
+				)}
+				{notification.type === 5 && (
+					<ConfigBox>
+						<Box>
+							<Typography component="h2">
+								{t("createNotifications.discordSettings.title")}
+							</Typography>
+							<Typography component="p">
+								{t("createNotifications.discordSettings.description")}
+							</Typography>
+						</Box>
+						<Stack gap={theme.spacing(12)}>
+							<TextInput
+								label={t("createNotifications.discordSettings.webhookLabel")}
 								value={notification.config.webhookUrl || ""}
 								error={Boolean(errors.config)}
 								helperText={errors["config"]}

--- a/client/src/Pages/Notifications/utils.js
+++ b/client/src/Pages/Notifications/utils.js
@@ -1,6 +1,7 @@
 export const NOTIFICATION_TYPES = [
 	{ _id: 1, name: "E-mail", value: "email" },
-	{ _id: 2, name: "Slack", value: "webhook" },
+	{ _id: 2, name: "Slack", value: "slack" },
 	{ _id: 3, name: "PagerDuty", value: "pager_duty" },
 	{ _id: 4, name: "Webhook", value: "webhook" },
+	{ _id: 5, name: "Discord", value: "discord" },
 ];

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -298,6 +298,12 @@
 			"description": "Configure your webhook here",
 			"webhookLabel": "Webhook URL",
 			"webhookPlaceholder": "https://your-server.com/webhook"
+		},
+		"discordSettings": {
+			"title": "Discord",
+			"description": "Configure your Discord webhook here",
+			"webhookLabel": "Discord Webhook URL",
+			"webhookPlaceholder": "https://your-server.com/webhook"
 		}
 	},
 

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -102,6 +102,7 @@ class NotificationController {
 				success =
 					await this.notificationService.sendTestPagerDutyNotification(notification);
 			}
+
 			if (!success) {
 				return res.error({
 					msg: "Sending notification failed",
@@ -128,7 +129,11 @@ class NotificationController {
 		}
 
 		try {
-			const notification = await this.db.createNotification(req.body);
+			const body = req.body;
+			const { _id, teamId } = req.user;
+			body.userId = _id;
+			body.teamId = teamId;
+			const notification = await this.db.createNotification(body);
 			return res.success({
 				msg: "Notification created successfully",
 				data: notification,

--- a/server/db/models/Notification.js
+++ b/server/db/models/Notification.js
@@ -7,7 +7,7 @@ const configSchema = mongoose.Schema(
 		chatId: { type: String },
 		platform: {
 			type: String,
-			enum: ["slack", "pager_duty", "webhook"],
+			enum: ["slack", "pager_duty", "webhook", "discord"],
 		},
 		routingKey: { type: String },
 	},

--- a/server/validation/joi.js
+++ b/server/validation/joi.js
@@ -558,14 +558,6 @@ const triggerNotificationBodyValidation = joi.object({
 });
 
 const createNotificationBodyValidation = joi.object({
-	userId: joi.string().required().messages({
-		"number.empty": "User ID is required",
-		"any.required": "User ID is required",
-	}),
-	teamId: joi.string().required().messages({
-		"string.empty": "Team ID is required",
-		"any.required": "Team ID is required",
-	}),
 	notificationName: joi.string().required().messages({
 		"string.empty": "Notification name is required",
 		"any.required": "Notification name is required",


### PR DESCRIPTION
This PR adds `discord` types to the notification channels.  As these are actually just webhooks there is no special configuraiton required other than correctly formatting the message on the backend.

- [x] Add a discord type notification
- [x] Remove userId and teamId from submission and validation, this should be fetched from middleware
- [x] Simplify validation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Discord as a notification type, including UI options, configuration fields, and validation.
  - Discord webhook settings are now available with localized English labels and descriptions.

- **Improvements**
  - Notification type handling now uses descriptive string values instead of numeric IDs for clarity and consistency.
  - Slack notification type value corrected for more accurate platform assignment.
  - Internal validation and schema updated to support Discord and streamline notification creation.

- **Bug Fixes**
  - Improved field validation logic to match the updated notification type handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->