### PR TITLE
feat: add middleware for verifying team access

### DIFF
--- a/server/middleware/verifyOwnership.js
+++ b/server/middleware/verifyOwnership.js
@@ -6,7 +6,6 @@ const SERVICE_NAME = "verifyOwnership";
 const verifyOwnership = (Model, paramName) => {
 	const stringService = ServiceRegistry.get(StringService.SERVICE_NAME);
 	return async (req, res, next) => {
-		console.log(req.params);
 		const userId = req.user._id;
 		const documentId = req.params[paramName];
 

--- a/server/middleware/verifyOwnership.js
+++ b/server/middleware/verifyOwnership.js
@@ -6,8 +6,10 @@ const SERVICE_NAME = "verifyOwnership";
 const verifyOwnership = (Model, paramName) => {
 	const stringService = ServiceRegistry.get(StringService.SERVICE_NAME);
 	return async (req, res, next) => {
+		console.log(req.params);
 		const userId = req.user._id;
 		const documentId = req.params[paramName];
+
 		try {
 			const doc = await Model.findById(documentId);
 			//If the document is not found, return a 404 error
@@ -35,7 +37,7 @@ const verifyOwnership = (Model, paramName) => {
 
 			// If the userID does not match the document's userID, return a 403 error
 			if (userId.toString() !== doc.userId.toString()) {
-				const error = new Error(stringService.verifyOwnerUnauthorized);
+				const error = new Error("Unauthorized");
 				error.status = 403;
 				throw error;
 			}

--- a/server/middleware/verifyTeamAccess.js
+++ b/server/middleware/verifyTeamAccess.js
@@ -5,6 +5,19 @@ const verifyTeamAccess = (Model, paramName) => {
 		try {
 			const documentId = req.params[paramName];
 			const doc = await Model.findById(documentId);
+
+			if (!doc) {
+				const error = new Error("Document not found");
+				error.status = 404;
+				throw error;
+			}
+
+			if (!req?.user?.teamId || !doc.teamId) {
+				const error = new Error("Missing team information");
+				error.status = 400;
+				throw error;
+			}
+
 			if (req.user.teamId.toString() === doc.teamId.toString()) {
 				next();
 				return;

--- a/server/middleware/verifyTeamAccess.js
+++ b/server/middleware/verifyTeamAccess.js
@@ -1,0 +1,25 @@
+const SERVICE_NAME = "verifyTeamAccess";
+
+const verifyTeamAccess = (Model, paramName) => {
+	return async (req, res, next) => {
+		try {
+			const documentId = req.params[paramName];
+			const doc = await Model.findById(documentId);
+			if (req.user.teamId.toString() === doc.teamId.toString()) {
+				next();
+				return;
+			}
+
+			const error = new Error("Unauthorized");
+			error.status = 403;
+			throw error;
+		} catch (error) {
+			error.service = SERVICE_NAME;
+			error.method = "verifyTeamAccess";
+			next(error);
+			return;
+		}
+	};
+};
+
+export { verifyTeamAccess };

--- a/server/routes/maintenanceWindowRoute.js
+++ b/server/routes/maintenanceWindowRoute.js
@@ -1,7 +1,8 @@
 import { Router } from "express";
 import { verifyOwnership } from "../middleware/verifyOwnership.js";
+import { verifyTeamAccess } from "../middleware/verifyTeamAccess.js";
 import Monitor from "../db/models/Monitor.js";
-
+import MaintenanceWindow from "../db/models/MaintenanceWindow.js";
 class MaintenanceWindowRoutes {
 	constructor(maintenanceWindowController) {
 		this.router = Router();
@@ -24,9 +25,17 @@ class MaintenanceWindowRoutes {
 
 		this.router.get("/:id", this.maintenanceWindowController.getMaintenanceWindowById);
 
-		this.router.put("/:id", this.maintenanceWindowController.editMaintenanceWindow);
+		this.router.put(
+			"/:id",
+			verifyTeamAccess(MaintenanceWindow, "id"),
+			this.maintenanceWindowController.editMaintenanceWindow
+		);
 
-		this.router.delete("/:id", this.maintenanceWindowController.deleteMaintenanceWindow);
+		this.router.delete(
+			"/:id",
+			verifyTeamAccess(MaintenanceWindow, "id"),
+			this.maintenanceWindowController.deleteMaintenanceWindow
+		);
 	}
 
 	getRouter() {

--- a/server/routes/monitorRoute.js
+++ b/server/routes/monitorRoute.js
@@ -2,7 +2,9 @@ import { Router } from "express";
 import { isAllowed } from "../middleware/isAllowed.js";
 import multer from "multer";
 import { fetchMonitorCertificate } from "../controllers/controllerUtils.js";
-
+import Monitor from "../db/models/Monitor.js";
+import { verifyOwnership } from "../middleware/verifyOwnership.js";
+import { verifyTeamAccess } from "../middleware/verifyTeamAccess.js";
 const upload = multer({
 	storage: multer.memoryStorage(), // Store file in memory as Buffer
 });
@@ -62,6 +64,7 @@ class MonitorRoutes {
 
 		this.router.delete(
 			"/:monitorId",
+			verifyOwnership(Monitor, "monitorId"),
 			isAllowed(["admin", "superadmin"]),
 			this.monitorController.deleteMonitor
 		);
@@ -74,6 +77,7 @@ class MonitorRoutes {
 
 		this.router.put(
 			"/:monitorId",
+			verifyTeamAccess(Monitor, "monitorId"),
 			isAllowed(["admin", "superadmin"]),
 			this.monitorController.editMonitor
 		);

--- a/server/routes/notificationRoute.js
+++ b/server/routes/notificationRoute.js
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import { verifyJWT } from "../middleware/verifyJWT.js";
-
+import { verifyOwnership } from "../middleware/verifyOwnership.js";
+import { verifyTeamAccess } from "../middleware/verifyTeamAccess.js";
+import Notification from "../db/models/Notification.js";
 class NotificationRoutes {
 	constructor(notificationController) {
 		this.router = Router();
@@ -18,10 +20,18 @@ class NotificationRoutes {
 
 		this.router.get("/team", this.notificationController.getNotificationsByTeamId);
 
-		this.router.delete("/:id", this.notificationController.deleteNotification);
+		this.router.delete(
+			"/:id",
+			verifyOwnership(Notification, "id"),
+			this.notificationController.deleteNotification
+		);
 
 		this.router.get("/:id", this.notificationController.getNotificationById);
-		this.router.put("/:id", this.notificationController.editNotification);
+		this.router.put(
+			"/:id",
+			verifyTeamAccess(Notification, "id"),
+			this.notificationController.editNotification
+		);
 	}
 
 	getRouter() {


### PR DESCRIPTION
This PR adds middleware for verifying whether or not a user is part of a team that a document belongs to.

This should be applied to `put` routes, only users from the same team should be able to edit documents.

`delete` routes should generally have the `verifyOwnership` middleware applied so that only the creator of an item may delete it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added team-based access control for editing and deleting maintenance windows, monitors, and notifications.
  - Introduced ownership and team access verification for monitor and notification actions to enhance authorization.

- **Bug Fixes**
  - Updated unauthorized access messages for ownership verification to display a consistent "Unauthorized" message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->