### PR TITLE
fix: add universal header to infra details

### DIFF
--- a/client/src/Hooks/monitorHooks.js
+++ b/client/src/Hooks/monitorHooks.js
@@ -220,7 +220,7 @@ const useFetchMonitorById = ({ monitorId, setMonitor, updateTrigger }) => {
 	return [isLoading];
 };
 
-const useFetchHardwareMonitorById = ({ monitorId, dateRange }) => {
+const useFetchHardwareMonitorById = ({ monitorId, dateRange, updateTrigger }) => {
 	const [isLoading, setIsLoading] = useState(true);
 	const [networkError, setNetworkError] = useState(false);
 	const [monitor, setMonitor] = useState(undefined);
@@ -243,7 +243,7 @@ const useFetchHardwareMonitorById = ({ monitorId, dateRange }) => {
 			}
 		};
 		fetchMonitor();
-	}, [monitorId, dateRange]);
+	}, [monitorId, dateRange, updateTrigger]);
 	return [monitor, isLoading, networkError];
 };
 

--- a/client/src/Pages/Infrastructure/Details/index.jsx
+++ b/client/src/Pages/Infrastructure/Details/index.jsx
@@ -1,7 +1,7 @@
 // Components
 import { Stack, Typography } from "@mui/material";
 import Breadcrumbs from "../../../Components/Breadcrumbs";
-import MonitorStatusHeader from "../../../Components/MonitorStatusHeader";
+import MonitorDetailsControlHeader from "../../../Components/MonitorDetailsControlHeader";
 import MonitorTimeFrameHeader from "../../../Components/MonitorTimeFrameHeader";
 import StatusBoxes from "./Components/StatusBoxes";
 import GaugeBoxes from "./Components/GaugeBoxes";
@@ -26,6 +26,7 @@ const InfrastructureDetails = () => {
 
 	// Local state
 	const [dateRange, setDateRange] = useState("recent");
+	const [trigger, setTrigger] = useState(false);
 
 	// Utils
 	const theme = useTheme();
@@ -36,7 +37,12 @@ const InfrastructureDetails = () => {
 	const [monitor, isLoading, networkError] = useFetchHardwareMonitorById({
 		monitorId,
 		dateRange,
+		updateTrigger: trigger,
 	});
+
+	const triggerUpdate = () => {
+		setTrigger(!trigger);
+	};
 
 	if (networkError === true) {
 		return (
@@ -57,11 +63,12 @@ const InfrastructureDetails = () => {
 		return (
 			<Stack gap={theme.spacing(10)}>
 				<Breadcrumbs list={BREADCRUMBS} />
-				<MonitorStatusHeader
+				<MonitorDetailsControlHeader
 					path={"infrastructure"}
-					isAdmin={false}
-					shouldRender={!isLoading}
+					isLoading={isLoading}
+					isAdmin={isAdmin}
 					monitor={monitor}
+					triggerUpdate={triggerUpdate}
 				/>
 				<GenericFallback>
 					<Typography>{t("distributedUptimeDetailsNoMonitorHistory")}</Typography>
@@ -73,11 +80,12 @@ const InfrastructureDetails = () => {
 	return (
 		<Stack gap={theme.spacing(10)}>
 			<Breadcrumbs list={BREADCRUMBS} />
-			<MonitorStatusHeader
+			<MonitorDetailsControlHeader
 				path={"infrastructure"}
+				isLoading={isLoading}
 				isAdmin={isAdmin}
-				shouldRender={!isLoading}
 				monitor={monitor}
+				triggerUpdate={triggerUpdate}
 			/>
 			<StatusBoxes
 				shouldRender={!isLoading}


### PR DESCRIPTION
Infrastructure Details page was not using universal details header:

- [x] Add header
- [x] Add trigger prop
![image](https://github.com/user-attachments/assets/8b239583-bda1-4286-b188-ca7b4619b27f)
 