### PR TITLE
Fix the broken breadcrumbs link

### DIFF
--- a/client/src/Pages/StatusPage/Create/index.jsx
+++ b/client/src/Pages/StatusPage/Create/index.jsx
@@ -239,7 +239,7 @@ const CreateStatusPage = () => {
 			<Breadcrumbs
 				list={[
 					{ name: t("statusBreadCrumbsStatusPages", "Status"), path: "/status" },
-					{ name: t("statusBreadCrumbsDetails", "Details"), path: `/status/${url}` },
+					{ name: t("statusBreadCrumbsDetails", "Details"), path: `/status/uptime/${url}` },
 					{ name: t("configure", "Configure"), path: `/status/create/${url}` },
 				]}
 			/>


### PR DESCRIPTION
## Changes Made

- Updated breadcrumbs  to use `/status/uptime/${url}` instead of `/status/${url}` 

## Issue "Fixed"

Fixes #2696  

## Checklist

- [x] I deployed the application locally.
- [x] I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.


