### PR TITLE
add capture to prod and staging docker-compose

### DIFF
--- a/docker/prod/docker-compose.yaml
+++ b/docker/prod/docker-compose.yaml
@@ -49,3 +49,14 @@ services:
       start_period: 0s
       start_interval: 1s
       retries: 30
+  capture:
+    image: ghcr.io/bluewave-labs/capture:latest
+    container_name: capture
+    restart: unless-stopped
+    ports:
+      - "59232:59232"
+    environment:
+      - API_SECRET=my_secret
+      - GIN_MODE=release
+    volumes:
+      - /etc/os-release:/etc/os-release:ro

--- a/docker/staging/docker-compose.yaml
+++ b/docker/staging/docker-compose.yaml
@@ -49,3 +49,14 @@ services:
       start_period: 0s
       start_interval: 1s
       retries: 30
+  capture:
+    image: ghcr.io/bluewave-labs/capture:latest
+    container_name: capture
+    restart: unless-stopped
+    ports:
+      - "59232:59232"
+    environment:
+      - API_SECRET=my_secret
+      - GIN_MODE=release
+    volumes:
+      - /etc/os-release:/etc/os-release:ro


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new public “Capture” service now available in both Staging and Production, accessible on port 59232.
* **Chores**
  * Updated deployment configuration to include the Capture service with automatic restart behavior and production-ready runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->