### PR TITLE
fix: load monitor from params if present

### DIFF
--- a/client/src/Pages/Incidents/index.jsx
+++ b/client/src/Pages/Incidents/index.jsx
@@ -11,6 +11,7 @@ import { useFetchMonitorsByTeamId } from "../../Hooks/monitorHooks";
 import { useState, useEffect } from "react";
 import NetworkError from "../../Components/GenericFallback/NetworkError";
 import { useTranslation } from "react-i18next";
+import { useParams } from "react-router-dom";
 
 //Constants
 const Incidents = () => {
@@ -30,6 +31,13 @@ const Incidents = () => {
 	//Utils
 	const theme = useTheme();
 	const [monitors, , isLoading, networkError] = useFetchMonitorsByTeamId({});
+	const { monitorId } = useParams();
+
+	useEffect(() => {
+		if (monitorId) {
+			setSelectedMonitor(monitorId);
+		}
+	}, [monitorId]);
 
 	useEffect(() => {
 		const monitorLookup = monitors?.reduce((acc, monitor) => {


### PR DESCRIPTION
When visiting the incidents page from a link on the details page the specified monitor is not loaded.

This PR impelemnts loading a seleceted monitor from URL params if specified on the incidents page.

- [x] Extract `monitorId` from URL params
- [x] Set selected monitor based on this `monitorId`

Incidents page now loads correctly. 