### PR TITLE
remove redis from production docker copose

### DIFF
--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -29,21 +29,9 @@ services:
     env_file:
       - server.env
     depends_on:
-      - redis
       - mongodb
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-  redis:
-    image: ghcr.io/bluewave-labs/checkmate:redis-demo
-    restart: always
-    volumes:
-      - ./redis/data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 30s
-      timeout: 10s
-      retries: 5
-      start_period: 5s
   mongodb:
     image: ghcr.io/bluewave-labs/checkmate:mongo-demo
     restart: always


### PR DESCRIPTION
This PR removes redis from the production docker compose file as Redis is no longer used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed Redis service from the production Docker configuration.
  - Updated service dependencies to reflect the removal of Redis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->