### PR TITLE
fix: refresh status page table after deletion

### DIFF
--- a/client/src/Pages/StatusPage/Create/index.jsx
+++ b/client/src/Pages/StatusPage/Create/index.jsx
@@ -136,7 +136,8 @@ const CreateStatusPage = () => {
 		// Start deletion process but don't wait for it
 		deleteStatusPage();
 		// Immediately navigate away to prevent additional fetches for the deleted page
-		navigate("/status");
+		// Pass state to trigger refresh in the status pages list
+		navigate("/status", { state: { shouldRefresh: true } });
 	};
 
 	const handleSubmit = async () => {

--- a/client/src/Pages/StatusPage/StatusPages/Hooks/useStatusPagesFetch.jsx
+++ b/client/src/Pages/StatusPage/StatusPages/Hooks/useStatusPagesFetch.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { networkService } from "../../../../main";
 import { useSelector } from "react-redux";
 import { createToast } from "../../../../Utils/toastUtils";
@@ -10,23 +10,27 @@ const useStatusPagesFetch = () => {
 	const [networkError, setNetworkError] = useState(false);
 	const [statusPages, setStatusPages] = useState(undefined);
 
+	const fetchStatusPages = useCallback(async () => {
+		try {
+			setIsLoading(true);
+			setNetworkError(false);
+			const res = await networkService.getStatusPagesByTeamId();
+			setStatusPages(res?.data?.data);
+		} catch (error) {
+			setNetworkError(true);
+			createToast({
+				body: error.message,
+			});
+		} finally {
+			setIsLoading(false);
+		}
+	}, []);
+
 	useEffect(() => {
-		const fetchStatusPages = async () => {
-			try {
-				const res = await networkService.getStatusPagesByTeamId();
-				setStatusPages(res?.data?.data);
-			} catch (error) {
-				setNetworkError(true);
-				createToast({
-					body: error.message,
-				});
-			} finally {
-				setIsLoading(false);
-			}
-		};
 		fetchStatusPages();
-	}, [user]);
-	return [isLoading, networkError, statusPages];
+	}, [user, fetchStatusPages]);
+
+	return [isLoading, networkError, statusPages, fetchStatusPages];
 };
 
 export { useStatusPagesFetch };

--- a/client/src/Pages/StatusPage/StatusPages/index.jsx
+++ b/client/src/Pages/StatusPage/StatusPages/index.jsx
@@ -11,6 +11,8 @@ import { useTheme } from "@emotion/react";
 import { useTranslation } from "react-i18next";
 import { useStatusPagesFetch } from "./Hooks/useStatusPagesFetch";
 import { useIsAdmin } from "../../../Hooks/useIsAdmin";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 const BREADCRUMBS = [{ name: `Status Pages`, path: "" }];
 
 const StatusPages = () => {
@@ -18,7 +20,17 @@ const StatusPages = () => {
 	const theme = useTheme();
 	const { t } = useTranslation();
 	const isAdmin = useIsAdmin();
-	const [isLoading, networkError, statusPages] = useStatusPagesFetch();
+	const location = useLocation();
+	const [isLoading, networkError, statusPages, refetchStatusPages] = useStatusPagesFetch();
+
+	// Refetch data when navigating back from deletion
+	useEffect(() => {
+		// Check if we're returning from a status page operation (creation, editing, or deletion)
+		// This helps ensure the list is up to date when returning from those operations
+		if (location.state?.shouldRefresh || location.key !== location.state?.lastLocationKey) {
+			refetchStatusPages();
+		}
+	}, [location, refetchStatusPages]);
 
 	if (isLoading) {
 		return <SkeletonLayout />;


### PR DESCRIPTION
## Summary
- Fixes status page table not refreshing after deletion
- Implements automatic data refresh when returning from status page deletion

## Problem
When deleting a status page from the configure page, users would navigate back to the status pages list, but the deleted status page would still appear in the table. This created confusion as users expected the deleted item to be removed from the list immediately.

## Solution
- Enhanced `useStatusPagesFetch` hook to expose a `refetchStatusPages` function
- Modified the StatusPages component to detect navigation from deletion operations
- Added automatic refresh trigger when returning from status page operations
- Updated deletion navigation to pass state indicating a refresh is needed

## Changes
1. **useStatusPagesFetch.jsx**: Made fetch function available externally using `useCallback`
2. **StatusPages/index.jsx**: Added `useEffect` to detect and handle refresh scenarios  
3. **Create/index.jsx**: Modified navigation after deletion to include refresh trigger state

## Test Plan
- [ ] Create a status page
- [ ] Delete the status page from the configure page
- [ ] Verify the status page is immediately removed from the table
- [ ] Ensure normal navigation still works correctly
- [ ] Test with multiple status pages to confirm only deleted ones are removed

## Technical Details
The fix uses React Router's navigation state to communicate between components. When deletion occurs, the navigation includes `{ state: { shouldRefresh: true } }`, which triggers an automatic data refetch in the destination component.

This approach maintains the existing optimistic UI pattern while ensuring data consistency when users return to the status pages list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status Pages list now auto-refreshes when returning from create/edit/delete actions.
  * Exposed a refresh capability enabling the list to re-fetch on relevant navigation events.
  * Improved error feedback with toasts on fetch failures.

* **Bug Fixes**
  * Resolved stale data after deleting a status page by triggering a refresh on return to the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->