### PR TITLE
feat: toast refactor

### DIFF
--- a/client/src/Components/Toast/body.jsx
+++ b/client/src/Components/Toast/body.jsx
@@ -1,0 +1,34 @@
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+
+import { useTheme } from "@emotion/react";
+import PropTypes from "prop-types";
+
+const ToastBody = ({ body }) => {
+	const theme = useTheme();
+
+	if (Array.isArray(body)) {
+		return (
+			<Stack gap={theme.spacing(2)}>
+				{body.map((item, idx) => (
+					<Typography
+						key={`item-${idx}`}
+						color={theme.palette.secondary.contrastText}
+					>
+						{item}
+					</Typography>
+				))}
+			</Stack>
+		);
+	} else if (typeof body === "string") {
+		return <Typography color={theme.palette.secondary.contrastText}>{body}</Typography>;
+	}
+
+	return null;
+};
+
+ToastBody.propTypes = {
+	body: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+};
+
+export default ToastBody;

--- a/client/src/Components/Toast/index.jsx
+++ b/client/src/Components/Toast/index.jsx
@@ -1,0 +1,83 @@
+import Stack from "@mui/material/Stack";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import ToastBody from "./body";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import ErrorOutlineOutlinedIcon from "@mui/icons-material/ErrorOutlineOutlined";
+import WarningAmberOutlinedIcon from "@mui/icons-material/WarningAmberOutlined";
+import CloseIcon from "@mui/icons-material/Close";
+
+// Utils
+import { useTheme } from "@emotion/react";
+import PropTypes from "prop-types";
+
+const icons = {
+	info: <InfoOutlinedIcon />,
+	error: <ErrorOutlineOutlinedIcon />,
+	warning: <WarningAmberOutlinedIcon />,
+};
+
+const Toast = ({ variant, title, body, onClick, hasDismiss, hasIcon }) => {
+	const theme = useTheme();
+	const icon = icons[variant];
+
+	return (
+		<Stack
+			gap={theme.spacing(2)}
+			paddingTop={theme.spacing(4)}
+			paddingRight={theme.spacing(8)}
+			paddingBottom={theme.spacing(4)}
+			paddingLeft={theme.spacing(8)}
+			backgroundColor={theme.palette.alert.main}
+			border={`solid 1px ${theme.palette.alert.contrastText}`}
+			borderRadius={theme.shape.borderRadius}
+		>
+			<Stack
+				direction="row"
+				gap={theme.spacing(8)}
+				justifyContent="space-between"
+				alignItems="center"
+			>
+				{hasIcon && icon}
+				{title && (
+					<Typography
+						fontWeight="700"
+						color={theme.palette.secondary.contrastText}
+					>
+						{title}
+					</Typography>
+				)}
+				<IconButton onClick={onClick}>
+					<CloseIcon />
+				</IconButton>
+			</Stack>
+
+			<ToastBody body={body} />
+			{hasDismiss && (
+				<Button
+					variant="text"
+					color="info"
+					onClick={onClick}
+					sx={{
+						fontWeight: "600",
+						width: "fit-content",
+					}}
+				>
+					Dismiss
+				</Button>
+			)}
+		</Stack>
+	);
+};
+
+export default Toast;
+
+Toast.propTypes = {
+	variant: PropTypes.string.isRequired,
+	title: PropTypes.string,
+	body: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+	hasDismiss: PropTypes.bool,
+	hasIcon: PropTypes.bool,
+	onClick: PropTypes.func,
+};

--- a/client/src/Utils/toastUtils.jsx
+++ b/client/src/Utils/toastUtils.jsx
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import { toast, Slide } from "react-toastify";
-import Alert from "../Components/Alert";
-
+import Toast from "../Components/Toast";
 /**
  * @param {object} props
  * @param {'info' | 'error' | 'warning'} - The variant of the alert (e.g., "info", "error").
@@ -15,6 +14,7 @@ export const createToast = ({
 	variant = "info",
 	title,
 	body,
+	hasDismiss = false,
 	hasIcon = false,
 	config = {},
 }) => {
@@ -29,13 +29,14 @@ export const createToast = ({
 
 	toast(
 		({ closeToast }) => (
-			<Alert
+			<Toast
 				variant={variant}
 				title={title}
 				body={body}
 				isToast={true}
-				hasIcon={hasIcon}
 				onClick={closeToast}
+				hasDismiss={hasDismiss}
+				hasIcon={hasIcon}
 			/>
 		),
 		toastConfig
@@ -47,5 +48,6 @@ createToast.propTypes = {
 	title: PropTypes.string,
 	body: PropTypes.string.isRequired,
 	hasIcon: PropTypes.bool,
+	hasDismiss: PropTypes.bool,
 	config: PropTypes.object,
 };


### PR DESCRIPTION
The 'createToast` util uses an `Alert` component which has unused/redundant styles, references obsolete CSS, and is hard to read in general.  In addition, the `Alert` component has been used for other uses besides creating toasts and as such has become over generalized.

This PR creates a new dedicated `Toast` component that maintains the functionality and appearance of the old `Alert `component while being significantly easier to read.  It also allows displaying a list of items rather than just one item, which will be useful for displaying validation errors.

<img width="550" height="802" alt="Screenshot from 2025-07-16 10-29-16" src="https://github.com/user-attachments/assets/f970d8e1-a467-43ff-8695-dc92c2a3eebb" />
