### PR TITLE
feat: add stat boxes and timeframe header

### DIFF
--- a/client/src/Pages/Uptime/Details/index.jsx
+++ b/client/src/Pages/Uptime/Details/index.jsx
@@ -111,6 +111,7 @@ const UptimeDetails = () => {
 		return (
 			<Stack gap={theme.spacing(10)}>
 				<Breadcrumbs list={BREADCRUMBS} />
+
 				<MonitorDetailsControlHeader
 					path={"uptime"}
 					isAdmin={isAdmin}
@@ -118,6 +119,19 @@ const UptimeDetails = () => {
 					monitor={monitor}
 					triggerUpdate={triggerUpdate}
 				/>
+				<UptimeStatusBoxes
+					isLoading={monitorIsLoading}
+					monitor={monitor}
+					monitorStats={monitorStats}
+					certificateExpiry={certificateExpiry}
+				/>
+				<MonitorTimeFrameHeader
+					isLoading={monitorIsLoading}
+					hasDateRange={true}
+					dateRange={dateRange}
+					setDateRange={setDateRange}
+				/>
+
 				<GenericFallback>
 					<Typography>{t("distributedUptimeDetailsNoMonitorHistory")}</Typography>
 				</GenericFallback>


### PR DESCRIPTION
This PR updates the Uptime monitor details page empty view

If a monitor has no checks for the "recent" time period (the default time period) but _does_ have checks for times > recent, the page currently shows that "no checks exist".  This is not accurate as checks do exist, just not for the selected time period.

This PR adds the time frame header to the empty view so that users can select other time frames to see if there are checks there

![image](https://github.com/user-attachments/assets/2e5d44bc-c5e1-4e77-a241-6edae9e7460a)
