### PR TITLE
fix: pagespeed header

### DIFF
--- a/client/src/Hooks/monitorHooks.js
+++ b/client/src/Hooks/monitorHooks.js
@@ -170,6 +170,7 @@ const useFetchStatsByMonitorId = ({
 	dateRange,
 	numToDisplay,
 	normalize,
+	updateTrigger,
 }) => {
 	const [monitor, setMonitor] = useState(undefined);
 	const [audits, setAudits] = useState(undefined);
@@ -197,7 +198,7 @@ const useFetchStatsByMonitorId = ({
 			}
 		};
 		fetchMonitor();
-	}, [monitorId, dateRange, numToDisplay, normalize, sortOrder, limit]);
+	}, [monitorId, dateRange, numToDisplay, normalize, sortOrder, limit, updateTrigger]);
 	return [monitor, audits, isLoading, networkError];
 };
 

--- a/client/src/Pages/PageSpeed/Details/index.jsx
+++ b/client/src/Pages/PageSpeed/Details/index.jsx
@@ -4,6 +4,7 @@ import Breadcrumbs from "../../../Components/Breadcrumbs";
 import MonitorTimeFrameHeader from "../../../Components/MonitorTimeFrameHeader";
 import MonitorStatusHeader from "../../../Components/MonitorStatusHeader";
 import PageSpeedStatusBoxes from "./Components/PageSpeedStatusBoxes";
+import MonitorDetailsControlHeader from "../../../Components/MonitorDetailsControlHeader";
 import PageSpeedAreaChart from "./Components/PageSpeedAreaChart";
 import PerformanceReport from "./Components/PerformanceReport";
 import GenericFallback from "../../../Components/GenericFallback";
@@ -27,6 +28,15 @@ const PageSpeedDetails = () => {
 	const isAdmin = useIsAdmin();
 	const { monitorId } = useParams();
 
+	// Local state
+	const [metrics, setMetrics] = useState({
+		accessibility: true,
+		bestPractices: true,
+		performance: true,
+		seo: true,
+	});
+	const [trigger, setTrigger] = useState(false);
+	// Network
 	const [monitor, audits, isLoading, networkError] = useFetchStatsByMonitorId({
 		monitorId,
 		sortOrder: "desc",
@@ -34,13 +44,7 @@ const PageSpeedDetails = () => {
 		dateRange: "day",
 		numToDisplay: null,
 		normalize: null,
-	});
-
-	const [metrics, setMetrics] = useState({
-		accessibility: true,
-		bestPractices: true,
-		performance: true,
-		seo: true,
+		updateTrigger: trigger,
 	});
 
 	// Handlers
@@ -48,6 +52,9 @@ const PageSpeedDetails = () => {
 		setMetrics((prev) => ({ ...prev, [id]: !prev[id] }));
 	};
 
+	const triggerUpdate = () => {
+		setTrigger(!trigger);
+	};
 	if (networkError === true) {
 		return (
 			<GenericFallback>
@@ -68,10 +75,12 @@ const PageSpeedDetails = () => {
 		return (
 			<Stack gap={theme.spacing(10)}>
 				<Breadcrumbs list={BREADCRUMBS} />
-				<MonitorStatusHeader
+				<MonitorDetailsControlHeader
 					path={"pagespeed"}
+					isLoading={isLoading}
 					isAdmin={isAdmin}
 					monitor={monitor}
+					triggerUpdate={triggerUpdate}
 				/>
 				<GenericFallback>
 					<Typography>{t("distributedUptimeDetailsNoMonitorHistory")}</Typography>
@@ -83,11 +92,12 @@ const PageSpeedDetails = () => {
 	return (
 		<Stack gap={theme.spacing(10)}>
 			<Breadcrumbs list={BREADCRUMBS} />
-			<MonitorStatusHeader
+			<MonitorDetailsControlHeader
 				path={"pagespeed"}
+				isLoading={isLoading}
 				isAdmin={isAdmin}
-				shouldRender={!isLoading}
 				monitor={monitor}
+				triggerUpdate={triggerUpdate}
 			/>
 			<PageSpeedStatusBoxes
 				shouldRender={!isLoading}


### PR DESCRIPTION
PageSpeed details page was not using the universal details page header component.

- [x] Add universal header
- [x] Add update trigger to hook

![image](https://github.com/user-attachments/assets/46ed54ea-c77b-4e42-a6ac-9d8c9f990320)
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a manual refresh option to the monitor details page, allowing users to trigger an immediate update of monitor statistics.

- **Improvements**
  - Replaced the header component in the monitor details view with an enhanced version that displays loading status and supports manual data refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->