### PR TITLE
hotfix: status page

### DIFF
--- a/client/src/Pages/StatusPage/Create/index.jsx
+++ b/client/src/Pages/StatusPage/Create/index.jsx
@@ -246,7 +246,7 @@ const CreateStatusPage = () => {
 					color="accent"
 					onClick={handleSubmit}
 				>
-					{t("settingsSave")}
+					{t("statusPageCreate.buttonSave")}
 				</Button>
 			</Stack>
 		</Stack>

--- a/client/src/Pages/StatusPage/Status/index.jsx
+++ b/client/src/Pages/StatusPage/Status/index.jsx
@@ -62,7 +62,7 @@ const PublicStatus = () => {
 		return <SkeletonLayout />;
 	}
 
-	if (monitors.length === 0) {
+	if (monitors?.length === 0) {
 		return (
 			<GenericFallback>
 				<Typography

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -835,5 +835,8 @@
 			"selectEnabled": "Enabled",
 			"title": "Monitor IP/URL on Status Page"
 		}
+	},
+	"statusPageCreate": {
+		"buttonSave": "Save"
 	}
 }

--- a/server/db/mongo/modules/statusPageModule.js
+++ b/server/db/mongo/modules/statusPageModule.js
@@ -90,6 +90,45 @@ const getStatusPage = async (url) => {
 	const stringService = ServiceRegistry.get(StringService.SERVICE_NAME);
 
 	try {
+		const preliminaryStatusPage = await StatusPage.findOne({ url });
+		if (!preliminaryStatusPage) {
+			const error = new Error(stringService.statusPageNotFound);
+			error.status = 404;
+			throw error;
+		}
+
+		if (!preliminaryStatusPage.monitors || preliminaryStatusPage.monitors.length === 0) {
+			const {
+				_id,
+				color,
+				companyName,
+				isPublished,
+				logo,
+				originalMonitors,
+				showCharts,
+				showUptimePercentage,
+				timezone,
+				showAdminLoginLink,
+				url,
+			} = preliminaryStatusPage;
+			return {
+				statusPage: {
+					_id,
+					color,
+					companyName,
+					isPublished,
+					logo,
+					originalMonitors,
+					showCharts,
+					showUptimePercentage,
+					timezone,
+					showAdminLoginLink,
+					url,
+				},
+				monitors: [],
+			};
+		}
+
 		const statusPageQuery = await StatusPage.aggregate([
 			{ $match: { url: url } },
 			{


### PR DESCRIPTION
Downgrading for MongoDB 4.4 compatability had an unintedned consequences with regards to how empty sets are treated.

- [x] Do a preliminary query to see if a status page has monitors, if not return early with an empty array for monitors
- [x] Delete monitors from status page on `deleteMany` monitors