### PR TITLE
early return if paused

### DIFF
--- a/server/service/PulseQueue/PulseQueueHelper.js
+++ b/server/service/PulseQueue/PulseQueueHelper.js
@@ -13,6 +13,10 @@ class PulseQueueHelper {
 		return async (job) => {
 			try {
 				const monitor = job.attrs.data.monitor;
+
+				if (monitor.isActive === false) {
+					return;
+				}
 				const monitorId = job.attrs.data.monitor._id;
 				if (!monitorId) {
 					throw new Error("No monitor id");


### PR DESCRIPTION
The new Pulse based JobQueue behaves differently than the BullMQ based JobQueue.  In the old JobQueue, when a monitor was paused the job was deleted form the queue, and re-added when resumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of inactive monitors to prevent unnecessary processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->