### PR TITLE
fix: translations ignore empty strings

### DIFF
--- a/client/src/Utils/i18n.js
+++ b/client/src/Utils/i18n.js
@@ -24,6 +24,7 @@ i18n.use(initReactI18next).init({
 	interpolation: {
 		escapeValue: false,
 	},
+	returnEmptyString: false,
 });
 
 export default i18n;


### PR DESCRIPTION
This PR adds a flag to the i18n implementation to ignore empty strings