### PR TITLE
refactor: build and send

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -7,7 +7,6 @@ import {
 	recoveryTokenValidation,
 	newPasswordValidation,
 } from "../validation/joi.js";
-import logger from "../utils/logger.js";
 import jwt from "jsonwebtoken";
 import { getTokenFromHeaders } from "../utils/utils.js";
 import crypto from "crypto";
@@ -15,12 +14,13 @@ import { handleValidationError, handleError } from "./controllerUtils.js";
 const SERVICE_NAME = "authController";
 
 class AuthController {
-	constructor(db, settingsService, emailService, jobQueue, stringService) {
+	constructor({ db, settingsService, emailService, jobQueue, stringService, logger }) {
 		this.db = db;
 		this.settingsService = settingsService;
 		this.emailService = emailService;
 		this.jobQueue = jobQueue;
 		this.stringService = stringService;
+		this.logger = logger;
 	}
 
 	/**

--- a/server/controllers/monitorController.js
+++ b/server/controllers/monitorController.js
@@ -580,12 +580,8 @@ class MonitorController {
 			const subject = this.stringService.testEmailSubject;
 			const context = { testName: "Monitoring System" };
 
-			const messageId = await this.emailService.buildAndSendEmail(
-				"testEmailTemplate",
-				context,
-				to,
-				subject
-			);
+			const html = await this.emailService.buildEmail("testEmailTemplate", context);
+			const messageId = await this.emailService.sendEmail(to, subject, html);
 
 			if (!messageId) {
 				return res.error({

--- a/server/controllers/settingsController.js
+++ b/server/controllers/settingsController.js
@@ -117,7 +117,7 @@ class SettingsController {
 				data: { messageId },
 			});
 		} catch (error) {
-			next(handleValidationError(error, SERVICE_NAME));
+			next(handleError(error, SERVICE_NAME));
 			return;
 		}
 	};

--- a/server/controllers/settingsController.js
+++ b/server/controllers/settingsController.js
@@ -90,26 +90,21 @@ class SettingsController {
 			const subject = this.stringService.testEmailSubject;
 			const context = { testName: "Monitoring System" };
 
-			const messageId = await this.emailService.buildAndSendEmail(
-				"testEmailTemplate",
-				context,
-				to,
-				subject,
-				{
-					systemEmailHost,
-					systemEmailPort,
-					systemEmailUser,
-					systemEmailAddress,
-					systemEmailPassword,
-					systemEmailConnectionHost,
-					systemEmailSecure,
-					systemEmailPool,
-					systemEmailIgnoreTLS,
-					systemEmailRequireTLS,
-					systemEmailRejectUnauthorized,
-					systemEmailTLSServername,
-				}
-			);
+			const html = await this.emailService.buildEmail("testEmailTemplate", context);
+			const messageId = await this.emailService.sendEmail(to, subject, html, {
+				systemEmailHost,
+				systemEmailPort,
+				systemEmailUser,
+				systemEmailAddress,
+				systemEmailPassword,
+				systemEmailConnectionHost,
+				systemEmailSecure,
+				systemEmailPool,
+				systemEmailIgnoreTLS,
+				systemEmailRequireTLS,
+				systemEmailRejectUnauthorized,
+				systemEmailTLSServername,
+			});
 
 			if (!messageId) {
 				return res.error({

--- a/server/index.js
+++ b/server/index.js
@@ -239,13 +239,14 @@ const startApp = async () => {
 	process.on("SIGTERM", shutdown);
 
 	//Create controllers
-	const authController = new AuthController(
-		ServiceRegistry.get(MongoDB.SERVICE_NAME),
-		ServiceRegistry.get(SettingsService.SERVICE_NAME),
-		ServiceRegistry.get(EmailService.SERVICE_NAME),
-		ServiceRegistry.get(JobQueue.SERVICE_NAME),
-		ServiceRegistry.get(StringService.SERVICE_NAME)
-	);
+	const authController = new AuthController({
+		db: ServiceRegistry.get(MongoDB.SERVICE_NAME),
+		settingsService: ServiceRegistry.get(SettingsService.SERVICE_NAME),
+		emailService: ServiceRegistry.get(EmailService.SERVICE_NAME),
+		jobQueue: ServiceRegistry.get(JobQueue.SERVICE_NAME),
+		stringService: ServiceRegistry.get(StringService.SERVICE_NAME),
+		logger: logger,
+	});
 
 	const monitorController = new MonitorController(
 		ServiceRegistry.get(MongoDB.SERVICE_NAME),

--- a/server/service/emailService.js
+++ b/server/service/emailService.js
@@ -80,24 +80,28 @@ class EmailService {
 		 */
 	};
 
-	/**
-	 * Asynchronously builds and sends an email using a specified template and context.
-	 *
-	 * @param {string} template - The name of the template to use for the email body.
-	 * @param {Object} context - The data context to render the template with.
-	 * @param {string} to - The recipient's email address.
-	 * @param {string} subject - The subject of the email.
-	 * @returns {Promise<string>} A promise that resolves to the messageId of the sent email.
-	 */
-	buildAndSendEmail = async (template, context, to, subject, transportConfig) => {
-		// TODO - Consider an update transporter method so this only needs to be recreated when smtp settings change
+	buildEmail = async (template, context) => {
+		try {
+			const mjml = this.templateLookup[template](context);
+			const html = await this.mjml2html(mjml);
+			return html.html;
+		} catch (error) {
+			this.logger.error({
+				message: error.message,
+				service: SERVICE_NAME,
+				method: "buildEmail",
+				stack: error.stack,
+			});
+		}
+	};
+
+	sendEmail = async (to, subject, html, transportConfig) => {
 		let config;
 		if (typeof transportConfig !== "undefined") {
 			config = transportConfig;
 		} else {
 			config = await this.settingsService.getDBSettings();
 		}
-
 		const {
 			systemEmailHost,
 			systemEmailPort,
@@ -131,45 +135,24 @@ class EmailService {
 				servername: systemEmailTLSServername,
 			},
 		};
-
 		this.transporter = this.nodemailer.createTransport(emailConfig);
 
-		const buildHtml = async (template, context) => {
-			try {
-				const mjml = this.templateLookup[template](context);
-				const html = await this.mjml2html(mjml);
-				return html.html;
-			} catch (error) {
-				this.logger.error({
-					message: error.message,
-					service: SERVICE_NAME,
-					method: "buildAndSendEmail",
-					stack: error.stack,
-				});
-			}
-		};
-
-		const sendEmail = async (to, subject, html) => {
-			try {
-				const info = await this.transporter.sendMail({
-					to: to,
-					from: systemEmailAddress,
-					subject: subject,
-					html: html,
-				});
-				return info;
-			} catch (error) {
-				this.logger.error({
-					message: error.message,
-					service: SERVICE_NAME,
-					method: "sendEmail",
-					stack: error.stack,
-				});
-			}
-		};
-		const html = await buildHtml(template, context);
-		const info = await sendEmail(to, subject, html);
-		return info?.messageId;
+		try {
+			const info = await this.transporter.sendMail({
+				to: to,
+				from: systemEmailAddress,
+				subject: subject,
+				html: html,
+			});
+			return info?.messageId;
+		} catch (error) {
+			this.logger.error({
+				message: error.message,
+				service: SERVICE_NAME,
+				method: "sendEmail",
+				stack: error.stack,
+			});
+		}
 	};
 }
 


### PR DESCRIPTION
Builidng and sending emails currently happens in one step which reduces reusability of the method.

This PR breaks the method into two

- [x] Extract build portion to `buildEmail`
- [x] Extract send portion to `sendEmail`

This will allow us to refactor NotificationService more effectively 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved email handling by separating email content creation and sending into distinct steps across registration, invitation, monitoring, settings, and notification features.
  - Enhanced error handling and logging for email delivery, providing better reliability and issue visibility.
  - Updated controller initialization to include enhanced logging support.

No visible changes to the user interface or main workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->