### PR TITLE
fix: add missing tooltip date format for 'recent' timeframe in charts

### DIFF
--- a/client/src/Components/Charts/Utils/chartUtilFunctions.js
+++ b/client/src/Components/Charts/Utils/chartUtilFunctions.js
@@ -1,5 +1,6 @@
 export const tooltipDateFormatLookup = (dateRange) => {
 	const dateFormatLookup = {
+		recent: "ddd. MMMM D, YYYY, hh:mm A",
 		day: "ddd. MMMM D, YYYY, hh:mm A",
 		week: "ddd. MMMM D, YYYY, hh:mm A",
 		month: "ddd. MMMM D, YYYY",

--- a/client/src/Pages/Infrastructure/Details/index.jsx
+++ b/client/src/Pages/Infrastructure/Details/index.jsx
@@ -121,6 +121,7 @@ const InfrastructureDetails = () => {
 						<AreaChartBoxes
 							shouldRender={!isLoading}
 							monitor={monitor}
+							dateRange={dateRange}
 						/>
 					</>
 				)}


### PR DESCRIPTION
## Describe your changes

Added missing 'recent' property to tooltipDateFormatLookup to ensure consistent date formatting in chart tooltips and X-axis display.

## Write your issue number after "Fixes "

Fixes #2823 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1091" height="309" alt="Captura de pantalla 2025-08-20 a la(s) 6 22 32 p m" src="https://github.com/user-attachments/assets/73e1ab92-8e19-4e66-a342-27fc385b2025" />

<img width="552" height="302" alt="Captura de pantalla 2025-08-20 a la(s) 6 22 49 p m" src="https://github.com/user-attachments/assets/4d9110d3-e615-4d76-bcd5-8a4773960db2" />

