### PR TITLE
remove redis from workflows

### DIFF
--- a/.github/workflows/deploy-images.yml
+++ b/.github/workflows/deploy-images.yml
@@ -74,18 +74,6 @@ jobs:
         run: |
           docker push ghcr.io/bluewave-labs/checkmate-mongo:latest
 
-      - name: Build Redis Docker image
-        run: |
-          docker build \
-            -t ghcr.io/bluewave-labs/checkmate-redis:latest \
-            -f ./docker/dist/redis.Dockerfile \
-            --label org.opencontainers.image.source=https://github.com/bluewave-labs/checkmate \
-            .
-
-      - name: Push Redis Docker image
-        run: |
-          docker push ghcr.io/bluewave-labs/checkmate-redis:latest
-
   docker-build-and-push-server-mono-multiarch:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -71,17 +71,6 @@ jobs:
       - name: Push MongoDB Docker image
         run: docker push ghcr.io/bluewave-labs/checkmate:mongo-staging
 
-      - name: Build Redis Docker image
-        run: |
-          docker build \
-            -t ghcr.io/bluewave-labs/checkmate:redis-staging \
-            -f ./docker/staging/redis.Dockerfile \
-            --label org.opencontainers.image.source=https://github.com/bluewave-labs/checkmate \
-            .
-
-      - name: Push Redis Docker image
-        run: docker push ghcr.io/bluewave-labs/checkmate:redis-staging
-
   deploy-to-staging:
     needs: docker-build-and-push-server
     runs-on: ubuntu-latest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined deployment pipelines by removing Redis image build and push steps from production and staging workflows.
  * All other images (frontend, backend, Mongo, multi-arch) continue to build and deploy as before.
  * No impact on application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->