### PR TITLE
Apply consistent styling to queue buttons and set server logs as default tab

### DIFF
--- a/client/src/Pages/Logs/Queue/index.jsx
+++ b/client/src/Pages/Logs/Queue/index.jsx
@@ -39,34 +39,50 @@ const QueueDetails = () => {
 				<JobTable jobs={jobs} />
 				<FailedJobTable metrics={metrics} />
 
-				<ButtonGroup
-					variant="contained"
-					color="accent"
+				<Stack
+					direction="row"
+					justifyContent="flex-end"
 					sx={{
 						position: "sticky",
 						bottom: 0,
+						boxShadow: theme.shape.boxShadow,
 						zIndex: 1000,
+						mt: 3,
 						backgroundColor: theme.palette.primary.main,
-						p: theme.spacing(4),
-						border: `1px solid ${theme.palette.primary.lowContrast}`,
+						display: "flex",
+						justifyContent: "flex-end",
+						pb: theme.spacing(4),
+						pr: theme.spacing(15),
+						pl: theme.spacing(5),
+						pt: theme.spacing(4),
+						border: 1,
+						borderStyle: "solid",
+						borderColor: theme.palette.primary.lowContrast,
 						borderRadius: theme.spacing(2),
 					}}
 				>
+					<ButtonGroup
+						variant="contained"
+						color="accent"
+					>
 					<Button
 						onClick={() => {
 							setTrigger(!trigger);
 						}}
 						loading={isLoading}
+						sx={{ px: theme.spacing(12), py: theme.spacing(8) }}
 					>
 						{t("queuePage.refreshButton")}
 					</Button>
 					<Button
 						onClick={() => flushQueue(trigger, setTrigger)}
 						loading={isFlushing}
+						sx={{ px: theme.spacing(12), py: theme.spacing(8) }}
 					>
 						{t("queuePage.flushButton")}
 					</Button>
-				</ButtonGroup>
+					</ButtonGroup>
+				</Stack>
 			</Stack>
 		</Stack>
 	);

--- a/client/src/Pages/Logs/index.jsx
+++ b/client/src/Pages/Logs/index.jsx
@@ -15,7 +15,7 @@ const Logs = () => {
 	const theme = useTheme();
 
 	// Local state
-	const [value, setValue] = useState(2);
+	const [value, setValue] = useState(0);
 
 	// Handlers
 	const handleChange = (event, newValue) => {


### PR DESCRIPTION
## Summary
- Apply Settings save button styling to Refresh and Flush queue buttons in Job queue
- Wrap buttons in consistent Stack component with sticky positioning and proper spacing  
- Set Server Logs as default tab when navigating to Logs section
- Ensure visual consistency across Settings and Queue button areas

## Test plan
- [x] Navigate to Logs section and verify Server Logs is the default tab
- [x] Navigate to Logs > Job queue and verify buttons have consistent styling with Settings save button
- [x] Verify buttons are right-aligned with proper spacing and sticky positioning
- [x] Test button functionality (Refresh and Flush queue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default view now opens on the Logs tab instead of Diagnostics.
- Style
  - Bottom action bar updated to a sticky footer with improved spacing, shadow, and borders for better visibility.
  - Action buttons now have consistent padding for uniform sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->