### PR TITLE
hotfix: stop propagation

### DIFF
--- a/client/src/Pages/Notifications/components/ActionMenu.jsx
+++ b/client/src/Pages/Notifications/components/ActionMenu.jsx
@@ -18,6 +18,7 @@ const ActionMenu = ({ notification, onDelete }) => {
 
 	// Handlers
 	const handleClick = (event) => {
+		event.stopPropagation();
 		setAnchorEl(event.currentTarget);
 	};
 


### PR DESCRIPTION
Action menu on notifications row item action was propagating up to row click handler