### PR TITLE
fix: send test notifications

### DIFF
--- a/client/src/Components/MonitorDetailsControlHeader/index.jsx
+++ b/client/src/Components/MonitorDetailsControlHeader/index.jsx
@@ -14,6 +14,7 @@ import { useTheme } from "@mui/material/styles";
 import { usePauseMonitor } from "../../Hooks/monitorHooks";
 import { useSendTestEmail } from "../../Hooks/useSendTestEmail";
 import { useTranslation } from "react-i18next";
+import { useTestAllNotifications } from "../../Hooks/useNotifications";
 /**
  * MonitorDetailsControlHeader component displays the control header for monitor details.
  * It includes status display, pause/resume button, and a configure button for admins.
@@ -39,7 +40,10 @@ const MonitorDetailsControlHeader = ({
 	const { t } = useTranslation();
 	const [pauseMonitor, isPausing, error] = usePauseMonitor();
 
-	const [isSending, emailError, sendTestEmail] = useSendTestEmail();
+	// const [isSending, emailError, sendTestEmail] = useSendTestEmail();
+
+	const [testAllNotifications, isSending, errorAllNotifications] =
+		useTestAllNotifications();
 
 	if (isLoading) {
 		return <Skeleton />;
@@ -62,10 +66,10 @@ const MonitorDetailsControlHeader = ({
 					loading={isSending}
 					startIcon={<EmailIcon />}
 					onClick={() => {
-						sendTestEmail();
+						testAllNotifications({ monitorId: monitor?._id });
 					}}
 				>
-					{t("sendTestEmail")}
+					{t("sendTestNotifications")}
 				</Button>
 				<Button
 					variant="contained"

--- a/client/src/Hooks/useNotifications.js
+++ b/client/src/Hooks/useNotifications.js
@@ -174,6 +174,30 @@ const useTestNotification = () => {
 	return [testNotification, isLoading, error];
 };
 
+const useTestAllNotifications = () => {
+	const [isLoading, setIsLoading] = useState(false);
+	const [error, setError] = useState(undefined);
+	const { t } = useTranslation();
+	const testAllNotifications = async ({ monitorId }) => {
+		try {
+			setIsLoading(true);
+			await networkService.testAllNotifications({ monitorId });
+			createToast({
+				body: t("notifications.test.success"),
+			});
+		} catch (error) {
+			createToast({
+				body: error.response?.data?.msg || error.message,
+			});
+			setError(error);
+		} finally {
+			setIsLoading(false);
+		}
+	};
+
+	return [testAllNotifications, isLoading, error];
+};
+
 export {
 	useCreateNotification,
 	useGetNotificationsByTeamId,
@@ -181,4 +205,5 @@ export {
 	useGetNotificationById,
 	useEditNotification,
 	useTestNotification,
+	useTestAllNotifications,
 };

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -678,6 +678,16 @@ class NetworkService {
 		});
 	}
 
+	async testAllNotifications(config) {
+		const { monitorId } = config;
+		return this.axiosInstance.post("/notifications/test/all", {
+			monitorId,
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+	}
+
 	/**
 	 * ************************************
 	 * Creates a maintenance window

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -714,7 +714,7 @@
 		"saving": "Saving..."
 	},
 	"settingsEmailConnectionHost": "Email connection host - Hostname to use in the HELO/EHLO greeting",
-	"sendTestEmail": "Send test email",
+	"sendTestNotifications": "Send test notifications",
 	"emailSent": "Email sent successfully",
 	"failedToSendEmail": "Failed to send email",
 	"settingsTestEmail": "Send test e-mail",

--- a/server/controllers/monitorController.js
+++ b/server/controllers/monitorController.js
@@ -1,4 +1,3 @@
-import Monitor from "../db/models/Monitor.js";
 import {
 	getMonitorByIdParamValidation,
 	getMonitorByIdQueryValidation,
@@ -16,8 +15,6 @@ import {
 	getHardwareDetailsByIdQueryValidation,
 } from "../validation/joi.js";
 import sslChecker from "ssl-checker";
-import jwt from "jsonwebtoken";
-import { getTokenFromHeaders } from "../utils/utils.js";
 import logger from "../utils/logger.js";
 import { handleError, handleValidationError } from "./controllerUtils.js";
 import axios from "axios";

--- a/server/controllers/notificationController.js
+++ b/server/controllers/notificationController.js
@@ -193,6 +193,22 @@ class NotificationController {
 			next(handleError(error, SERVICE_NAME, "editNotification"));
 		}
 	};
+
+	testAllNotifications = async (req, res, next) => {
+		try {
+			const { monitorId } = req.body;
+			const monitor = await this.db.getMonitorById(monitorId);
+			const notifications = monitor.notifications;
+			if (notifications.length === 0) throw new Error("No notifications");
+			const result = await this.notificationService.testAllNotifications(notifications);
+			if (!result) throw new Error("Failed to send all notifications");
+			return res.success({
+				msg: "All notifications sent successfully",
+			});
+		} catch (error) {
+			next(handleError(error, SERVICE_NAME, "testAllNotifications"));
+		}
+	};
 }
 
 export default NotificationController;

--- a/server/routes/notificationRoute.js
+++ b/server/routes/notificationRoute.js
@@ -14,6 +14,7 @@ class NotificationRoutes {
 		this.router.post("/trigger", this.notificationController.triggerNotification);
 
 		this.router.post("/test", this.notificationController.testNotification);
+		this.router.post("/test/all", this.notificationController.testAllNotifications);
 
 		this.router.post("/", this.notificationController.createNotification);
 

--- a/server/service/notificationService.js
+++ b/server/service/notificationService.js
@@ -418,6 +418,29 @@ class NotificationService {
 			});
 		}
 	}
+
+	async testAllNotifications(notificationIDs) {
+		const notifications = await this.db.getNotificationsByIds(notificationIDs);
+
+		// Map each notification to a test promise
+		const testPromises = notifications.map(async (notification) => {
+			try {
+				if (notification.type === "email") {
+					await this.sendTestEmail(notification);
+				} else if (notification.type === "webhook") {
+					await this.sendTestWebhookNotification(notification);
+				} else if (notification.type === "pager_duty") {
+					await this.sendTestPagerDutyNotification(notification);
+				}
+				return true;
+			} catch (err) {
+				return false;
+			}
+		});
+
+		const results = await Promise.all(testPromises);
+		return results.every((r) => r === true);
+	}
 }
 
 export default NotificationService;


### PR DESCRIPTION
This PR updates the monitor details header.  It only allows for sending a test email, however a user is more likely to want to test all their notifications

- [x] Replace send test-email with test-notification
- [x] Add controller and route for test all notificaitons
- [x] Add notification service method to test all notifications

![image](https://github.com/user-attachments/assets/6a981a44-adfc-4f2f-afc5-1ff2fd04f563)
  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to test all notifications for a monitor at once from the user interface.
  - Introduced a new button labeled "Send test notifications" in the monitor details control header.
  - Success and error messages are now shown when testing all notifications.

- **Bug Fixes**
  - Improved error handling and messaging when testing notifications.

- **Documentation**
  - Updated English text to reflect the new "Send test notifications" feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->