### PR TITLE
fix: resolve Sharp module Alpine Linux compatibility

### DIFF
--- a/docker/dist-arm/server.Dockerfile
+++ b/docker/dist-arm/server.Dockerfile
@@ -10,13 +10,21 @@ RUN npm run build
 
 FROM node:20-alpine AS backend
 
+# Install Sharp dependencies for Alpine Linux
+RUN apk add --no-cache \
+    vips-dev \
+    vips-tools \
+    python3 \
+    make \
+    g++
+
 WORKDIR /app/server
 
 COPY server ./
 
 COPY --from=frontend-build /app/client/dist ./public
 
-RUN npm ci
+RUN npm ci --include=optional && npm rebuild sharp
 
 RUN chmod +x ./scripts/inject-vars.sh
 

--- a/docker/dist-mono/server.Dockerfile
+++ b/docker/dist-mono/server.Dockerfile
@@ -10,13 +10,21 @@ RUN npm run build
 
 FROM node:20-alpine AS app
 
+# Install Sharp dependencies for Alpine Linux
+RUN apk add --no-cache \
+    vips-dev \
+    vips-tools \
+    python3 \
+    make \
+    g++
+
 WORKDIR /app/server
 
 COPY server ./
 
 COPY --from=frontend-build /app/client/dist ./public
 
-RUN npm install
+RUN npm install --include=optional && npm rebuild sharp
 
 RUN chmod +x ./scripts/inject-vars.sh
 

--- a/docker/prod/server.Dockerfile
+++ b/docker/prod/server.Dockerfile
@@ -1,12 +1,20 @@
 FROM node:20-alpine
 
+# Install Sharp dependencies for Alpine Linux
+RUN apk add --no-cache \
+    vips-dev \
+    vips-tools \
+    python3 \
+    make \
+    g++
+
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 
 WORKDIR /app
 
 COPY ./server/package*.json ./
 
-RUN npm install
+RUN npm install --include=optional && npm rebuild sharp
 
 COPY ./server ./
 

--- a/docker/staging/server.Dockerfile
+++ b/docker/staging/server.Dockerfile
@@ -1,12 +1,20 @@
 FROM node:20-alpine
 
+# Install Sharp dependencies for Alpine Linux
+RUN apk add --no-cache \
+    vips-dev \
+    vips-tools \
+    python3 \
+    make \
+    g++
+
 ENV NODE_OPTIONS="--max-old-space-size=2048"
 
 WORKDIR /app
 
 COPY ./server/package*.json ./
 
-RUN npm install
+RUN npm install --include=optional && npm rebuild sharp
 
 COPY ./server ./
 


### PR DESCRIPTION
## Summary
- Fix Sharp module loading error on Alpine Linux containers
- Add required dependencies for Sharp compilation on Alpine
- Resolve "Could not load sharp module using linuxmusl-x64 runtime" error

## Changes Made
- **Added Alpine dependencies**: `vips-dev`, `vips-tools`, `python3`, `make`, `g++`
- **Added Sharp rebuild**: `npm rebuild sharp` after install
- **Updated Dockerfiles**: prod, staging, dist-mono, dist-arm server containers

## Root Cause
Sharp's prebuilt binaries weren't compatible with Alpine's musl libc. The fix ensures Sharp builds correctly for the Alpine environment by:
1. Installing native dependencies required for Sharp/libvips
2. Rebuilding Sharp to compile against the correct runtime

## Testing
This resolves the deployment issue where containers would crash with:
```
Error: Could not load the "sharp" module using the linuxmusl-x64 runtime
```

Fixes deployment failures on both `checkmate-backend-mono:latest` and `checkmate-backend-mono-multiarch:latest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Resolved image processing failures by ensuring native modules are correctly built, improving reliability across Alpine/ARM and multi-arch environments.

- Chores
  - Updated server container builds (staging, prod, mono, arm) to include required system libraries and install optional dependencies.
  - Rebuilt native dependencies during image build to align with system libraries.
  - Set a Node.js memory limit to reduce out-of-memory issues during builds and runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->