### PR TITLE
fix notification validation

### DIFF
--- a/server/src/validation/joi.js
+++ b/server/src/validation/joi.js
@@ -580,17 +580,31 @@ const createNotificationBodyValidation = joi.object({
 	}),
 
 	address: joi.when("type", {
-		is: "email",
-		then: joi.string().email().required().messages({
-			"string.empty": "E-mail address cannot be empty",
-			"any.required": "E-mail address is required",
-			"string.email": "Please enter a valid e-mail address",
-		}),
-		otherwise: joi.string().uri().required().messages({
-			"string.empty": "Webhook URL cannot be empty",
-			"any.required": "Webhook URL is required",
-			"string.uri": "Please enter a valid Webhook URL",
-		}),
+		switch: [
+			{
+				is: "email",
+				then: joi.string().email().required().messages({
+					"string.empty": "E-mail address cannot be empty",
+					"any.required": "E-mail address is required",
+					"string.email": "Please enter a valid e-mail address",
+				}),
+			},
+			{
+				is: "pager_duty",
+				then: joi.string().required().messages({
+					"string.empty": "PagerDuty integration key cannot be empty",
+					"any.required": "PagerDuty integration key is required",
+				}),
+			},
+			{
+				is: joi.string().valid("webhook", "slack", "discord"),
+				then: joi.string().uri().required().messages({
+					"string.empty": "Webhook URL cannot be empty",
+					"any.required": "Webhook URL is required",
+					"string.uri": "Please enter a valid Webhook URL",
+				}),
+			},
+		],
 	}),
 });
 


### PR DESCRIPTION
This PR provides validation for Pager Duty type notification channels which was previously missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for PagerDuty notification addresses using integration keys.
* **Bug Fixes**
  * Improved validation for webhook-based notifications (Slack, Discord, generic webhooks) to require valid URLs with clearer error messages.
  * Ensured non-email addresses are no longer misclassified, preventing incorrect validation behavior.
  * Enhanced email and webhook validation feedback to guide users in entering correct formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->