### PR TITLE
feat: add a request logger

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -11,7 +11,7 @@ import { handleErrors } from "./middleware/handleErrors.js";
 import { setupRoutes } from "./config/routes.js";
 import { generalApiLimiter } from "./middleware/rateLimiter.js";
 import { sanitizeBody, sanitizeQuery } from "./middleware/sanitization.js";
-
+import { requestLogger } from "./middleware/requestLogger.js";
 export const createApp = ({ services, controllers, envSettings, frontendPath, openApiSpec }) => {
 	const allowedOrigin = envSettings.clientHost;
 
@@ -36,6 +36,7 @@ export const createApp = ({ services, controllers, envSettings, frontendPath, op
 
 	app.use(sanitizeBody());
 	app.use(sanitizeQuery());
+	app.use(requestLogger);
 
 	app.use(
 		helmet({

--- a/server/src/middleware/requestLogger.js
+++ b/server/src/middleware/requestLogger.js
@@ -1,0 +1,44 @@
+import { logger } from "../utils/logger.js";
+
+const requestLogger = (req, res, next) => {
+	if (process.env.LOG_REQUESTS === "true") {
+		const start = process.hrtime.bigint();
+		const { method, url, ip } = req;
+		const userAgent = req.get("User-Agent") || "Unknown";
+		const requestId = Math.random().toString(36).substring(2, 11);
+
+		const baseDetails = { requestId, method, url, ip, userAgent };
+
+		logger.info({
+			message: `${method} ${url}`,
+			service: "RequestLogger",
+			method: "incoming",
+			details: baseDetails,
+		});
+
+		res.on("finish", () => {
+			const end = process.hrtime.bigint();
+			const duration = Number(end - start) / 1000000; // Convert to milliseconds
+			const { statusCode } = res;
+			const contentLength = res.get("Content-Length") || 0;
+
+			const logLevel = statusCode >= 400 ? "warn" : "info";
+
+			logger[logLevel]({
+				message: `${method} ${url} ${statusCode}`,
+				service: "RequestLogger",
+				method: "completed",
+				details: {
+					...baseDetails,
+					statusCode,
+					duration: `${duration.toFixed(2)}ms`,
+					contentLength: `${contentLength} bytes`,
+				},
+			});
+		});
+	}
+
+	next();
+};
+
+export { requestLogger };


### PR DESCRIPTION
This PR adds request logging middleware to the project.

It is enabled by `LOG_REQUESTS` env var, this should be set to `true` to log requests.