### PR TITLE
Fix: Reduce animated gif size to 2/3 in empty states

### DIFF
--- a/client/src/Components/Fallback/FallbackBackground.jsx
+++ b/client/src/Components/Fallback/FallbackBackground.jsx
@@ -19,10 +19,8 @@ const FallbackBackground = () => {
 					zIndex: 1,
 					border: "none",
 					borderRadius: theme.spacing(8),
-					width: "66.67%", // 2/3 of original size
-					maxWidth: "66.67%",
-					display: "block",
-					objectFit: "contain",
+					width: "100%",
+					transform: "scale(0.6667)",
 				}}
 			/>
 			<Box

--- a/client/src/Components/Fallback/FallbackBackground.jsx
+++ b/client/src/Components/Fallback/FallbackBackground.jsx
@@ -19,7 +19,10 @@ const FallbackBackground = () => {
 					zIndex: 1,
 					border: "none",
 					borderRadius: theme.spacing(8),
-					width: "100%",
+					width: "66.67%", // 2/3 of original size
+					maxWidth: "66.67%",
+					display: "block",
+					objectFit: "contain",
 				}}
 			/>
 			<Box


### PR DESCRIPTION
Reduces animated gif size from 100% to 66.67% width in fallback components for better visual balance in empty state screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Scales the loading image to two-thirds size for a more balanced fallback display.
  * Maintains full-width layout while reducing visual dominance and distortion across screen sizes.
  * Preserves consistent spacing and alignment for cleaner loading states.
  * Improves responsiveness and prevents overflow for a more polished user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->