### PR TITLE
fix: verify transport before sending email

### DIFF
--- a/client/src/Components/TabPanels/Account/TeamPanel.jsx
+++ b/client/src/Components/TabPanels/Account/TeamPanel.jsx
@@ -168,7 +168,7 @@ const TeamPanel = () => {
 			});
 		} catch (error) {
 			createToast({
-				body: error.message || "Unknown error.",
+				body: error?.response?.data?.msg || error.message || "Unknown error.",
 			});
 		} finally {
 			setIsSendingInvite(false);
@@ -268,7 +268,7 @@ const TeamPanel = () => {
 					value={toInvite.email}
 					onChange={handleChange}
 					error={errors.email ? true : false}
-					helperText={errors.email}
+					helperText={t(errors.email)}
 				/>
 				<Select
 					id="team-member-role"

--- a/server/controllers/inviteController.js
+++ b/server/controllers/inviteController.js
@@ -77,11 +77,16 @@ class InviteController {
 					name: firstname,
 					link: `${clientHost}/register/${inviteToken.token}`,
 				});
-				await this.emailService.sendEmail(
+				const result = await this.emailService.sendEmail(
 					req.body.email,
 					"Welcome to Uptime Monitor",
 					html
 				);
+				if (!result) {
+					return res.error({
+						msg: "Failed to send invite e-mail... Please verify your settings.",
+					});
+				}
 			} catch (error) {
 				logger.warn({
 					message: error.message,

--- a/server/service/emailService.js
+++ b/server/service/emailService.js
@@ -138,6 +138,17 @@ class EmailService {
 		this.transporter = this.nodemailer.createTransport(emailConfig);
 
 		try {
+			await this.transporter.verify();
+		} catch (error) {
+			this.logger.warn({
+				message: "Email transporter verification failed",
+				service: SERVICE_NAME,
+				method: "verifyTransporter",
+			});
+			return false;
+		}
+
+		try {
 			const info = await this.transporter.sendMail({
 				to: to,
 				from: systemEmailAddress,

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -76,7 +76,7 @@ class Logger {
 	info(config) {
 		const logEntry = this.buildLogEntry("info", config);
 		this.cacheLog(logEntry);
-		this.logger.info(config.message, logEntry);
+		this.logger.info(logEntry);
 	}
 
 	/**
@@ -90,7 +90,7 @@ class Logger {
 	warn(config) {
 		const logEntry = this.buildLogEntry("warn", config);
 		this.cacheLog(logEntry);
-		this.logger.warn(config.message, logEntry);
+		this.logger.warn(logEntry);
 	}
 
 	/**
@@ -104,7 +104,7 @@ class Logger {
 	error(config) {
 		const logEntry = this.buildLogEntry("error", config);
 		this.cacheLog(logEntry);
-		this.logger.error(config.message, logEntry);
+		this.logger.error(logEntry);
 	}
 	/**
 	 * Logs a debug message.
@@ -117,7 +117,7 @@ class Logger {
 	debug(config) {
 		const logEntry = this.buildLogEntry("debug", config);
 		this.cacheLog(logEntry);
-		this.logger.debug(config.message, logEntry);
+		this.logger.debug(logEntry);
 	}
 
 	cacheLog(entry) {


### PR DESCRIPTION
This PR adds a verify function to check if the email transport is configured or not before attempting to send an email

- [x] Verify transport, return `false` if invalid
- [x] Handle error on invite page  