### PR TITLE
Fix status page deletion error

### DIFF
--- a/server/src/controllers/statusPageController.js
+++ b/server/src/controllers/statusPageController.js
@@ -95,7 +95,7 @@ class StatusPageController extends BaseController {
 
 	deleteStatusPage = this.asyncHandler(
 		async (req, res) => {
-			await this.db.deleteStatusPage(req.params.url);
+			await this.db.statusPageModule.deleteStatusPage(req.params.url);
 			return res.success({
 				msg: this.stringService.statusPageDelete,
 			});


### PR DESCRIPTION
## Summary
Fixes a critical bug where status page deletion fails with "this.db.deleteStatusPage is not a function" error.

## Problem
When users attempt to delete a status page, the operation fails with the following error:
```
this.db.deleteStatusPage is not a function
```

This occurs because the controller method is calling the database module incorrectly.

## Root Cause
The `deleteStatusPage` method in `statusPageController.js` was calling:
```javascript
await this.db.deleteStatusPage(req.params.url);
```

However, all other methods in the same controller correctly use the module reference pattern:
```javascript
await this.db.statusPageModule.methodName();
```

## Solution
Fixed the method call to use the proper module reference:
```javascript
await this.db.statusPageModule.deleteStatusPage(req.params.url);
```

## Files Changed
- `server/src/controllers/statusPageController.js` - Fixed database module reference

## Testing
- [x] Verified the `deleteStatusPage` method exists in `StatusPageModule`
- [x] Confirmed all other controller methods use the same pattern
- [x] Ensured consistency across the controller

## Impact
- ✅ Status pages can now be deleted successfully
- ✅ No breaking changes to existing functionality
- ✅ Maintains consistency with other controller methods

This is a critical bug fix that restores status page deletion functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined backend handling for status page deletion to use a more modular internal pathway.
  * Improves maintainability and aligns deletion logic with current architecture.
  * No changes to user experience, API behavior, or response formats.

* **Chores**
  * Internal cleanup to consolidate deletion logic under a single module.
  * No action required from users or integrators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->