### PR TITLE
fix(edit-user): redirect current user to profile page when accessing …

### DIFF
--- a/client/src/Pages/Account/EditUser/index.jsx
+++ b/client/src/Pages/Account/EditUser/index.jsx
@@ -9,17 +9,28 @@ import Button from "@mui/material/Button";
 import RoleTable from "../components/RoleTable";
 
 // Utils
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useTheme } from "@emotion/react";
 import { useTranslation } from "react-i18next";
 import { useGetUser, useEditUser } from "../../../Hooks/userHooks";
 import { EDITABLE_ROLES, ROLES } from "../../../Utils/roleUtils";
 import { useEditUserForm, useValidateEditUserForm } from "./hooks/editUser";
+import { useSelector } from "react-redux";
+import { useEffect } from "react";
 
 const EditUser = () => {
 	const { userId } = useParams();
 	const theme = useTheme();
 	const { t } = useTranslation();
+	const navigate = useNavigate();
+	const currentUser = useSelector((state) => state.auth.user);
+
+	useEffect(() => {
+		if (currentUser?._id && userId === currentUser._id) {
+			navigate("/account/profile");
+		}
+	}, [userId, currentUser?._id, navigate]);
+
 	const BREADCRUMBS = [
 		{ name: t("menu.team"), path: "/account/team" },
 		{ name: t("editUserPage.title"), path: "" },

--- a/client/src/Pages/Account/components/TeamPanel.jsx
+++ b/client/src/Pages/Account/components/TeamPanel.jsx
@@ -90,14 +90,14 @@ const TeamPanel = () => {
 		};
 		let team = members;
 		if (filter !== "all")
-			team = members.filter((member) => {
+			team = members?.filter((member) => {
 				if (filter === "admin") {
 					return member.role.includes("admin") || member.role.includes("superadmin");
 				}
 				return member.role.includes(filter);
 			});
 
-		team = team.map((member) => ({
+		team = team?.map((member) => ({
 			...member,
 			id: member._id,
 			role: member.role.map((role) => ROLE_MAP[role]).join(","),


### PR DESCRIPTION
…self via team route

**(Please remove this line only before submitting your PR. Ensure that all relevant items are checked before submission.)** 

## Describe your changes

Briefly describe the changes you made and their purpose. 

- Added a check to detect if the current user is trying to access their own edit page via the /account/team/:userId route.

- Implemented a redirect to /account/profile when self-edit is attempted from the team route.

- Ensures consistent user experience by handling self-edit only through the profile page.

- Prevents UI issues where Redux state wouldn’t update properly on self-edit via team view.

- 🔗 Attached a short video demonstrating the behavior before and after the fix for clarity.

## Write your issue number after "Fixes "

Fixes #2716

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


https://github.com/user-attachments/assets/4afe72b4-7448-4ff3-af02-b04a53779868

