### PR TITLE
fix network timing for port and docker

### DIFF
--- a/server/src/service/v1/infrastructure/networkService.js
+++ b/server/src/service/v1/infrastructure/networkService.js
@@ -33,11 +33,11 @@ class NetworkService {
 		const start = process.hrtime.bigint();
 		try {
 			const response = await operation();
-			// const elapsedMs = Math.round(Number(process.hrtime.bigint() - start) / 1_000_000);
-			return { response };
+			const elapsedMs = Math.round(Number(process.hrtime.bigint() - start) / 1_000_000);
+			return { response, responseTime: elapsedMs };
 		} catch (error) {
-			// const elapsedMs = Math.round(Number(process.hrtime.bigint() - start) / 1_000_000);
-			return { response: null, error };
+			const elapsedMs = Math.round(Number(process.hrtime.bigint() - start) / 1_000_000);
+			return { response: null, responseTime: elapsedMs, error };
 		}
 	}
 
@@ -350,9 +350,9 @@ class NetworkService {
 			}
 
 			const container = docker.getContainer(targetContainer.Id);
-			const { response, error } = await this.timeRequest(() => container.inspect());
+			const { response, responseTime, error } = await this.timeRequest(() => container.inspect());
 
-			dockerResponse.responseTime = response.time;
+			dockerResponse.responseTime = responseTime;
 			dockerResponse.status = response?.State?.Status === "running" ? true : false;
 			dockerResponse.code = 200;
 			dockerResponse.message = "Docker container status fetched successfully";
@@ -375,7 +375,7 @@ class NetworkService {
 	async requestPort(monitor) {
 		try {
 			const { url, port } = monitor;
-			const { response, error } = await this.timeRequest(async () => {
+			const { response, responseTime, error } = await this.timeRequest(async () => {
 				return new Promise((resolve, reject) => {
 					const socket = this.net.createConnection(
 						{
@@ -408,7 +408,7 @@ class NetworkService {
 				message: this.stringService.portSuccess,
 				monitorId: monitor._id,
 				type: monitor.type,
-				responseTime: response.time,
+				responseTime: responseTime,
 			};
 
 			if (error) {


### PR DESCRIPTION
- [x] Ping timing reflects response from ping tool
- [x] Docker and Port retain original timing 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added response time metrics to network actions, now visible in monitoring and inspection views (e.g., Docker inspection and port checks).
- Bug Fixes
  - Ensured response time is consistently provided for both successful and failed requests, preventing missing or mismatched timing data in reports.
- Refactor
  - Standardized how response time is propagated across network operations to improve consistency in user-facing metrics without altering existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->