### PR TITLE
feat: display transport settings

### DIFF
--- a/client/src/Components/TextLink/index.jsx
+++ b/client/src/Components/TextLink/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from "prop-types";
 import { useTheme } from "@emotion/react";
 import { Link as RouterLink } from "react-router-dom";
 
-const TextLink = ({ text, linkText, href }) => {
+const TextLink = ({ text, linkText, href, target = "_self" }) => {
 	const theme = useTheme();
 
 	return (
@@ -18,6 +18,7 @@ const TextLink = ({ text, linkText, href }) => {
 				color="accent"
 				to={href}
 				component={RouterLink}
+				target={target}
 			>
 				{linkText}
 			</Link>
@@ -29,6 +30,7 @@ TextLink.propTypes = {
 	text: PropTypes.string,
 	linkText: PropTypes.string,
 	href: PropTypes.string,
+	target: PropTypes.string,
 };
 
 export default TextLink;

--- a/client/src/Pages/Settings/SettingsEmail.jsx
+++ b/client/src/Pages/Settings/SettingsEmail.jsx
@@ -242,8 +242,8 @@ const SettingsEmail = ({
 						))}
 
 						<TextLink
-							text="This builds an SMTP transport for NodeMailer"
-							linkText="See specifications here"
+							text={t("settingsEmailTransportLinkDescription")}
+							linkText={t("settingsEmailTransportLinkText")}
 							href="https://nodemailer.com/smtp"
 							target="_blank"
 						/>

--- a/client/src/Pages/Settings/SettingsEmail.jsx
+++ b/client/src/Pages/Settings/SettingsEmail.jsx
@@ -268,7 +268,6 @@ const SettingsEmail = ({
 										},
 										name: systemEmailConnectionHost || "localhost",
 										pool: systemEmailPool,
-										user: systemEmailUser,
 										tls: {
 											rejectUnauthorized: systemEmailRejectUnauthorized,
 											ignoreTLS: systemEmailIgnoreTLS,

--- a/client/src/Pages/Settings/SettingsEmail.jsx
+++ b/client/src/Pages/Settings/SettingsEmail.jsx
@@ -4,6 +4,8 @@ import ConfigBox from "../../Components/ConfigBox";
 import TextInput from "../../Components/Inputs/TextInput";
 import Button from "@mui/material/Button";
 import Stack from "@mui/material/Stack";
+import { Switch } from "@mui/material";
+import TextLink from "../../Components/TextLink";
 // Utils
 import { useTheme } from "@emotion/react";
 import { PropTypes } from "prop-types";
@@ -12,7 +14,6 @@ import { useTranslation } from "react-i18next";
 import { PasswordEndAdornment } from "../../Components/Inputs/TextInput/Adornments";
 import { useSendTestEmail } from "../../Hooks/useSendTestEmail";
 import { createToast } from "../../Utils/toastUtils";
-import { Switch } from "@mui/material";
 
 const SettingsEmail = ({
 	isAdmin,
@@ -239,6 +240,47 @@ const SettingsEmail = ({
 								/>
 							</Box>
 						))}
+
+						<TextLink
+							text="This builds an SMTP transport for NodeMailer"
+							linkText="See specifications here"
+							href="https://nodemailer.com/smtp"
+							target="_blank"
+						/>
+						<Box
+							component={"pre"}
+							sx={{
+								fontFamily: "monospace",
+								p: 2,
+								borderRadius: 1,
+								overflow: "auto",
+							}}
+						>
+							<code>
+								{JSON.stringify(
+									{
+										host: systemEmailHost,
+										port: systemEmailPort,
+										secure: systemEmailSecure,
+										auth: {
+											user: systemEmailUser || systemEmailAddress,
+											pass: "<your_password>",
+										},
+										name: systemEmailConnectionHost || "localhost",
+										pool: systemEmailPool,
+										user: systemEmailUser,
+										tls: {
+											rejectUnauthorized: systemEmailRejectUnauthorized,
+											ignoreTLS: systemEmailIgnoreTLS,
+											requireTLS: systemEmailRequireTLS,
+											servername: systemEmailTLSServername,
+										},
+									},
+									null,
+									2
+								)}
+							</code>
+						</Box>
 					</Box>
 
 					<Box>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -450,6 +450,8 @@
 	"settingsEmailPassword": "Email password - Password for authentication",
 	"settingsEmailUser": "Email user - Username for authentication, overrides email address if specified",
 	"settingsEmailFieldResetLabel": "Password is set. Click Reset to change it.",
+	"settingsEmailTransportLinkDescription": "This builds an SMTP transport for NodeMailer",
+	"settingsEmailTransportLinkText": "See specifications here",
 	"state": "State",
 	"statusBreadCrumbsStatusPages": "Status Pages",
 	"statusBreadCrumbsDetails": "Details",


### PR DESCRIPTION
It is not clear what the e-mail settings actually result in when selected.

This PR adds a feature to displays the e-mail transport that is generated based on the config settings

![image](https://github.com/user-attachments/assets/6381eaa8-00ca-4f75-8eb6-b3ec2ccd25c8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an informational section in email settings displaying SMTP transport configuration as formatted JSON with sensitive data hidden.
  - Included a clickable link to the official NodeMailer SMTP documentation within the email settings UI.

- **Enhancements**
  - Updated text link components to allow specifying how links open (e.g., same tab or new tab).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->