### PR TITLE
feat: disable send test notification when 0 notifications are configured

### DIFF
--- a/client/src/Components/MonitorDetailsControlHeader/index.jsx
+++ b/client/src/Components/MonitorDetailsControlHeader/index.jsx
@@ -43,6 +43,8 @@ const MonitorDetailsControlHeader = ({
 
 	const isTestNotificationsDisabled = monitor?.notifications?.length === 0;
 
+	const tooltipTitle = isTestNotificationsDisabled ? t("testNotificationsDisabled") : "";
+
 	// const [isSending, emailError, sendTestEmail] = useSendTestEmail();
 
 	const [testAllNotifications, isSending, errorAllNotifications] =
@@ -66,13 +68,7 @@ const MonitorDetailsControlHeader = ({
 				<Tooltip
 					key={monitor?._id}
 					placement="bottom"
-					title={
-						isTestNotificationsDisabled
-							? t(
-									'There are no notifications setup for this monitor. You need to add one by clicking "Configure" button'
-								)
-							: ""
-					}
+					title={tooltipTitle}
 				>
 					<span>
 						<Button

--- a/client/src/locales/ar.json
+++ b/client/src/locales/ar.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -826,6 +826,7 @@
 		"teamMembers": "Team members"
 	},
 	"testLocale": "testLocale",
+	"testNotificationsDisabled": "There are no notifications setup for this monitor. You need to add one by clicking 'Configure' button",
 	"timeZoneInfo": "All dates and times are in GMT+0 time zone.",
 	"timezone": "Timezone",
 	"title": "Title",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/pt-BR.json
+++ b/client/src/locales/pt-BR.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/tr.json
+++ b/client/src/locales/tr.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "Bildirimleri dene",
+	"testNotificationsDisabled": "",
 	"selectAll": "Tümünü seç",
 	"showAdminLoginLink": "",
 	"logsPage": {

--- a/client/src/locales/zh-TW.json
+++ b/client/src/locales/zh-TW.json
@@ -690,6 +690,7 @@
 	},
 	"advancedMatching": "",
 	"sendTestNotifications": "",
+	"testNotificationsDisabled": "",
 	"selectAll": "",
 	"showAdminLoginLink": "",
 	"logsPage": {


### PR DESCRIPTION
I have disabled the tooltip if the monitor parameter has any empty notifications array. I have created a ternary operator that manages the tooltip in case of empty notification array.

![image](https://github.com/user-attachments/assets/d6dcad30-de76-4e0d-b1ed-b454f1e35c22)


Fixes #2510 


- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tooltip and disabled state to the "Send Test Notifications" button when no notifications are configured, providing user guidance and preventing test notifications from being sent in this case.
  * Introduced localized messages supporting this new tooltip across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->