### PR TITLE
fix: update time format function, resolves #2477

### DIFF
--- a/client/src/Pages/PageSpeed/Details/Components/PageSpeedStatusBoxes/index.jsx
+++ b/client/src/Pages/PageSpeed/Details/Components/PageSpeedStatusBoxes/index.jsx
@@ -5,13 +5,8 @@ import { getHumanReadableDuration } from "../../../../../Utils/timeUtils";
 import { useTranslation } from "react-i18next";
 
 const PageSpeedStatusBoxes = ({ shouldRender, monitor }) => {
-	const { time: uptimeDuration, units: uptimeUnits } = getHumanReadableDuration(
-		monitor?.uptimeDuration
-	);
-
-	const { time: lastCheckTime, units: lastCheckUnits } = getHumanReadableDuration(
-		monitor?.lastChecked
-	);
+	const uptimeDuration = getHumanReadableDuration(monitor?.uptimeDuration);
+	const time = getHumanReadableDuration(monitor?.lastChecked);
 
 	const { t } = useTranslation();
 
@@ -22,7 +17,6 @@ const PageSpeedStatusBoxes = ({ shouldRender, monitor }) => {
 				subHeading={
 					<>
 						{uptimeDuration}
-						<Typography component="span">{uptimeUnits}</Typography>
 						<Typography component="span">{t("ago")}</Typography>
 					</>
 				}
@@ -31,8 +25,7 @@ const PageSpeedStatusBoxes = ({ shouldRender, monitor }) => {
 				heading="last check"
 				subHeading={
 					<>
-						{lastCheckTime}
-						<Typography component="span">{lastCheckUnits}</Typography>
+						{time}
 						<Typography component="span">{t("ago")}</Typography>
 					</>
 				}

--- a/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
+++ b/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
@@ -80,7 +80,7 @@ const UptimeStatusBoxes = ({
 };
 
 UptimeStatusBoxes.propTypes = {
-	shouldRender: PropTypes.bool,
+	isLoading: PropTypes.bool,
 	monitor: PropTypes.object,
 	monitorStats: PropTypes.object,
 	certificateExpiry: PropTypes.string,

--- a/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
+++ b/client/src/Pages/Uptime/Details/Components/UptimeStatusBoxes/index.jsx
@@ -24,30 +24,22 @@ const UptimeStatusBoxes = ({
 	const timeOfLastCheck = monitorStats?.lastCheckTimestamp;
 	const timeSinceLastCheck = Date.now() - timeOfLastCheck;
 
-	const { time: streakTime, units: streakUnits } =
-		getHumanReadableDuration(timeSinceLastFailure);
+	const streakTime = getHumanReadableDuration(timeSinceLastFailure);
 
-	const { time: lastCheckTime, units: lastCheckUnits } =
-		getHumanReadableDuration(timeSinceLastCheck);
+	const lastCheckTime = getHumanReadableDuration(timeSinceLastCheck);
 	return (
 		<StatusBoxes shouldRender={!isLoading}>
 			<StatBox
 				gradient={true}
 				status={determineState(monitor)}
 				heading={"active for"}
-				subHeading={
-					<>
-						{streakTime}
-						<Typography component="span">{streakUnits}</Typography>
-					</>
-				}
+				subHeading={streakTime}
 			/>
 			<StatBox
 				heading="last check"
 				subHeading={
 					<>
 						{lastCheckTime}
-						<Typography component="span">{lastCheckUnits}</Typography>
 						<Typography component="span">{"ago"}</Typography>
 					</>
 				}

--- a/client/src/Utils/timeUtils.js
+++ b/client/src/Utils/timeUtils.js
@@ -104,10 +104,10 @@ export const getHumanReadableDuration = (ms) => {
 
 	if (result.length === 0) {
 		// fallback for durations < 1s
-		return { time: 0, units: "seconds" };
+		return "0s";
 	}
 
-	return { time: result.join(" "), units: null };
+	return result.join(" ");
 };
 
 export const formatDate = (date, customOptions) => {

--- a/client/src/Utils/timeUtils.js
+++ b/client/src/Utils/timeUtils.js
@@ -79,22 +79,35 @@ export const formatDurationSplit = (ms) => {
 
 export const getHumanReadableDuration = (ms) => {
 	const durationObj = dayjs.duration(ms);
-	if (durationObj.asDays() >= 1) {
-		const days = Math.floor(durationObj.asDays());
-		return { time: days, units: days === 1 ? "day" : "days" };
-	} else if (durationObj.asHours() >= 1) {
-		const hoursRounded = Math.round(durationObj.asHours() * 10) / 10;
-		const hours = Number.isInteger(hoursRounded)
-			? Math.floor(hoursRounded)
-			: hoursRounded;
-		return { time: hours, units: hours <= 1 ? "hour" : "hours" };
-	} else if (durationObj.asMinutes() >= 1) {
-		const minutes = Math.floor(durationObj.asMinutes());
-		return { time: minutes, units: minutes === 1 ? "minute" : "minutes" };
-	} else {
-		const seconds = Math.floor(durationObj.asSeconds());
-		return { time: seconds, units: seconds === 1 ? "second" : "seconds" };
+
+	const parts = {
+		days: Math.floor(durationObj.asDays()),
+		hours: durationObj.hours(),
+		minutes: durationObj.minutes(),
+		seconds: durationObj.seconds(),
+	};
+
+	const result = [];
+
+	if (parts.days > 0) {
+		result.push(`${parts.days}d`);
 	}
+	if (parts.hours > 0) {
+		result.push(`${parts.hours}h`);
+	}
+	if (result.length < 2 && parts.minutes > 0) {
+		result.push(`${parts.minutes}m`);
+	}
+	if (result.length < 2 && parts.seconds > 0) {
+		result.push(`${parts.seconds}s`);
+	}
+
+	if (result.length === 0) {
+		// fallback for durations < 1s
+		return { time: 0, units: "seconds" };
+	}
+
+	return { time: result.join(" "), units: null };
 };
 
 export const formatDate = (date, customOptions) => {


### PR DESCRIPTION
This PR updates the time formatting funciton to return a value with the two most significant units in human readable string format

E.g.

`"1d 20m"`
`"1h 20s"`
`"20s"`


- [x] Update time formatting function

![image](https://github.com/user-attachments/assets/e64e6c5e-80e2-4148-b23d-24f79aabb505)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved duration formatting for time displays, now showing up to two abbreviated units (e.g., "2d 3h") for clearer readability.
  - Updated internal naming for loading state in uptime status boxes to better reflect its usage, with no impact on user-facing behavior.
  - Simplified duration display by consolidating time and units into a single formatted string for clearer and more consistent presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->