### PR TITLE
Fix: Skip notifications during maintenance windows

### DIFF
--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js
@@ -28,11 +28,12 @@ class SuperSimpleQueueHelper {
 		return async (monitor) => {
 			try {
 				const monitorId = monitor._id;
+				const teamId = monitor.teamId;
 				if (!monitorId) {
 					throw new Error("No monitor id");
 				}
 
-				const maintenanceWindowActive = await this.isInMaintenanceWindow(monitorId);
+				const maintenanceWindowActive = await this.isInMaintenanceWindow(monitorId, teamId);
 				if (maintenanceWindowActive) {
 					this.logger.info({
 						message: `Monitor ${monitorId} is in maintenance window`,
@@ -77,8 +78,11 @@ class SuperSimpleQueueHelper {
 		};
 	};
 
-	async isInMaintenanceWindow(monitorId) {
-		const maintenanceWindows = await this.db.maintenanceWindowModule.getMaintenanceWindowsByMonitorId(monitorId);
+	async isInMaintenanceWindow(monitorId, teamId) {
+		const maintenanceWindows = await this.db.maintenanceWindowModule.getMaintenanceWindowsByMonitorId({
+			monitorId: monitorId.toString(),
+			teamId: teamId.toString(),
+		});
 		// Check for active maintenance window:
 		const maintenanceWindowIsActive = maintenanceWindows.reduce((acc, window) => {
 			if (window.active) {


### PR DESCRIPTION
## Describe your changes

Prevents notifications from being sent when monitors are in active maintenance windows.

## Write your issue number after "Fixes "

Fixes #2940  

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Maintenance windows are now evaluated per team, preventing cross-team interference.
  - Improves accuracy of alerting and notifications during scheduled maintenance.
  - Reduces unnecessary alerts when other teams have overlapping maintenance windows.
  - No changes required to existing configurations; applies automatically to all teams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->