### PR TITLE
Add missing Telegram support to notifications dropdown

### DIFF
--- a/client/src/Pages/Notifications/utils.js
+++ b/client/src/Pages/Notifications/utils.js
@@ -4,6 +4,7 @@ export const NOTIFICATION_TYPES = [
 	{ _id: 3, name: "PagerDuty", value: "pager_duty" },
 	{ _id: 4, name: "Webhook", value: "webhook" },
 	{ _id: 5, name: "Discord", value: "discord" },
+	{ _id: 6, name: "Telegram", value: "telegram" },
 ];
 
 export const TITLE_MAP = {
@@ -12,6 +13,7 @@ export const TITLE_MAP = {
 	pager_duty: "createNotifications.pagerDutySettings.title",
 	webhook: "createNotifications.webhookSettings.title",
 	discord: "createNotifications.discordSettings.title",
+	telegram: "createNotifications.telegramSettings.title",
 };
 
 export const DESCRIPTION_MAP = {
@@ -20,6 +22,7 @@ export const DESCRIPTION_MAP = {
 	pager_duty: "createNotifications.pagerDutySettings.description",
 	webhook: "createNotifications.webhookSettings.description",
 	discord: "createNotifications.discordSettings.description",
+	telegram: "createNotifications.telegramSettings.description",
 };
 
 export const LABEL_MAP = {
@@ -28,6 +31,7 @@ export const LABEL_MAP = {
 	pager_duty: "createNotifications.pagerDutySettings.integrationKeyLabel",
 	webhook: "createNotifications.webhookSettings.webhookLabel",
 	discord: "createNotifications.discordSettings.webhookLabel",
+	telegram: "createNotifications.telegramSettings.tokenLabel",
 };
 
 export const PLACEHOLDER_MAP = {
@@ -36,4 +40,5 @@ export const PLACEHOLDER_MAP = {
 	pager_duty: "createNotifications.pagerDutySettings.integrationKeyPlaceholder",
 	webhook: "createNotifications.webhookSettings.webhookPlaceholder",
 	discord: "createNotifications.discordSettings.webhookPlaceholder",
+	telegram: "createNotifications.telegramSettings.tokenPlaceholder",
 };

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -288,6 +288,12 @@
 			"webhookLabel": "Slack webhook URL",
 			"webhookPlaceholder": "https://hooks.slack.com/services/..."
 		},
+		"telegramSettings": {
+			"description": "Configure your Telegram bot here",
+			"title": "Telegram",
+			"tokenLabel": "Bot token",
+			"tokenPlaceholder": "123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11"
+		},
 		"testNotification": "Test notification",
 		"title": "Create notification channel",
 		"typeSettings": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -665,6 +665,12 @@
 			"webhookLabel": "",
 			"webhookPlaceholder": ""
 		},
+		"telegramSettings": {
+			"title": "",
+			"description": "",
+			"tokenLabel": "",
+			"tokenPlaceholder": ""
+		},
 		"pagerdutySettings": {
 			"title": "",
 			"description": "",

--- a/client/src/locales/pt-BR.json
+++ b/client/src/locales/pt-BR.json
@@ -665,6 +665,12 @@
 			"webhookLabel": "",
 			"webhookPlaceholder": ""
 		},
+		"telegramSettings": {
+			"title": "",
+			"description": "",
+			"tokenLabel": "",
+			"tokenPlaceholder": ""
+		},
 		"pagerdutySettings": {
 			"title": "",
 			"description": "",

--- a/server/src/db/models/Notification.js
+++ b/server/src/db/models/Notification.js
@@ -16,7 +16,7 @@ const NotificationSchema = mongoose.Schema(
 		},
 		type: {
 			type: String,
-			enum: ["email", "slack", "discord", "webhook", "pager_duty"],
+			enum: ["email", "slack", "discord", "webhook", "pager_duty", "telegram"],
 		},
 		notificationName: {
 			type: String,


### PR DESCRIPTION
Fix: Add missing Telegram support to notifications dropdown


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Telegram as a new notification type.
  * Introduced new fields and localization entries for configuring Telegram notifications in the user interface.

* **Localization**
  * Added English localization strings for Telegram notification settings.
  * Added placeholder entries for Telegram settings in Spanish and Portuguese (Brazil) locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->