### PR TITLE
feat: add monitor grouping backend support

### DIFF
--- a/server/src/db/models/Monitor.js
+++ b/server/src/db/models/Monitor.js
@@ -70,6 +70,14 @@ const MonitorSchema = mongoose.Schema(
 			type: Boolean,
 			default: true,
 		},
+		isInMaintenance: {
+			type: Boolean,
+			default: false,
+		},
+		group: {
+			type: String,
+			default: null,
+		},
 		interval: {
 			// in milliseconds
 			type: Number,

--- a/server/src/db/mongo/modules/statusPageModule.js
+++ b/server/src/db/mongo/modules/statusPageModule.js
@@ -223,6 +223,7 @@ class StatusPageModule {
 							url: 1,
 							port: 1,
 							isActive: 1,
+							group: 1,
 							interval: 1,
 							uptimePercentage: 1,
 							notifications: 1,

--- a/server/src/validation/joi.js
+++ b/server/src/validation/joi.js
@@ -173,6 +173,7 @@ const createMonitorBodyValidation = joi.object({
 	jsonPath: joi.string().allow(""),
 	expectedValue: joi.string().allow(""),
 	matchMethod: joi.string(),
+	group: joi.string().allow(null, ""),
 	gameId: joi.string().allow(""),
 });
 
@@ -202,6 +203,7 @@ const editMonitorBodyValidation = joi.object({
 		usage_disk: joi.number(),
 		usage_temperature: joi.number(),
 	}),
+	group: joi.string().allow(null, ""),
 	gameId: joi.string(),
 });
 


### PR DESCRIPTION
## Summary
- Add group field to Monitor schema for categorizing monitors
- Update API validation to accept group field in monitor operations  
- Include group field in status page projections for frontend display

## Backend Changes
- **Monitor.js**: Add optional `group` field (String, default: null)
- **joi.js**: Add group validation to create/edit monitor endpoints
- **statusPageModule.js**: Include group field in monitor projections

## Implementation Details
- Group field is optional and backward compatible
- Supports null/empty values for ungrouped monitors
- Ready for frontend integration

**Backend PR** - Frontend PR will follow separately per PR separation guidelines.