### PR TITLE
feat/n of m frontend

### DIFF
--- a/client/src/Hooks/monitorHooks.js
+++ b/client/src/Hooks/monitorHooks.js
@@ -369,6 +369,8 @@ const useUpdateMonitor = () => {
 			setIsLoading(true);
 			const updatedFields = {
 				name: monitor.name,
+				statusWindowSize: monitor.statusWindowSize,
+				statusWindowThreshold: monitor.statusWindowThreshold,
 				description: monitor.description,
 				interval: monitor.interval,
 				notifications: monitor.notifications,

--- a/client/src/Pages/Uptime/Create/index.jsx
+++ b/client/src/Pages/Uptime/Create/index.jsx
@@ -615,18 +615,16 @@ const UptimeCreate = ({ isClone = false }) => {
 							component="h2"
 							variant="h2"
 						>
-							Incidents
+							{t("createMonitorPage.incidentConfigTitle")}
 						</Typography>
 						<Typography component="p">
-							{
-								"A sliding window is used to determine when a monitor goes down.  The status of a monitor will only change when the percentage of checks in the sliding window meet the specified value."
-							}
+							{t("createMonitorPage.incidentConfigDescription")}
 						</Typography>
 					</Box>
 					<Stack gap={theme.spacing(20)}>
 						<TextInput
 							name="statusWindowSize"
-							label={"How many checks should be in the sliding window?"}
+							label={t("createMonitorPage.incidentConfigStatusWindowLabel")}
 							type="number"
 							value={monitor.statusWindowSize}
 							onChange={onChange}
@@ -635,9 +633,7 @@ const UptimeCreate = ({ isClone = false }) => {
 						/>
 						<TextInput
 							name="statusWindowThreshold"
-							label={
-								"What percentage of checks in the sliding window fail/succeed before monitor status changes?"
-							}
+							label={t("createMonitorPage.incidentConfigStatusWindowThresholdLabel")}
 							type="number"
 							value={monitor.statusWindowThreshold}
 							onChange={onChange}

--- a/client/src/Pages/Uptime/Create/index.jsx
+++ b/client/src/Pages/Uptime/Create/index.jsx
@@ -55,6 +55,8 @@ const UptimeCreate = ({ isClone = false }) => {
 	// States
 	const [monitor, setMonitor] = useState({
 		type: "http",
+		statusWindowSize: 5,
+		statusWindowThreshold: 60,
 		matchMethod: "equal",
 		expectedValue: "",
 		jsonPath: "",
@@ -177,7 +179,10 @@ const UptimeCreate = ({ isClone = false }) => {
 						? `http${https ? "s" : ""}://` + monitor.url
 						: monitor.url,
 				name: monitor.name || monitor.url.substring(0, 50),
+				statusWindowSize: monitor.statusWindowSize,
+				statusWindowThreshold: monitor.statusWindowThreshold,
 				type: monitor.type,
+
 				port:
 					monitor.type === "port" || monitor.type === "game" ? monitor.port : undefined,
 				interval: monitor.interval,
@@ -192,6 +197,8 @@ const UptimeCreate = ({ isClone = false }) => {
 				_id: monitor._id,
 				url: monitor.url,
 				name: monitor.name || monitor.url.substring(0, 50),
+				statusWindowSize: monitor.statusWindowSize,
+				statusWindowThreshold: monitor.statusWindowThreshold,
 				type: monitor.type,
 				matchMethod: monitor.matchMethod,
 				expectedValue: monitor.expectedValue,
@@ -599,6 +606,43 @@ const UptimeCreate = ({ isClone = false }) => {
 							onChange={onChange}
 							error={errors["name"] ? true : false}
 							helperText={errors["name"]}
+						/>
+					</Stack>
+				</ConfigBox>
+				<ConfigBox>
+					<Box>
+						<Typography
+							component="h2"
+							variant="h2"
+						>
+							Incidents
+						</Typography>
+						<Typography component="p">
+							{
+								"A sliding window is used to determine when a monitor goes down.  The status of a monitor will only change when the percentage of checks in the sliding window meet the specified value."
+							}
+						</Typography>
+					</Box>
+					<Stack gap={theme.spacing(20)}>
+						<TextInput
+							name="statusWindowSize"
+							label={"How many checks should be in the sliding window?"}
+							type="number"
+							value={monitor.statusWindowSize}
+							onChange={onChange}
+							error={errors["statusWindowSize"] ? true : false}
+							helperText={errors["statusWindowSize"]}
+						/>
+						<TextInput
+							name="statusWindowThreshold"
+							label={
+								"What percentage of checks in the sliding window fail/succeed before monitor status changes?"
+							}
+							type="number"
+							value={monitor.statusWindowThreshold}
+							onChange={onChange}
+							error={errors["statusWindowThreshold"] ? true : false}
+							helperText={errors["statusWindowThreshold"]}
 						/>
 					</Stack>
 				</ConfigBox>

--- a/client/src/Validation/validation.js
+++ b/client/src/Validation/validation.js
@@ -115,6 +115,16 @@ const monitorValidation = joi.object({
 	_id: joi.string(),
 	userId: joi.string(),
 	teamId: joi.string(),
+	statusWindowSize: joi.number().min(1).max(20).default(5).messages({
+		"number.base": "Status window size must be a number.",
+		"number.min": "Status window size must be at least 1.",
+		"number.max": "Status window size must be at most 20.",
+	}),
+	statusWindowThreshold: joi.number().min(1).max(100).default(60).messages({
+		"number.base": "Incident percentage must be a number.",
+		"number.min": "Incident percentage must be at least 1.",
+		"number.max": "Incident percentage must be at most 100.",
+	}),
 	url: joi.when("type", {
 		is: "docker",
 		then: joi

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1,18 +1,4 @@
 {
-	"ClickUpload": "Click to upload",
-	"DeleteAccountButton": "Remove account",
-	"DeleteAccountTitle": "Remove account",
-	"DeleteAccountWarning": "Removing your account means you won't be able to sign in again and all your data will be removed. This isn't reversible.",
-	"DeleteDescriptionText": "This will remove the account and all associated data from the server. This isn't reversible.",
-	"DeleteWarningTitle": "Really remove this account?",
-	"DragandDrop": "drag and drop",
-	"EmailDescriptionText": "This is your current email address — it cannot be changed.",
-	"FirstName": "First name",
-	"LastName": "Last name",
-	"MaxSize": "Maximum Size",
-	"PhotoDescriptionText": "This photo will be displayed in your profile page.",
-	"SupportedFormats": "Supported formats",
-	"YourPhoto": "Profile photo",
 	"aboutus": "About Us",
 	"access": "Access",
 	"actions": "Actions",
@@ -202,13 +188,6 @@
 	"avgCpuTemperature": "Average CPU Temperature",
 	"bar": "Bar",
 	"basicInformation": "Basic Information",
-	"bytesPerSecond": "Bytes per second",
-	"bytesReceived": "Bytes Received",
-	"bytesSent": "Bytes Sent",
-	"dataReceived": "Data Received",
-	"dataSent": "Data Sent",
-	"dataRate": "Data Rate",
-	"rate": "Rate",
 	"bulkImport": {
 		"fallbackPage": "Import a file to upload a list of servers in bulk",
 		"invalidFileType": "Invalid file type",
@@ -222,17 +201,21 @@
 		"uploadSuccess": "Monitors created successfully!",
 		"validationFailed": "Validation failed"
 	},
+	"bytesPerSecond": "Bytes per second",
+	"bytesReceived": "Bytes Received",
+	"bytesSent": "Bytes Sent",
 	"cancel": "Cancel",
 	"checkFormError": "Please check the form for errors.",
 	"checkFrequency": "Check frequency",
-	"chooseGame": "Choose game",
 	"checkHooks": {
 		"failureResolveAll": "Failed to resolve all incidents.",
 		"failureResolveMonitor": "Failed to resolve monitor incidents.",
 		"failureResolveOne": "Failed to resolve incident."
 	},
 	"checkingEvery": "Checking every",
+	"chooseGame": "Choose game",
 	"city": "CITY",
+	"ClickUpload": "Click to upload",
 	"common": {
 		"appName": "Checkmate",
 		"buttons": {
@@ -262,6 +245,12 @@
 	"createMaintenance": "Create maintenance",
 	"createMaintenanceWindow": "Create maintenance window",
 	"createMonitor": "Create monitor",
+	"createMonitorPage": {
+		"incidentConfigDescription": "A sliding window is used to determine when a monitor goes down.  The status of a monitor will only change when the percentage of checks in the sliding window meet the specified value.",
+		"incidentConfigStatusWindowLabel": "How many checks should be in the sliding window?",
+		"incidentConfigStatusWindowThresholdLabel": "What percentage of checks in the sliding window fail/succeed before monitor status changes?",
+		"incidentConfigTitle": "Incidents"
+	},
 	"createNew": "Create new",
 	"createNotifications": {
 		"dialogDeleteConfirm": "Delete",
@@ -311,13 +300,22 @@
 		}
 	},
 	"createYour": "Create your",
+	"dataRate": "Data Rate",
+	"dataReceived": "Data Received",
+	"dataSent": "Data Sent",
 	"date&Time": "Date & Time",
 	"delete": "Delete",
+	"DeleteAccountButton": "Remove account",
+	"DeleteAccountTitle": "Remove account",
+	"DeleteAccountWarning": "Removing your account means you won't be able to sign in again and all your data will be removed. This isn't reversible.",
+	"DeleteDescriptionText": "This will remove the account and all associated data from the server. This isn't reversible.",
 	"deleteDialogDescription": "Once deleted, this monitor cannot be retrieved.",
 	"deleteDialogTitle": "Do you really want to delete this monitor?",
 	"deleteStatusPage": "Do you want to delete this status page?",
 	"deleteStatusPageConfirm": "Yes, delete status page",
 	"deleteStatusPageDescription": "Once deleted, your status page cannot be retrieved.",
+	"DeleteWarningTitle": "Really remove this account?",
+	"details": "Details",
 	"diagnosticsPage": {
 		"diagnosticDescription": "System diagnostics",
 		"gauges": {
@@ -341,15 +339,6 @@
 	},
 	"disk": "Disk",
 	"diskUsage": "Disk Usage",
-	"drops": "Drops",
-	"errors": "Errors",
-	"errorsIn": "Errors In",
-	"errorsOut": "Errors Out",
-	"networkErrors": "Network Errors",
-	"networkDrops": "Network Drops",
-	"networkInterface": "Network Interface",
-	"selectInterface": "Select Interface",
-	"details": "Details",
 	"displayName": "Display name",
 	"distributedRightCategoryTitle": "Monitor",
 	"distributedStatusHeaderText": "Real-time, real-device coverage",
@@ -395,6 +384,8 @@
 	"distributedUptimeStatusUptLogo": "Upt Logo",
 	"dockerContainerMonitoring": "Docker container monitoring",
 	"dockerContainerMonitoringDescription": "Check whether your Docker container is running or not.",
+	"DragandDrop": "drag and drop",
+	"drops": "Drops",
 	"duration": "Duration",
 	"edit": "Edit",
 	"editing": "Editing...",
@@ -417,6 +408,7 @@
 			"validationErrors": "Validation errors"
 		}
 	},
+	"EmailDescriptionText": "This is your current email address — it cannot be changed.",
 	"emailSent": "Email sent successfully",
 	"errorInvalidFieldId": "Invalid field ID provided",
 	"errorInvalidTypeId": "Invalid notification type provided",
@@ -434,6 +426,9 @@
 			}
 		}
 	},
+	"errors": "Errors",
+	"errorsIn": "Errors In",
+	"errorsOut": "Errors Out",
 	"expectedValue": "Expected value",
 	"export": {
 		"failed": "Failed to export monitors",
@@ -442,9 +437,12 @@
 	},
 	"failedToSendEmail": "Failed to send email",
 	"features": "Features",
+	"FirstName": "First name",
 	"frequency": "Frequency",
 	"friendlyNameInput": "Friendly name",
 	"friendlyNamePlaceholder": "Maintenance at __ : __ for ___ minutes",
+	"gameServerMonitoring": "Game Server Monitoring",
+	"gameServerMonitoringDescription": "Check whether your game server is running or not",
 	"gb": "GB",
 	"general": {
 		"noOptionsFound": "No {{unit}} found"
@@ -520,6 +518,7 @@
 	"invalidFileFormat": "Unsupported file format!",
 	"invalidFileSize": "File size is too large!",
 	"inviteNoTokenFound": "No invite token found",
+	"LastName": "Last name",
 	"loginHere": "Login here",
 	"logsPage": {
 		"description": "System logs - last 1000 lines",
@@ -571,6 +570,7 @@
 		"regexPlaceholder": "^(success|ok)$",
 		"text": "Match Method"
 	},
+	"MaxSize": "Maximum Size",
 	"mb": "MB",
 	"mem": "Mem",
 	"memory": "Memory",
@@ -632,6 +632,11 @@
 			"namePlaceholder": "My Container",
 			"placeholder": "abcd1234"
 		},
+		"game": {
+			"label": "URL to monitor",
+			"namePlaceholder": "localhost:5173",
+			"placeholder": "localhost"
+		},
 		"http": {
 			"label": "URL to monitor",
 			"namePlaceholder": "Google",
@@ -646,16 +651,14 @@
 			"label": "URL to monitor",
 			"namePlaceholder": "Localhost:5173",
 			"placeholder": "localhost"
-		},
-		"game": {
-			"label": "URL to monitor",
-			"namePlaceholder": "localhost:5173",
-			"placeholder": "localhost"
 		}
 	},
 	"ms": "ms",
 	"navControls": "Controls",
 	"network": "Network",
+	"networkDrops": "Network Drops",
+	"networkErrors": "Network Errors",
+	"networkInterface": "Network Interface",
 	"nextWindow": "Next window",
 	"noNetworkStatsAvailable": "No network stats available.",
 	"notFoundButton": "Go to the main dashboard",
@@ -739,6 +742,10 @@
 	"notifySMS": "Notify via SMS (coming soon)",
 	"now": "Now",
 	"os": "OS",
+	"packetsPerSecond": "Packets per second",
+	"packetsReceived": "Packets Received",
+	"packetsReceivedRate": "Packets Received Rate",
+	"packetsSent": "Packets Sent",
 	"pageSpeed": {
 		"fallback": {
 			"actionButton": "Let's create your first PageSpeed monitor!",
@@ -769,17 +776,12 @@
 		"passwordRequirements": "New password must contain at least 8 characters and must have at least one uppercase letter, one lowercase letter, one number and one special character.",
 		"saving": "Saving..."
 	},
-	"packetsPerSecond": "Packets per second",
-	"packetsReceived": "Packets Received",
-	"packetsReceivedRate": "Packets Received Rate",
-	"packetsSent": "Packets Sent",
 	"pause": "Pause",
+	"PhotoDescriptionText": "This photo will be displayed in your profile page.",
 	"pingMonitoring": "Ping monitoring",
 	"pingMonitoringDescription": "Check whether your server is available or not.",
 	"portMonitoring": "Port monitoring",
 	"portMonitoringDescription": "Check whether your port is open or not.",
-	"gameServerMonitoring": "Game Server Monitoring",
-	"gameServerMonitoringDescription": "Check whether your game server is running or not",
 	"portToMonitor": "Port to monitor",
 	"publicLink": "Public link",
 	"publicURL": "Public URL",
@@ -814,6 +816,7 @@
 		"refreshButton": "Refresh",
 		"title": "Queue"
 	},
+	"rate": "Rate",
 	"remove": "Remove",
 	"removeLogo": "Remove Logo",
 	"repeat": "Repeat",
@@ -829,6 +832,7 @@
 	},
 	"save": "Save",
 	"selectAll": "Select all",
+	"selectInterface": "Select Interface",
 	"sendTestNotifications": "Send test notifications",
 	"seperateEmails": "You can separate multiple emails with a comma",
 	"settingsAppearance": "Appearance",
@@ -873,6 +877,10 @@
 			"title": "Email",
 			"toastEmailRequiredFieldsError": "Email address, host, port and password are required"
 		},
+		"globalThresholds": {
+			"description": "Configure global CPU, Memory, Disk, and Temperature thresholds. If a value is provided, it will automatically be enabled for monitoring.",
+			"title": "Global Thresholds"
+		},
 		"pageSpeedSettings": {
 			"description": "Enter your Google PageSpeed API key to enable Google PageSpeed monitoring. Click Reset to update the key.",
 			"labelApiKey": "PageSpeed API key",
@@ -905,10 +913,6 @@
 			"title": "Display timezone"
 		},
 		"title": "Settings",
-		"globalThresholds": {
-			"title": "Global Thresholds",
-			"description": "Configure global CPU, Memory, Disk, and Temperature thresholds. If a value is provided, it will automatically be enabled for monitoring."
-		},
 		"uiSettings": {
 			"description": "Switch between light and dark mode, or change user interface language.",
 			"labelLanguage": "Language",
@@ -985,6 +989,7 @@
 	"statusPageStatusNotPublic": "This status page is not public.",
 	"statusPageStatusServiceStatus": "Service status",
 	"submit": "Submit",
+	"SupportedFormats": "Supported formats",
 	"teamPanel": {
 		"cancel": "Cancel",
 		"email": "Email",
@@ -1040,10 +1045,10 @@
 	"uptimeCreateJsonPathQuery": "for query language documentation.",
 	"uptimeGeneralInstructions": {
 		"docker": "Enter the Docker ID of your container. Docker IDs must be the full 64 char Docker ID. You can run docker inspect <short_id> to get the full container ID.",
+		"game": "Enter the IP address or hostname and the port number to ping (e.g., 192.168.1.100 or example.com) and choose game type.",
 		"http": "Enter the URL or IP to monitor (e.g., https://example.com/ or 192.168.1.100) and add a clear display name that appears on the dashboard.",
 		"ping": "Enter the IP address or hostname to ping (e.g., 192.168.1.100 or example.com) and add a clear display name that appears on the dashboard.",
-		"port": "Enter the URL or IP of the server, the port number and a clear display name that appears on the dashboard.",
-		"game": "Enter the IP address or hostname and the port number to ping (e.g., 192.168.1.100 or example.com) and choose game type."
+		"port": "Enter the URL or IP of the server, the port number and a clear display name that appears on the dashboard."
 	},
 	"uptimeMonitor": {
 		"fallback": {
@@ -1066,5 +1071,6 @@
 	"websiteMonitoring": "Website monitoring",
 	"websiteMonitoringDescription": "Use HTTP(s) to monitor your website or API endpoint.",
 	"whenNewIncident": "When there is a new incident,",
-	"window": "window"
+	"window": "window",
+	"YourPhoto": "Profile photo"
 }

--- a/server/src/service/infrastructure/statusService.js
+++ b/server/src/service/infrastructure/statusService.js
@@ -117,13 +117,18 @@ class StatusService {
 			// Update running stats
 			this.updateRunningStats({ monitor, networkResponse });
 
+			// If the status window size has changed, empty
+			while (monitor.statusWindow.length > monitor.statusWindowSize) {
+				monitor.statusWindow.shift();
+			}
+
 			// Update status sliding window
 			monitor.statusWindow.push(status);
 			if (monitor.statusWindow.length > monitor.statusWindowSize) {
 				monitor.statusWindow.shift();
 			}
 
-			if (!monitor.status) {
+			if (monitor.status === undefined || monitor.status === null) {
 				monitor.status = status;
 			}
 
@@ -145,10 +150,16 @@ class StatusService {
 
 			// Check if threshold has been met
 			const failures = monitor.statusWindow.filter((s) => s === false).length;
-			const failureRate = failures / monitor.statusWindow.length;
+			const failureRate = (failures / monitor.statusWindow.length) * 100;
+
+			console.log({
+				failureRate,
+				status: monitor.status,
+				statusWindow: monitor.statusWindow,
+			});
 
 			// If threshold has been met and the monitor is not already down, mark down:
-			if (failureRate > monitor.statusWindowThreshold && monitor.status !== false) {
+			if (failureRate >= monitor.statusWindowThreshold && monitor.status !== false) {
 				newStatus = false;
 				statusChanged = true;
 			}

--- a/server/src/validation/joi.js
+++ b/server/src/validation/joi.js
@@ -155,6 +155,8 @@ const createMonitorBodyValidation = joi.object({
 	name: joi.string().required(),
 	description: joi.string().required(),
 	type: joi.string().required(),
+	statusWindowSize: joi.number().min(1).max(20).default(5),
+	statusWindowThreshold: joi.number().min(1).max(100).default(60),
 	url: joi.string().required(),
 	ignoreTlsErrors: joi.boolean().default(false),
 	port: joi.number(),
@@ -183,6 +185,8 @@ const createMonitorsBodyValidation = joi.array().items(
 
 const editMonitorBodyValidation = joi.object({
 	name: joi.string(),
+	statusWindowSize: joi.number().min(1).max(20).default(5),
+	statusWindowThreshold: joi.number().min(1).max(100).default(60),
 	description: joi.string(),
 	interval: joi.number(),
 	notifications: joi.array().items(joi.string()),


### PR DESCRIPTION
This PR adds front end config so users can set `n` of `m` check related settings

- [x] Add an "Incidents" config section
- [x] Add config field for sliding window size
- [x] Add config field for sliding window threshold

Example:

If you want to be notified when the latest 3/5 checks are down, set window size to 5, and threshold to 60% (3/5).

If you want the original behavior where you are notified immediately on change, set window size to 1, threshold to 100%

<img width="2070" height="566" alt="Screenshot from 2025-08-18 15-34-55" src="https://github.com/user-attachments/assets/d772545c-44cc-4b79-8926-46538ce9e9dd" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added incident configuration on monitor create/edit: status window size and incident threshold with validation and defaults.
  - Introduced UI inputs and help text for these fields.
  - Expanded translations for game server monitoring, global thresholds, and additional network/telemetry labels.

- Bug Fixes
  - Improved incident detection: failure rate now calculated as a percentage and triggers when meeting or exceeding the threshold.
  - Preserves existing monitor status values during updates.
  - Ensures status history respects the configured window size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->