### PR TITLE
Add toggle to optionally display admin login link on status page and fix syntax errors

### DIFF
--- a/client/src/Pages/StatusPage/Create/Components/Tabs/Content.jsx
+++ b/client/src/Pages/StatusPage/Create/Components/Tabs/Content.jsx
@@ -90,6 +90,13 @@ const Content = ({
 							isChecked={form.showUptimePercentage}
 							onChange={handleFormChange}
 						/>
+						<Checkbox
+							id="showAdminLoginLink"
+							name="showAdminLoginLink"
+							label={t("showAdminLoginLink")}
+							isChecked={form.showAdminLoginLink}
+							onChange={handleFormChange}
+						/>
 					</Stack>
 				</ConfigStack>
 			</Stack>

--- a/client/src/Pages/StatusPage/Create/index.jsx
+++ b/client/src/Pages/StatusPage/Create/index.jsx
@@ -20,7 +20,7 @@ const TAB_LIST = ["General settings", "Contents"];
 
 const ERROR_TAB_MAPPING = [
 	["companyName", "url", "timezone", "color", "isPublished", "logo"],
-	["monitors", "showUptimePercentage", "showCharts"],
+	["monitors", "showUptimePercentage", "showCharts", "showAdminLoginLink"],
 ];
 
 const CreateStatusPage = () => {
@@ -39,6 +39,7 @@ const CreateStatusPage = () => {
 		monitors: [],
 		showCharts: true,
 		showUptimePercentage: true,
+		showAdminLoginLink: false,
 	});
 	const [errors, setErrors] = useState({});
 	const [selectedMonitors, setSelectedMonitors] = useState([]);
@@ -195,6 +196,7 @@ const CreateStatusPage = () => {
 				logo: newLogo,
 				showCharts: statusPage?.showCharts ?? true,
 				showUptimePercentage: statusPage?.showUptimePercentage ?? true,
+				showAdminLoginLink: statusPage?.showAdminLoginLink ?? false,
 			};
 		});
 		setSelectedMonitors(statusPageMonitors);

