### PR TITLE
Update maintenance window description

### DIFF
--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -251,7 +251,7 @@
 	"edit": "Edit",
 	"createA": "Create a",
 	"remove": "Remove",
-	"maintenanceWindowDescription": "Your pings won't be sent during this time frame",
+	"maintenanceWindowDescription": "During active maintenance windows, all monitoring is completely suspended for selected monitors. No network checks (pings, HTTP requests, port checks, etc.) will be performed, preventing any status updates or notifications from being triggered. Your monitors will appear frozen at their last known status, and status pages will display a maintenance indicator. Once the maintenance window ends, monitoring automatically resumes, and alerts will trigger if issues are detected. Maintenance periods do not count against uptime calculations.",
 	"startTime": "Start time",
 	"timeZoneInfo": "All dates and times are in GMT+0 time zone.",
 	"monitorsToApply": "Monitors to apply maintenance window to",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -251,7 +251,7 @@
 	"edit": "Edit",
 	"createA": "Create a",
 	"remove": "Remove",
-	"maintenanceWindowDescription": "During active maintenance windows, all monitoring is completely suspended for selected monitors. No network checks (pings, HTTP requests, port checks, etc.) will be performed, preventing any status updates or notifications from being triggered. Your monitors will appear frozen at their last known status, and status pages will display a maintenance indicator. Once the maintenance window ends, monitoring automatically resumes, and alerts will trigger if issues are detected. Maintenance periods do not count against uptime calculations.",
+	"maintenanceWindowDescription": "During maintenance windows, all monitoring is suspended for selected monitors. No network checks will be performed, preventing any status updates or notifications from being triggered. Your monitors will appear frozen at their last known status, and status pages will display a maintenance indicator. Once the maintenance window ends, monitoring automatically resumes, and alerts will trigger if issues are detected. Maintenance periods do not count against uptime calculations.",
 	"startTime": "Start time",
 	"timeZoneInfo": "All dates and times are in GMT+0 time zone.",
 	"monitorsToApply": "Monitors to apply maintenance window to",


### PR DESCRIPTION
Improve the maintenance window description to clearly explain what happens during maintenance - all monitoring is suspended, no notifications are triggered, and status pages show maintenance indicators.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Expanded the Maintenance Window description in the UI to clearly explain behavior: monitoring is suspended for selected monitors, no checks/status updates/notifications occur, monitors appear frozen, status pages show a maintenance indicator, monitoring auto-resumes after the window, alerts trigger if issues are detected afterward, and uptime calculations are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->