### PR TITLE
Adding Global Threshold Settings

### DIFF
--- a/client/src/Pages/Settings/SettingsGlobalThresholds.jsx
+++ b/client/src/Pages/Settings/SettingsGlobalThresholds.jsx
@@ -1,0 +1,117 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import ConfigBox from "../../Components/ConfigBox";
+import TextInput from "../../Components/Inputs/TextInput";
+
+import { useTheme } from "@emotion/react";
+import { PropTypes } from "prop-types";
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+
+const SettingsGlobalThresholds = ({
+	isAdmin,
+	HEADING_SX,
+	settingsData,
+	setSettingsData,
+}) => {
+	const { t } = useTranslation();     // For language translation
+	const theme = useTheme();           // MUI theme access
+
+	// Local state for thresholds
+	const [thresholds, setThresholds] = useState({
+		cpu: "",
+		memory: "",
+		disk: "",
+		temperature: "",
+	});
+
+	// Load existing thresholds from settingsData on first render or when settingsData changes
+	useEffect(() => {
+		if (settingsData?.settings?.globalThresholds) {
+			setThresholds({
+				cpu: settingsData.settings.globalThresholds.cpu || "",
+				memory: settingsData.settings.globalThresholds.memory || "",
+				disk: settingsData.settings.globalThresholds.disk || "",
+				temperature: settingsData.settings.globalThresholds.temperature || "",
+			});
+		}
+	}, [settingsData]);
+
+	// Handles input change and updates state & parent data
+	const handleChange = (e, min, max) => {
+		const { name, value } = e.target;
+
+		// Allow empty or numeric value within range
+		if (
+			value === "" ||
+			(/^\d+$/.test(value) && Number(value) >= min && Number(value) <= max)
+		) {
+			const updatedThresholds = {
+				...thresholds,
+				[name]: value,
+			};
+
+			setThresholds(updatedThresholds);
+
+			// Update settingsData without enabling/disabling metrics
+			setSettingsData({
+				...settingsData,
+				settings: {
+					...settingsData.settings,
+					globalThresholds: updatedThresholds,
+				},
+			});
+		}
+	};
+
+	// Only render this section for admins
+	if (!isAdmin) return null;
+
+	return (
+		<ConfigBox>
+			{/* Header and description */}
+			<Box>
+				<Typography component="h1" variant="h2">
+					{t("settingsPage.globalThresholds.title", "Global Thresholds")}
+				</Typography>
+				<Typography sx={HEADING_SX}>
+					{t(
+						"settingsPage.globalThresholds.description",
+						"Configure global CPU, Memory, Disk, and Temperature thresholds."
+					)}
+				</Typography>
+			</Box>
+
+			{/* Threshold inputs */}
+			<Stack gap={theme.spacing(20)}>
+				{[
+					["CPU Threshold (%)", "cpu", 1, 100],
+					["Memory Threshold (%)", "memory", 1, 100],
+					["Disk Threshold (%)", "disk", 1, 100],
+					["Temperature Threshold (°C)", "temperature", 1, 150],
+				].map(([label, name, min, max]) => (
+					<TextInput
+						key={name}
+						name={name}
+						label={label}
+						placeholder={`${min} - ${max}`}
+						type="number"
+						value={thresholds[name]}
+						onChange={(e) => handleChange(e, min, max)}
+					/>
+				))}
+			</Stack>
+		</ConfigBox>
+	);
+};
+
+// Prop types
+SettingsGlobalThresholds.propTypes = {
+	isAdmin: PropTypes.bool,
+	HEADING_SX: PropTypes.object,
+	settingsData: PropTypes.object,
+	setSettingsData: PropTypes.func,
+};
+
+export default SettingsGlobalThresholds;

--- a/client/src/Pages/Settings/index.jsx
+++ b/client/src/Pages/Settings/index.jsx
@@ -8,6 +8,7 @@ import SettingsPagespeed from "./SettingsPagespeed";
 import SettingsDemoMonitors from "./SettingsDemoMonitors";
 import SettingsAbout from "./SettingsAbout";
 import SettingsEmail from "./SettingsEmail";
+import SettingsGlobalThresholds from "./SettingsGlobalThresholds";
 import Button from "@mui/material/Button";
 // Utils
 import { settingsValidation } from "../../Validation/validation";
@@ -48,6 +49,7 @@ const Settings = () => {
 		setIsApiKeySet,
 		setIsEmailPasswordSet,
 	});