--- a/client/src/Pages/StatusPage/Status/index.jsx
+++ b/client/src/Pages/StatusPage/Status/index.jsx
@@ -48,7 +48,7 @@ const PublicStatus = () => {
 	let link = undefined;
 	const isPublic = location.pathname.startsWith("/status/uptime/public");
 	// Public status page
-	if (isPublic) {
+	if (isPublic && statusPage && statusPage.showAdminLoginLink === true) {
 		sx = {
 			paddingTop: theme.spacing(20),
 			paddingLeft: "20vw",

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -871,6 +871,9 @@ class NetworkService {
 		if (form.showUptimePercentage !== undefined) {
 			fd.append("showUptimePercentage", String(form.showUptimePercentage));
 		}
+		if (form.showAdminLoginLink !== undefined) {
+			fd.append("showAdminLoginLink", String(form.showAdminLoginLink));
+		}
 		form.monitors &&
 			form.monitors.forEach((monitorId) => {
 				fd.append("monitors[]", monitorId);

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -1037,7 +1037,7 @@ class NetworkService {
 	async flushQueue() {
 		return this.axiosInstance.post(`/queue/flush`);
 	}
-    
+
 	async exportMonitors() {
 		const response = await this.axiosInstance.get("/monitors/export", {
 			responseType: "blob",

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -1033,7 +1033,7 @@ class NetworkService {
 
 	async flushQueue() {
 		return this.axiosInstance.post(`/queue/flush`);
-    
+	}
     
 	async exportMonitors() {
 		const response = await this.axiosInstance.get("/monitors/export", {

--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -277,6 +277,7 @@ const statusPageValidation = joi.object({
 	logo: logoImageValidation,
 	showUptimePercentage: joi.boolean(),
 	showCharts: joi.boolean(),
+	showAdminLoginLink: joi.boolean(),
 });
 
 const settingsValidation = joi.object({

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -319,6 +319,7 @@
 	"statusPageCreateTabsContentFeaturesDescription": "Show more details on the status page",
 	"showCharts": "Show charts",
 	"showUptimePercentage": "Show uptime percentage",
+	"showAdminLoginLink": "Show \"Administrator? Login Here\" link on the status page",
 	"removeLogo": "Remove Logo",
 	"statusPageStatus": "A public status page is not set up.",
 	"statusPageStatusContactAdmin": "Please contact to your administrator",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -786,6 +786,7 @@
 			"failedAtHeader": "Last failed at",
 			"failReasonHeader": "Fail reason"
 		}
+	},
 	"export": {
 		"title": "Export Monitors",
 		"success": "Monitors exported successfully!",

--- a/client/src/locales/pt-BR.json
+++ b/client/src/locales/pt-BR.json
@@ -312,6 +312,7 @@
 	"statusPageCreateTabsContentFeaturesDescription": "Mostrar mais detalhes na página de status",
 	"showCharts": "Mostrar gráficos",
 	"showUptimePercentage": "Mostrar porcentagem de Uptime",
+	"showAdminLoginLink": "Mostrar o link \"Administrador? Efetue login aqui\" na página de status",
 	"removeLogo": "Remover logo",
 	"statusPageStatus": "Uma página de status pública não está configurada.",
 	"statusPageStatusContactAdmin": "Entre em contato com seu administrador",

--- a/server/db/models/StatusPage.js
+++ b/server/db/models/StatusPage.js
@@ -70,6 +70,10 @@ const StatusPageSchema = mongoose.Schema(
 			type: Boolean,
 			default: true,
 		},
+		showAdminLoginLink: {
+			type: Boolean,
+			default: false,
+		}
 	},
 	{ timestamps: true }
 );

--- a/server/db/models/StatusPage.js
+++ b/server/db/models/StatusPage.js
@@ -73,7 +73,7 @@ const StatusPageSchema = mongoose.Schema(
 		showAdminLoginLink: {
 			type: Boolean,
 			default: false,
-		}
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/db/mongo/modules/statusPageModule.js
+++ b/server/db/mongo/modules/statusPageModule.js
@@ -153,6 +153,7 @@ const getStatusPage = async (url) => {
 						showCharts: 1,
 						showUptimePercentage: 1,
 						timezone: 1,
+						showAdminLoginLink: 1,
 						url: 1,
 					},
 					monitors: {

--- a/server/validation/joi.js
+++ b/server/validation/joi.js
@@ -463,6 +463,7 @@ const createStatusPageBodyValidation = joi.object({
 	isPublished: joi.boolean(),
 	showCharts: joi.boolean().optional(),
 	showUptimePercentage: joi.boolean(),
+	showAdminLoginLink: joi.boolean().optional(),
 });
 
 const imageValidation = joi


### PR DESCRIPTION
## Describe your changes

Added a toggle option in the status page settings to allow users to show or hide the “Administrator? Login Here” link on the status page. The toggle is available under Status page > Contents and is disabled by default. Implemented support for this feature in both the frontend and backend, including i18n for visible strings, validation, and database schema updates.

Additionally, fixed syntax errors in ‎`/client/src/Utils/NetworkService.js` (missing ‎`}` at line 1036) and ‎`/client/src/locales/en.json` (missing ‎`},` at line 789).

## Write your issue number after "Fixes "

Fixes #2498 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

When the toggle option 'Show "Administrator? Login Here" link on the status page' is enabled
![image](https://github.com/user-attachments/assets/63c36f0a-b6b8-4aa6-99e4-2894988ca007)
![image](https://github.com/user-attachments/assets/61bacdef-30b5-4020-bf1f-903bbb9036ea)

When it's disabled
![image](https://github.com/user-attachments/assets/ec78c6ce-812d-49d3-8ce5-e703a640cc18)
![image](https://github.com/user-attachments/assets/0fc0840b-a993-4f1d-9b9b-fe8f3e30772b)
