### PR TITLE
Feature/template

### DIFF
--- a/client/src/Pages/Infrastructure/Create/index.jsx
+++ b/client/src/Pages/Infrastructure/Create/index.jsx
@@ -133,38 +133,35 @@ const CreateInfrastructureMonitor = () => {
 	// Populate form fields if editing or on create default
 	useEffect(() => {
 		if (isCreate || !monitor) return;
-			const { thresholds = {} } = monitor;
+		const { thresholds = {} } = monitor;
 
-			setHttps(monitor.url.startsWith("https"));
+		setHttps(monitor.url.startsWith("https"));
 
-			setInfrastructureMonitor({
-				url: monitor.url.replace(/^https?:\/\//, ""),
-				name: monitor.name || "",
-				notifications: monitor.notifications || [],
-				interval: monitor.interval / MS_PER_MINUTE,
-				cpu: thresholds.usage_cpu !== undefined,
-				usage_cpu:
-					thresholds.usage_cpu !== undefined
-						? (thresholds.usage_cpu * 100).toString()
-						: "",
-				memory: thresholds.usage_memory !== undefined,
-				usage_memory:
-					thresholds.usage_memory !== undefined
-						? (thresholds.usage_memory * 100).toString()
-						: "",
-				disk: thresholds.usage_disk !== undefined,
-				usage_disk:
-					thresholds.usage_disk !== undefined
-						? (thresholds.usage_disk * 100).toString()
-						: "",
-				temperature: thresholds.usage_temperature !== undefined,
-				usage_temperature:
-					thresholds.usage_temperature !== undefined
-						? (thresholds.usage_temperature * 100).toString()
-						: "",
-				secret: monitor.secret || "",
-			});
-		
+		setInfrastructureMonitor({
+			url: monitor.url.replace(/^https?:\/\//, ""),
+			name: monitor.name || "",
+			notifications: monitor.notifications || [],
+			interval: monitor.interval / MS_PER_MINUTE,
+			cpu: thresholds.usage_cpu !== undefined,
+			usage_cpu:
+				thresholds.usage_cpu !== undefined ? (thresholds.usage_cpu * 100).toString() : "",
+			memory: thresholds.usage_memory !== undefined,
+			usage_memory:
+				thresholds.usage_memory !== undefined
+					? (thresholds.usage_memory * 100).toString()
+					: "",
+			disk: thresholds.usage_disk !== undefined,
+			usage_disk:
+				thresholds.usage_disk !== undefined
+					? (thresholds.usage_disk * 100).toString()
+					: "",
+			temperature: thresholds.usage_temperature !== undefined,
+			usage_temperature:
+				thresholds.usage_temperature !== undefined
+					? (thresholds.usage_temperature * 100).toString()
+					: "",
+			secret: monitor.secret || "",
+		});
 	}, [isCreate, monitor]);
 
 	// Handlers
@@ -303,7 +300,6 @@ const CreateInfrastructureMonitor = () => {
 		if (!selected) return;
 
 		const thresholds = thresholdTemplatesState[selected] || {};
-		console.log("Applying thresholds:", thresholds);
 
 		setInfrastructureMonitor({
 			...infrastructureMonitor,
@@ -585,13 +581,13 @@ const CreateInfrastructureMonitor = () => {
 						{!globalSettingsLoading && templateKeysState.length > 0 && (
 							<Stack gap={theme.spacing(6)}>
 								<FormControl fullWidth>
-									<InputLabel id="threshold-template-label">{t("Template")}</InputLabel>
+									<InputLabel id="threshold-template-label">{t("InfrastructureSelectTemplate")}</InputLabel>
 									<MuiSelect
 										labelId="threshold-template-label"
 										value={thresholdTemplate || ""}
 										onChange={handleThresholdTemplateChange}
 									>
-										<MenuItem value="">{t("Select Template")}</MenuItem>
+										<MenuItem value="">{t("InfrastructureSelectTemplate")}</MenuItem>
 										{templateKeysState.map((key) => (
 											<MenuItem
 												key={key}

--- a/client/src/Pages/Settings/SettingsGlobalThresholds.jsx
+++ b/client/src/Pages/Settings/SettingsGlobalThresholds.jsx
@@ -78,6 +78,8 @@ const SettingsGlobalThresholds = ({
 			},
 		}));
 		setTemplateValue("");
+		setThresholdValues({ cpu: "", memory: "", disk: "", temperature: "" });
+
 	};
 
 	const onchangeDropdown = (e) => {

--- a/client/src/Pages/Settings/SettingsGlobalThresholds.jsx
+++ b/client/src/Pages/Settings/SettingsGlobalThresholds.jsx
@@ -3,10 +3,16 @@ import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import ConfigBox from "../../Components/ConfigBox";
 import TextInput from "../../Components/Inputs/TextInput";
+import MenuItem from "@mui/material/MenuItem";
+import FormControl from "@mui/material/FormControl";
+import InputLabel from "@mui/material/InputLabel";
+import Select from "@mui/material/Select";
+import Button from "@mui/material/Button";
 
 import { useTheme } from "@emotion/react";
 import { PropTypes } from "prop-types";
 import { useTranslation } from "react-i18next";
+import { useState } from "react";
 
 const SettingsGlobalThresholds = ({
 	isAdmin,
@@ -14,38 +20,113 @@ const SettingsGlobalThresholds = ({
 	settingsData,
 	setSettingsData,
 }) => {
-	const { t } = useTranslation(); // For language translation
-	const theme = useTheme(); // MUI theme access
+	const { t } = useTranslation();
+	const theme = useTheme();
 
-	// Handles input change and updates parent state
-	const handleChange = (e, min, max) => {
-		const { name, value } = e.target;
+	const [templateValue, setTemplateValue] = useState(""); // selected template
+	const [textBoxValue, setTextBoxValue] = useState(""); // new template name
+	const [thresholdValues, setThresholdValues] = useState({
+		cpu: "",
+		memory: "",
+		disk: "",
+		temperature: "",
+	});
+	console.log(settingsData);
+	if (!isAdmin) return null;
 
-		const numValue = parseFloat(value);
-		const isValidNumber =
-			value === "" ||
-			(!isNaN(numValue) && isFinite(numValue) && numValue >= min && numValue <= max);
+	// Threshold ranges
+	const ranges = {
+		cpu: { min: 1, max: 100 },
+		memory: { min: 1, max: 100 },
+		disk: { min: 1, max: 100 },
+		temperature: { min: 1, max: 150 },
+	};
 
-		if (isValidNumber) {
-			setSettingsData((prev) => ({
-				...prev,
-				settings: {
-					...prev.settings,
-					globalThresholds: {
-						...prev.settings?.globalThresholds,
-						[name]: value,
-					},
-				},
-			}));
+	// Handle create/edit/delete templates
+	const handleUpdate = () => {
+		const selectedTemplate = templateValue;
+		const newTemplateName = textBoxValue?.trim();
+
+		// Build thresholds object with numbers only
+		const thresholds = {};
+		["cpu", "memory", "disk", "temperature"].forEach((key) => {
+			const val = thresholdValues[key];
+			if (val !== "") thresholds[key] = Number(val); // convert to number
+		});
+
+		// Copy current templates
+		const templates = { ...settingsData?.settings?.globalThresholds };
+
+		// Delete template if selected and all thresholds empty
+		if (selectedTemplate && Object.keys(thresholds).length === 0) {
+			delete templates[selectedTemplate];
+			setTemplateValue("");
+		} else if (
+			(newTemplateName || selectedTemplate) &&
+			Object.keys(thresholds).length > 0
+		) {
+			const name = newTemplateName || selectedTemplate;
+			templates[name] = thresholds;
+			setTemplateValue(name);
+			if (newTemplateName) setTextBoxValue("");
+		}
+
+		// Update state
+		setSettingsData((prev) => ({
+			...prev,
+			settings: {
+				...prev.settings,
+				globalThresholds: templates,
+			},
+		}));
+	};
+
+	const onchangeDropdown = (e) => {
+		const selected = e.target.value;
+		setTemplateValue(selected);
+
+		if (selected) {
+			setThresholdValues({
+				cpu: settingsData?.settings?.globalThresholds?.[selected]?.cpu || "",
+				memory: settingsData?.settings?.globalThresholds?.[selected]?.memory || "",
+				disk: settingsData?.settings?.globalThresholds?.[selected]?.disk || "",
+				temperature:
+					settingsData?.settings?.globalThresholds?.[selected]?.temperature || "",
+			});
+		} else {
+			setThresholdValues({ cpu: "", memory: "", disk: "", temperature: "" });
 		}
 	};
 
-	// Only render this section for admins
-	if (!isAdmin) return null;
+	// Template keys for dropdown
+	const templateKeys = settingsData?.settings?.globalThresholds
+		? Object.keys(settingsData.settings.globalThresholds)
+		: [];
+
+	// Input change with validation
+	const handleThresholdChange = (name, value) => {
+		const { min, max } = ranges[name];
+		let val = value;
+
+		if (val != "") {
+			val = parseInt(val, 10);
+			if (isNaN(val)) val = "";
+			else if (val < min) val = min;
+			else if (val > max) val = max;
+		}
+
+		setThresholdValues((prev) => ({
+			...prev,
+			[name]: val,
+		}));
+	};
+
+	// Disable update if no template selected and no new template
+	const isUpdateDisabled = !templateValue && !textBoxValue.trim();
 
 	return (
 		<ConfigBox>
-			{/* Header and description */}
+			{/* Header */}
 			<Box>
 				<Typography
 					component="h1"
@@ -61,30 +142,90 @@ const SettingsGlobalThresholds = ({
 				</Typography>
 			</Box>
 
-			{/* Threshold inputs */}
 			<Stack gap={theme.spacing(20)}>
-				{[
-					["CPU Threshold (%)", "cpu", 1, 100],
-					["Memory Threshold (%)", "memory", 1, 100],
-					["Disk Threshold (%)", "disk", 1, 100],
-					["Temperature Threshold (°C)", "temperature", 1, 150],
-				].map(([label, name, min, max]) => (
+				{/* Template Section */}
+				<Stack gap={theme.spacing(10)}>
+					<Box>
+						<Typography
+							component="h1"
+							variant="h2"
+						>
+							{t("settingsPage.globalThresholds.templateHeading", "Template Settings")}
+						</Typography>
+						<Typography sx={HEADING_SX}>
+							{t(
+								"settingsPage.globalThresholds.templateDescription",
+								"Select a template to edit its values, then click Update. To delete, select a template and leave all values empty. To add a new template, enter a name, fill values, and click Update."
+							)}
+						</Typography>
+					</Box>
+
+					<FormControl fullWidth>
+						<InputLabel id="template-select-label">
+							{t("settingsPage.globalThresholds.editTemplate", "Edit Template")}
+						</InputLabel>
+						<Select
+							labelId="template-select-label"
+							value={templateValue}
+							onChange={onchangeDropdown}
+						>
+							<MenuItem value="">{t("Select Template", "Select Template")}</MenuItem>
+							{templateKeys.map((key) => (
+								<MenuItem
+									key={key}
+									value={key}
+								>
+									{key}
+								</MenuItem>
+							))}
+						</Select>
+					</FormControl>
+
 					<TextInput
-						key={name}
-						name={name}
-						label={label}
-						placeholder={`${min} - ${max}`}
-						type="number"
-						value={settingsData?.settings?.globalThresholds?.[name] || ""}
-						onChange={(e) => handleChange(e, min, max)}
+						label={t(
+							"settingsPage.globalThresholds.newTemplateName",
+							"New Template Name"
+						)}
+						name="newTemplateName"
+						value={textBoxValue}
+						onChange={(e) => setTextBoxValue(e.target.value)}
 					/>
-				))}
+				</Stack>
+
+				{/* Threshold Inputs */}
+				<Stack gap={theme.spacing(10)}>
+					{[
+						["CPU Threshold (%)", "cpu", 1, 100],
+						["Memory Threshold (%)", "memory", 1, 100],
+						["Disk Threshold (%)", "disk", 1, 100],
+						["Temperature Threshold (°C)", "temperature", 1, 150],
+					].map(([label, name, min, max]) => (
+						<TextInput
+							key={name}
+							name={name}
+							label={label}
+							placeholder={`${min} - ${max}`}
+							type="number"
+							value={thresholdValues[name]}
+							onChange={(e) => handleThresholdChange(name, e.target.value)}
+						/>
+					))}
+				</Stack>
+
+				<Button
+					variant="contained"
+					color="accent"
+					sx={{ px: theme.spacing(4), py: theme.spacing(8), width: "fit-content" }}
+					onClick={handleUpdate}
+					disabled={isUpdateDisabled}
+				>
+					{t("settingsPage.globalThresholds.UpdateChanges", "Update Changes")}
+				</Button>
 			</Stack>
 		</ConfigBox>
 	);
 };
 
-// Prop types
 SettingsGlobalThresholds.propTypes = {
 	isAdmin: PropTypes.bool,
 	HEADING_SX: PropTypes.object,

--- a/client/src/Pages/Settings/SettingsGlobalThresholds.jsx
+++ b/client/src/Pages/Settings/SettingsGlobalThresholds.jsx
@@ -31,7 +31,6 @@ const SettingsGlobalThresholds = ({
 		disk: "",
 		temperature: "",
 	});
-	console.log(settingsData);
 	if (!isAdmin) return null;
 
 	// Threshold ranges
@@ -60,14 +59,13 @@ const SettingsGlobalThresholds = ({
 		// Delete template if selected and all thresholds empty
 		if (selectedTemplate && Object.keys(thresholds).length === 0) {
 			delete templates[selectedTemplate];
-			setTemplateValue("");
+			
 		} else if (
 			(newTemplateName || selectedTemplate) &&
 			Object.keys(thresholds).length > 0
 		) {
 			const name = newTemplateName || selectedTemplate;
 			templates[name] = thresholds;
-			setTemplateValue(name);
 			if (newTemplateName) setTextBoxValue("");
 		}
 
@@ -79,6 +77,7 @@ const SettingsGlobalThresholds = ({
 				globalThresholds: templates,
 			},
 		}));
+		setTemplateValue("");
 	};
 
 	const onchangeDropdown = (e) => {
@@ -169,7 +168,7 @@ const SettingsGlobalThresholds = ({
 							value={templateValue}
 							onChange={onchangeDropdown}
 						>
-							<MenuItem value="">{t("Select Template", "Select Template")}</MenuItem>
+							<MenuItem value="">{t("settingsPage.globalThresholds.selectTemplate", "Select Template")}</MenuItem>
 							{templateKeys.map((key) => (
 								<MenuItem
 									key={key}

--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -311,12 +311,18 @@ const settingsValidation = joi.object({
 	systemEmailRequireTLS: joi.boolean(),
 	systemEmailRejectUnauthorized: joi.boolean(),
 	globalThresholds: joi
-		.object({
-			cpu: joi.number().min(1).max(100).allow("").optional(),
-			memory: joi.number().min(1).max(100).allow("").optional(),
-			disk: joi.number().min(1).max(100).allow("").optional(),
-			temperature: joi.number().min(1).max(150).allow("").optional(),
-		})
+		.object()
+		.pattern(
+			joi.string(), 
+			joi
+				.object({
+					cpu: joi.number().min(1).max(100).allow("").optional(),
+					memory: joi.number().min(1).max(100).allow("").optional(),
+					disk: joi.number().min(1).max(100).allow("").optional(),
+					temperature: joi.number().min(1).max(150).allow("").optional(),
+				})
+				.optional()
+		)
 		.optional(),
 });
 

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -492,6 +492,7 @@
 	"infrastructureCustomizeAlerts": "Customize alerts",
 	"infrastructureDisplayNameLabel": "Display name",
 	"infrastructureEditMonitor": "Save Infrastructure Monitor",
+	"InfrastructureSelectTemplate": "Select Template",
 	"infrastructureEditYour": "Edit your",
 	"infrastructureMonitor": {
 		"fallback": {
@@ -907,8 +908,15 @@
 		"title": "Settings",
 		"globalThresholds": {
 			"title": "Global Thresholds",
-			"description": "Configure global CPU, Memory, Disk, and Temperature thresholds. If a value is provided, it will automatically be enabled for monitoring."
+			"selectTemplate": "Select Template",
+			"description": "Configure global CPU, Memory, Disk, and Temperature thresholds. If a value is provided, it will automatically be enabled for monitoring.",
+			"templateHeading": "Template Settings",
+			"templateDescription": "Select a template to edit its values, then click Update. To delete, select a template and leave all values empty. To add a new template, enter a name, fill values, and click Update.",
+			"editTemplate": "Edit Template",
+			"newTemplateName": "New Template Name",
+			"UpdateChanges": "Update Changes"
 		},
+
 		"uiSettings": {
 			"description": "Switch between light and dark mode, or change user interface language.",
 			"labelLanguage": "Language",

--- a/server/src/db/models/AppSettings.js
+++ b/server/src/db/models/AppSettings.js
@@ -66,10 +66,17 @@ const AppSettingsSchema = mongoose.Schema(
 			default: 1,
 		},
 		globalThresholds: {
-			cpu: { type: Number },
-			memory: { type: Number },
-			disk: { type: Number },
-			temperature: { type: Number },
+			type: Map,
+			of: new mongoose.Schema(
+				{
+					cpu: { type: Number, min: 1, max: 100 },
+					memory: { type: Number, min: 1, max: 100 },
+					disk: { type: Number, min: 1, max: 100 },
+					temperature: { type: Number, min: 1, max: 150 },
+				},
+				{ _id: false }
+			),
+			default: {},
 		},
 	},
 	{

--- a/server/src/validation/joi.js
+++ b/server/src/validation/joi.js
@@ -419,14 +419,15 @@ const updateAppSettingsBodyValidation = joi.object({
 	systemEmailRequireTLS: joi.boolean(),
 	systemEmailRejectUnauthorized: joi.boolean(),
 
-	globalThresholds: joi
-		.object({
+	globalThresholds: joi.object().pattern(
+		/.*/,
+		joi.object({
 			cpu: joi.number().min(1).max(100).allow("").optional(),
 			memory: joi.number().min(1).max(100).allow("").optional(),
 			disk: joi.number().min(1).max(100).allow("").optional(),
 			temperature: joi.number().min(1).max(150).allow("").optional(),
 		})
-		.optional(),
+	),
 });
 
 //****************************************


### PR DESCRIPTION
## Describe your changes  

I implemented **Global Threshold Templates** to allow users to store and reuse multiple sets of threshold values instead of being limited to a single global configuration.  

### Key Changes:
- **Templates Dropdown**: Added to the Settings page and Infrastructure Create/Edit pages.  
- **Inline Create/Update**:  
  - Users can select an existing template to auto-fill values.  
  - Users can type a new name directly in the dropdown to create a new template.  
  - Editing values of a selected template updates that template.  
  - If a template becomes empty, it is removed automatically.  
- **Infrastructure Create/Edit Pages**: Selecting a template auto-fills thresholds, but values can still be overridden for exceptions.  

This makes threshold management flexible, reusable, and less error-prone.  

## Issue Reference  

Fixes #2769 

## Checklist  

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.  
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.  
- [x] I have included the issue # in the PR.  
- [x] I have added i18n support to visible strings.  
- [x] I have **not** included any unrelated files (e.g., package-lock or package-json if deps unchanged).  
- [x] I didn’t use hardcoded values (all values are configurable).  
- [x] I made sure font sizes, color choices, etc. come from the theme.  
- [x] My PR is granular and targeted to this specific feature.  
- [x] I ran `npm run format` in server and client directories.  
- [x] I attached screenshots showing the new dropdown in Settings and Infrastructure pages.  

Video - https://drive.google.com/file/d/1Fklgo-Ah8Ng3uCMAc5asZ0BSR2itja5N/view?usp=sharing
