### PR TITLE
ci: remove extra 'Close PR' step in check-format workflow

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -39,24 +39,3 @@ jobs:
       - name: Check server formatting
         working-directory: server
         run: npm run format-check
-  close-pr-if-needed:
-    if: always()
-    runs-on: ubuntu-latest
-    needs: [format-client, format-server]
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Get PR number
-        id: pr
-        run: echo "PR_NUMBER=$(jq -r .pull_request.number "$GITHUB_EVENT_PATH")" >> $GITHUB_ENV
-
-      - name: Close PR using GitHub CLI
-        if: |
-          needs.format-client.result == 'failure' || 
-          needs.format-server.result == 'failure'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr close "$PR_NUMBER" --delete-branch --comment "❌ Formatting check failed — PR auto-closed.
-          Please run \`npm run format\` in both `client` and `server` directories and push again."


### PR DESCRIPTION
## Describe your changes

Deleted `close-pr-if-needed` that causes so many closed PRs.

Instead of closing the PR and deleting the remote branch instantly we can say "please run `npm run format` before pushing your changes" to new comers.

```shell
Checking formatting...
[warn] src/app.js
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
Error: Process completed with exit code 1.
```