### PR TITLE
Fix: resolve erroneous PageSpeed settings validation

### DIFF
--- a/client/src/Pages/PageSpeed/Create/index.jsx
+++ b/client/src/Pages/PageSpeed/Create/index.jsx
@@ -152,7 +152,7 @@ const PageSpeedSetup = () => {
 		});
 
 		const { error } = monitorValidation.validate(
-			{ ...monitor, [name]: value },
+			{ [name]: value, type: monitor.type },
 			{ abortEarly: false }
 		);
 		setErrors((prev) => ({

--- a/client/src/Pages/PageSpeed/Create/index.jsx
+++ b/client/src/Pages/PageSpeed/Create/index.jsx
@@ -152,7 +152,7 @@ const PageSpeedSetup = () => {
 		});
 
 		const { error } = monitorValidation.validate(
-			{ [name]: value },
+			{ ...monitor, [name]: value },
 			{ abortEarly: false }
 		);
 		setErrors((prev) => ({

--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -213,7 +213,6 @@ const monitorValidation = joi.object({
 		}),
 		otherwise: joi.string().allow(null, ""),
 	}),
-	notifications: joi.array().optional(),
 });
 
 const imageValidation = joi.object({

--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -213,6 +213,7 @@ const monitorValidation = joi.object({
 		}),
 		otherwise: joi.string().allow(null, ""),
 	}),
+	notifications: joi.array().optional(),
 });
 
 const imageValidation = joi.object({


### PR DESCRIPTION
## Describe your changes

Fixes #2799 

The field-level validation in `handleChange` was only passing the single changed field to the validator, missing the type context needed for conditional port validation rules. After that, the field validation read “"notifications" is not allowed”, so this also ensures that `notifications` are declared as an optional array.

With both of these changes made, I’m able to successfully create a PageSpeed monitor as expected, with and without selecting notifications.

## Checklist

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- ~~I have added i18n support to visible strings (instead of `<div>Add</div>`).~~ No new strings added.
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- ~~I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.~~ No visual changes applied.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- ~~I took a screenshot or a video and attached to this PR if there is a UI change.~~ No UI change unless you count the absence of validation errors.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Form validation now considers the selected monitor type when editing fields, ensuring rules are applied correctly for each type.
  * Reduces false validation errors and prevents invalid field/type combinations during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->