### PR TITLE
Fix skeleton flash on empty monitor pages

### DIFF
--- a/client/src/Components/Charts/StatusPageBarChart/index.jsx
+++ b/client/src/Components/Charts/StatusPageBarChart/index.jsx
@@ -22,7 +22,7 @@ const Bar = ({ width, height, backgroundColor, borderRadius, children }) => {
 
 	return (
 		<Box
-            width={width}
+			width={width}
 			position="relative"
 			height={height}
 			backgroundColor={backgroundColor}

--- a/client/src/Pages/Infrastructure/Monitors/index.jsx
+++ b/client/src/Pages/Infrastructure/Monitors/index.jsx
@@ -33,6 +33,7 @@ const InfrastructureMonitors = () => {
 	const [toFilterStatus, setToFilterStatus] = useState(undefined);
 	const [search, setSearch] = useState(undefined);
 	const [isSearching, setIsSearching] = useState(false);
+	const [hasInitialized, setHasInitialized] = useState(false);
 
 	// Utils
 	const theme = useTheme();
@@ -81,6 +82,17 @@ const InfrastructureMonitors = () => {
 		updateTrigger,
 	});
 
+	// Track initialization to prevent skeleton flash
+	useEffect(() => {
+		if (!isLoading && (summary !== undefined || monitors !== undefined)) {
+			setHasInitialized(true);
+		}
+	}, [isLoading, summary, monitors]);
+
+	// Show empty state when no monitors exist
+	const hasNoMonitors = hasInitialized && typeof summary?.totalMonitors === "undefined";
+	const isEmpty = hasInitialized && summary?.totalMonitors === 0;
+
 	if (networkError === true) {
 		return (
 			<GenericFallback>
@@ -96,7 +108,7 @@ const InfrastructureMonitors = () => {
 		);
 	}
 
-	if (!isLoading && typeof summary?.totalMonitors === "undefined") {
+	if (hasNoMonitors || isEmpty) {
 		return (
 			<Fallback
 				type="infrastructureMonitor"
@@ -106,6 +118,11 @@ const InfrastructureMonitors = () => {
 				isAdmin={isAdmin}
 			/>
 		);
+	}
+
+	// Don't render anything until we've initialized to prevent skeleton flash
+	if (!hasInitialized) {
+		return null;
 	}
 
 	return (

--- a/client/src/Pages/Maintenance/index.jsx
+++ b/client/src/Pages/Maintenance/index.jsx
@@ -64,7 +64,7 @@ const Maintenance = () => {
 			</GenericFallback>
 		);
 	}
-	// Only show the fallback if we've fetched data and there are no maintenance windows
+	// Show empty state when no maintenance windows exist
 	if (isDataFetched && maintenanceWindows.length === 0) {
 		return (
 			<Fallback
@@ -75,6 +75,11 @@ const Maintenance = () => {
 				isAdmin={isAdmin}
 			/>
 		);
+	}
+
+	// Don't render anything until we've fetched data to prevent table flash
+	if (!isDataFetched) {
+		return null;
 	}
 
 	return (

--- a/client/src/Pages/PageSpeed/Monitors/index.jsx
+++ b/client/src/Pages/PageSpeed/Monitors/index.jsx
@@ -1,5 +1,5 @@
 // Components
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Breadcrumbs from "../../../Components/Breadcrumbs";
 import { Stack, Typography } from "@mui/material";
 import CreateMonitorHeader from "../../../Components/MonitorCreateHeader";
@@ -22,6 +22,7 @@ const PageSpeed = () => {
 	const theme = useTheme();
 	const { t } = useTranslation();
 	const isAdmin = useIsAdmin();
+	const [hasInitialized, setHasInitialized] = useState(false);
 
 	const [monitors, monitorsSummary, isLoading, networkError] = useFetchMonitorsByTeamId({
 		limit: 10,
@@ -40,6 +41,17 @@ const PageSpeed = () => {
 		setIsEmailPasswordSet: () => {},
 	});
 
+	// Track initialization to prevent skeleton flash
+	useEffect(() => {
+		if (!isLoading && (monitorsSummary !== undefined || monitors !== undefined)) {
+			setHasInitialized(true);
+		}
+	}, [isLoading, monitorsSummary, monitors]);
+
+	// Show empty state when no monitors exist
+	const hasNoMonitors = hasInitialized && monitors?.length === 0;
+	const isEmpty = hasInitialized && monitorsSummary?.totalMonitors === 0;
+
 	if (networkError === true) {
 		return (
 			<GenericFallback>
@@ -55,7 +67,7 @@ const PageSpeed = () => {
 		);
 	}
 
-	if (!isLoading && monitors?.length === 0) {
+	if (hasNoMonitors || isEmpty) {
 		return (
 			<Fallback
 				type="pageSpeed"
@@ -69,6 +81,11 @@ const PageSpeed = () => {
 				)}
 			</Fallback>
 		);
+	}
+
+	// Don't render anything until we've initialized to prevent skeleton flash
+	if (!hasInitialized) {
+		return null;
 	}
 
 	return (

--- a/client/src/Pages/Uptime/Monitors/index.jsx
+++ b/client/src/Pages/Uptime/Monitors/index.jsx
@@ -77,6 +77,7 @@ const UptimeMonitors = () => {
 	const [selectedStatus, setSelectedStatus] = useState(undefined);
 	const [toFilterStatus, setToFilterStatus] = useState(undefined);
 	const [toFilterActive, setToFilterActive] = useState(undefined);
+	const [hasInitialized, setHasInitialized] = useState(false);
 
 	// Utils
 	const theme = useTheme();
@@ -152,6 +153,22 @@ const UptimeMonitors = () => {
 		}
 	}, [isSearching]);
 
+	// Track initialization to prevent skeleton flash
+	useEffect(() => {
+		if (
+			!monitorsWithSummaryIsLoading &&
+			!monitorsWithChecksIsLoading &&
+			(monitorsSummary !== undefined || monitorsWithChecks !== undefined)
+		) {
+			setHasInitialized(true);
+		}
+	}, [
+		monitorsWithSummaryIsLoading,
+		monitorsWithChecksIsLoading,
+		monitorsSummary,
+		monitorsWithChecks,
+	]);
+
 	const isLoading = monitorsWithSummaryIsLoading || monitorsWithChecksIsLoading;
 	if (networkError) {
 		return (
@@ -167,11 +184,13 @@ const UptimeMonitors = () => {
 			</GenericFallback>
 		);
 	}
-	if (
-		!isLoading &&
+	// Show empty state when no monitors exist
+	const hasNoMonitors =
+		hasInitialized &&
 		(monitorsSummary?.totalMonitors === 0 ||
-			typeof monitorsSummary?.totalMonitors === "undefined")
-	) {
+			typeof monitorsSummary?.totalMonitors === "undefined");
+
+	if (hasNoMonitors) {
 		return (
 			<Fallback
 				type="uptimeMonitor"
@@ -181,6 +200,11 @@ const UptimeMonitors = () => {
 				isAdmin={isAdmin}
 			/>
 		);
+	}
+
+	// Don't render anything until we've initialized to prevent skeleton flash
+	if (!hasInitialized) {
+		return null;
 	}
 	return (
 		<Stack


### PR DESCRIPTION
## Summary
Prevents skeleton/table flashing before empty state info pages are displayed.

## Changes
- Infrastructure monitors: Added initialization tracking to prevent skeleton flash
- PageSpeed monitors: Added initialization tracking to prevent skeleton flash  
- Uptime monitors: Added initialization tracking to prevent skeleton flash
- Maintenance windows: Added initialization check to prevent table flash

## Behavior
Empty monitor pages now show info content immediately without visual flashes.