### PR TITLE
fix: add entrypoint to prod certbot

### DIFF
--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -21,6 +21,8 @@ services:
     volumes:
       - ./certbot/www/:/var/www/certbot/:rw
       - ./certbot/conf/:/etc/letsencrypt/:rw
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; sleep 12h & wait $${!}; done;'"
+
   server:
     image: ghcr.io/bluewave-labs/checkmate:backend-demo
     restart: always


### PR DESCRIPTION
Production docker compose was missing certbot entrypoint