### PR TITLE
Relax monitor URL validation

### DIFF
--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -128,40 +128,36 @@ const monitorValidation = joi.object({
 			.string()
 			.trim()
 			.custom((value, helpers) => {
-				const noProtocol = value.replace(/^(https?:\/\/)/, "");
+				// 1. Standard URLs: must have protocol and pass canParse()
+				if (/^(https?:\/\/)/.test(value)) {
+					if (
+						typeof URL !== "undefined" &&
+						typeof URL.canParse === "function" &&
+						URL.canParse(value)
+					) {
+						return value;
+					}
+					// else, it's a malformed URL with protocol
+					return helpers.error("string.invalidUrl");
+				}
 
-				if (/^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?(:\d{1,5})?$/.test(noProtocol)) {
+				// 2. Docker/internal hostnames (no protocol)
+				if (/^[a-zA-Z0-9]([a-zA-Z0-9.-]*[a-zA-Z0-9])?(:\d{1,5})?$/.test(value)) {
+					if (value.includes("..")) {
+						return helpers.error("string.invalidUrl");
+					}
+					// Split by dot, check each label
+					const labels = value.split(":")[0].split(".");
+					for (const label of labels) {
+						if (!label) return helpers.error("string.invalidUrl");
+						if (label.startsWith("-") || label.endsWith("-")) {
+							return helpers.error("string.invalidUrl");
+						}
+					}
 					return value;
 				}
 
-				// Accept full domain/IP/URL (as fallback)
-				var urlRegex = new RegExp(
-					"^" +
-						"(?:(?:https?|ftp):\\/\\/)?" +
-						"(?:" +
-						"(?:[1-9]\\d?|1\\d\\d|2[01]\\d|22[0-3])" +
-						"(?:\\.(?:1?\\d{1,2}|2[0-4]\\d|25[0-5])){2}" +
-						"(?:\\.(?:[1-9]\\d?|1\\d\\d|2[0-4]\\d|25[0-4]))" +
-						"|" +
-						"(?:" +
-						"(?:" +
-						"[a-z0-9\\u00a1-\\uffff]" +
-						"[a-z0-9\\u00a1-\\uffff_-]{0,62}" +
-						")?" +
-						"[a-z0-9\\u00a1-\\uffff]\\." +
-						")+" +
-						"(?:[a-z\\u00a1-\\uffff]{2,}\\.?)" +
-						")" +
-						"(?::\\d{2,5})?" +
-						"(?:[/?#]\\S*)?" +
-						"$",
-					"i"
-				);
-
-				if (urlRegex.test(value)) {
-					return value;
-				}
-
+				// 3. Everything else is invalid
 				return helpers.error("string.invalidUrl");
 			})
 			.messages({


### PR DESCRIPTION

## Describe your changes

Relaxed the monitor URL validation logic to allow Docker internal hostnames (such as containername) in addition to fully qualified domains and IP addresses. This makes it possible to monitor Docker containers by name in local/dev environments, as requested.

## Write your issue number after "Fixes "

Fixes #2605

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL validation to support both full URLs with protocols and Docker/internal hostnames without protocols.
  * Enhanced error messages to provide clearer guidance on invalid or empty URL inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->