### PR TITLE
Fix: Set Server Logs as default tab on Logs page

### DIFF
--- a/client/src/Pages/Logs/index.jsx
+++ b/client/src/Pages/Logs/index.jsx
@@ -15,7 +15,7 @@ const Logs = () => {
 	const theme = useTheme();
 
 	// Local state
-	const [value, setValue] = useState(2);
+	const [value, setValue] = useState(0);
 
 	// Handlers
 	const handleChange = (event, newValue) => {


### PR DESCRIPTION
## Summary
Fixes the default tab selection on the Logs page. When users navigate to the Logs section from the sidebar, the "Server Logs" tab should be active by default instead of the "Diagnostics" tab.

## Problem
- When clicking "Logs" in the sidebar, the "Diagnostics" tab was the default active tab
- This was confusing since "Server Logs" is the first tab and more logical default
- Users would have to manually click on "Server Logs" every time they visited the page

## Solution
Changed the default `useState` value from `2` (Diagnostics) to `0` (Server Logs) in the Logs component.

**Before:**
```javascript
const [value, setValue] = useState(2); // Diagnostics tab
```

**After:**
```javascript
const [value, setValue] = useState(0); // Server Logs tab
```

## Tab Structure
- Index 0: "Server Logs" ← **Now default**
- Index 1: "Queue" 
- Index 2: "Diagnostics" ← *Previously default*

## Files Changed
- `client/src/Pages/Logs/index.jsx` - Updated default tab state

## Testing
- ✅ Server Logs tab is now active by default when navigating to `/logs`
- ✅ Tab switching functionality remains intact
- ✅ No regression in other tab behaviors

This improves the user experience by making the most commonly accessed tab (Server Logs) the default when entering the Logs section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the Logs page to open with the Logs tab selected by default instead of Diagnostics. This streamlines access to primary log information on first load.
  * No changes to user-facing controls or workflows beyond the initial tab selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->