### PR TITLE
Fix: Remove description text and dividers from Logs sections

### DIFF
--- a/client/src/Pages/Logs/Logs/index.jsx
+++ b/client/src/Pages/Logs/Logs/index.jsx
@@ -51,25 +51,6 @@ const Logs = () => {
 	];
 	return (
 		<Stack gap={theme.spacing(4)}>
-			<Box
-				sx={{
-					position: "sticky",
-					top: theme.spacing(17),
-					backdropFilter: "blur(10px)",
-					paddingY: theme.spacing(5),
-					paddingLeft: theme.spacing(6),
-				}}
-			>
-				<Typography variant="h2">{t("logsPage.description")}</Typography>
-			</Box>
-			<Divider
-				color={theme.palette.accent.main}
-				sx={{
-					position: "sticky",
-					top: theme.spacing(33),
-					backdropFilter: "blur(10px)",
-				}}
-			/>
 
 			<Stack
 				direction="row"

--- a/client/src/Pages/Logs/Logs/index.jsx
+++ b/client/src/Pages/Logs/Logs/index.jsx
@@ -56,10 +56,9 @@ const Logs = () => {
 				direction="row"
 				alignItems="center"
 				gap={theme.spacing(4)}
-				mt={theme.spacing(10)}
 				sx={{
 					position: "sticky",
-					top: theme.spacing(34),
+					top: theme.spacing(17),
 					backdropFilter: "blur(10px)",
 					paddingTop: theme.spacing(4),
 					paddingLeft: theme.spacing(6),

--- a/client/src/Pages/Logs/Queue/index.jsx
+++ b/client/src/Pages/Logs/Queue/index.jsx
@@ -29,8 +29,6 @@ const QueueDetails = () => {
 
 	return (
 		<Stack gap={theme.spacing(4)}>
-			<Typography variant="h2">{t("queuePage.metricsTable.title")}</Typography>
-			<Divider color={theme.palette.accent.main} />
 			<Stack
 				gap={theme.spacing(20)}
 				mt={theme.spacing(10)}


### PR DESCRIPTION
## Summary
Removes redundant description text and divider lines from the Server logs and Queue metrics sections to clean up the UI and eliminate unnecessary spacing.

## Changes Made

### Server Logs Tab
**Removed:**
- Description text: "System logs - last 1000 lines"
- Divider line below the description
- Excess top margin spacing (`mt={theme.spacing(10)}`)
- Adjusted sticky positioning for proper alignment with tab bar

### Queue Metrics Tab  
**Removed:**
- Description text: Queue metrics title
- Divider line below the description

## Rationale
- Description strings are redundant since users can infer content from tab names and actual content
- Removing them creates a cleaner, less cluttered interface
- Eliminates unwanted spacing between tab bar and content
- Improves visual hierarchy by removing unnecessary elements

## Files Changed
- `client/src/Pages/Logs/Logs/index.jsx` - Removed description, divider, and spacing
- `client/src/Pages/Logs/Queue/index.jsx` - Removed description and divider

## Visual Impact
- Cleaner interface with less visual noise
- Proper spacing between tab bar and "Log level" dropdown
- More space for actual log content
- Better focus on functional elements

## Testing
- ✅ Server logs tab loads with proper spacing
- ✅ Queue metrics tab loads without description/divider  
- ✅ No unwanted gaps between UI elements
- ✅ All functionality remains intact