### PR TITLE
fix: disable job on addition if monitor is paused

### DIFF
--- a/server/service/PulseQueue/PulseQueue.js
+++ b/server/service/PulseQueue/PulseQueue.js
@@ -57,6 +57,9 @@ class PulseQueue {
 		job.unique({ "data.monitor._id": monitor._id });
 		job.attrs.jobId = monitorId.toString();
 		job.repeatEvery(`${intervalInSeconds} seconds`);
+		if (monitor.isActive === false) {
+			job.disable();
+		}
 		await job.save();
 	};
 


### PR DESCRIPTION
Jobs that are created from a monitor in the Paused state should be set to the "disabled" state

- [x] Disable jobs when adding to queue if `isActive === false`, ie the monitor is paused.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - New jobs are now automatically disabled if the associated monitor is inactive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->