+	
 	const [addDemoMonitors, isAddingDemoMonitors] = useAddDemoMonitors();
 
 	const [isSaving, saveError, saveSettings] = useSaveSettings({
@@ -60,6 +62,7 @@ const Settings = () => {
 	const [deleteAllMonitors, isDeletingMonitors] = useDeleteAllMonitors();
 	const [deleteMonitorStats, isDeletingMonitorStats] = useDeleteMonitorStats();
 
+	
 	// Setup
 	const isAdmin = useIsAdmin();
 	const theme = useTheme();
@@ -149,6 +152,7 @@ const Settings = () => {
 			error.details.forEach((err) => {
 				newErrors[err.path[0]] = err.message;
 			});
+			
 			setErrors(newErrors);
 		}
 		saveSettings(settingsData?.settings);
@@ -190,6 +194,13 @@ const Settings = () => {
 				handleChange={handleChange}
 				errors={errors}
 			/>
+			<SettingsGlobalThresholds
+				isAdmin={isAdmin}
+				HEADING_SX={HEADING_SX}
+				settingsData={settingsData}
+				setSettingsData={setSettingsData}
+			/>
+
 			<SettingsDemoMonitors
 				isAdmin={isAdmin}
 				HEADER_SX={HEADING_SX}

--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -301,7 +301,14 @@ const settingsValidation = joi.object({
 	systemEmailIgnoreTLS: joi.boolean(),
 	systemEmailRequireTLS: joi.boolean(),
 	systemEmailRejectUnauthorized: joi.boolean(),
+	globalThresholds: joi.object({
+		cpu: joi.number().min(1).max(100).allow("").optional(),
+		memory: joi.number().min(1).max(100).allow("").optional(),
+		disk: joi.number().min(1).max(100).allow("").optional(),
+		temperature: joi.number().min(1).max(150).allow("").optional(),
+	}).optional(),
 });
+
 
 const dayjsValidator = (value, helpers) => {
 	if (!dayjs(value).isValid()) {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -758,6 +758,10 @@
 			"title": "Display timezone"
 		},
 		"title": "Settings",
+		"globalThresholds": {
+      		"title": "Global Thresholds",
+      		"description": "Configure global CPU, Memory, Disk, and Temperature thresholds. If a value is provided, it will automatically be enabled for monitoring."
+		},
 		"uiSettings": {
 			"description": "Switch between light and dark mode, or change user interface language.",
 			"labelLanguage": "Language",

--- a/server/db/models/AppSettings.js
+++ b/server/db/models/AppSettings.js
@@ -65,7 +65,13 @@ const AppSettingsSchema = mongoose.Schema(
 			type: Number,
 			default: 1,
 		},
-	},
+		globalThresholds: {
+    		cpu: { type: Number },
+    		memory: { type: Number},
+    		disk: { type: Number},
+    		temperature: { type: Number},
+  		}	
+},
 	{
 		timestamps: true,
 	}

--- a/server/validation/joi.js
+++ b/server/validation/joi.js
@@ -431,7 +431,15 @@ const updateAppSettingsBodyValidation = joi.object({
 	systemEmailIgnoreTLS: joi.boolean(),
 	systemEmailRequireTLS: joi.boolean(),
 	systemEmailRejectUnauthorized: joi.boolean(),
+
+	globalThresholds: joi.object({
+		cpu: joi.number().min(1).max(100).allow("").optional(),
+		memory: joi.number().min(1).max(100).allow("").optional(),
+		disk: joi.number().min(1).max(100).allow("").optional(),
+		temperature: joi.number().min(1).max(150).allow("").optional(),
+	}).optional(),
 });
+
 
 //****************************************
 // Status Page Validation


### PR DESCRIPTION
## Describe your changes

I implemented a Global Thresholds section in the Settings page. Users can define CPU, Memory, Disk, and Temperature threshold values and save them. These values are stored and automatically pre-filled when the user navigates to the Infrastructure page, ensuring consistent threshold usage across the app. 

## Write your issue number after "Fixes "

Fixes #2628

Video link - https://drive.google.com/file/d/1_I9UfGoO76JwyGgmO4MIQIlVZsaV2BKG/view?usp=sharing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user interface for configuring global CPU, Memory, Disk, and Temperature thresholds in the settings page (admin only).
  * New global threshold values are now automatically populated when creating a new infrastructure monitor.

* **Bug Fixes**
  * Improved error handling and validation for global thresholds in settings.

* **Documentation**
  * Added new English localization entries for global threshold settings.

* **Chores**
  * Updated validation logic to support the new global threshold fields in both client and server settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->