### PR TITLE
fix: add empty functions

### DIFF
--- a/client/src/Components/Fallback/index.jsx
+++ b/client/src/Components/Fallback/index.jsx
@@ -39,7 +39,11 @@ const Fallback = ({
 	const { t } = useTranslation();
 	const [settingsData, setSettingsData] = useState(undefined);
 
-	const [isLoading, error] = useFetchSettings({ setSettingsData });
+	const [isLoading, error] = useFetchSettings({
+		setSettingsData,
+		setIsApiKeySet: () => {},
+		setIsEmailPasswordSet: () => {},
+	});
 	// Custom warning message with clickable link
 	const renderWarningMessage = () => {
 		return (


### PR DESCRIPTION
useFetchSettings need to take two functions, provide empty placeholders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal settings handling to improve compatibility with the latest system requirements. No visible changes to the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->