### PR TITLE
Fix Advanced Matching submenu closes when editing an existing uptime …

### DIFF
--- a/client/src/Pages/v1/Uptime/Create/index.jsx
+++ b/client/src/Pages/v1/Uptime/Create/index.jsx
@@ -24,7 +24,7 @@ import SkeletonLayout from "./skeleton.jsx";
 // Utils
 import PropTypes from "prop-types";
 import { useTheme } from "@emotion/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { monitorValidation } from "../../../../Validation/validation.js";
 import { createToast } from "../../../../Utils/toastUtils.jsx";
@@ -69,8 +69,7 @@ const UptimeCreate = ({ isClone = false }) => {
 	const [https, setHttps] = useState(true);
 	const [isOpen, setIsOpen] = useState(false);
 	const [useAdvancedMatching, setUseAdvancedMatching] = useState(false);
-	const [isAdvancedMatchingInitialized, setIsAdvancedMatchingInitialized] =
-		useState(false);
+	const isAdvancedMatchingInitialized = useRef(false);
 	const [updateTrigger, setUpdateTrigger] = useState(false);
 	const [games, setGames] = useState({});
 	const triggerUpdate = () => {
@@ -298,18 +297,16 @@ const UptimeCreate = ({ isClone = false }) => {
 	const protocol = parsedUrl?.protocol?.replace(":", "") || "";
 
 	useEffect(() => {
-		if ((!isCreate || isClone) && monitor._id) {
-			if (!isAdvancedMatchingInitialized) {
-				if (monitor.matchMethod) {
-					setUseAdvancedMatching(true);
-				} else {
-					setUseAdvancedMatching(false);
-				}
-
-				setIsAdvancedMatchingInitialized(true);
+		if ((!isCreate || isClone) && monitor._id && !isAdvancedMatchingInitialized) {
+			if (monitor.matchMethod) {
+				setUseAdvancedMatching(true);
+			} else {
+				setUseAdvancedMatching(false);
 			}
+
+			isAdvancedMatchingInitialized.current = true;
 		}
-	}, [monitor._id, isCreate, isClone, isAdvancedMatchingInitialized]);
+	}, [monitor._id, isCreate, isClone]);
 
 	if (Object.keys(monitor).length === 0) {
 		return <SkeletonLayout />;

--- a/client/src/Pages/v1/Uptime/Create/index.jsx
+++ b/client/src/Pages/v1/Uptime/Create/index.jsx
@@ -69,6 +69,8 @@ const UptimeCreate = ({ isClone = false }) => {
 	const [https, setHttps] = useState(true);
 	const [isOpen, setIsOpen] = useState(false);
 	const [useAdvancedMatching, setUseAdvancedMatching] = useState(false);
+	const [isAdvancedMatchingInitialized, setIsAdvancedMatchingInitialized] =
+		useState(false);
 	const [updateTrigger, setUpdateTrigger] = useState(false);
 	const [games, setGames] = useState({});
 	const triggerUpdate = () => {
@@ -296,14 +298,18 @@ const UptimeCreate = ({ isClone = false }) => {
 	const protocol = parsedUrl?.protocol?.replace(":", "") || "";
 
 	useEffect(() => {
-		if (!isCreate || isClone) {
-			if (monitor.matchMethod) {
-				setUseAdvancedMatching(true);
-			} else {
-				setUseAdvancedMatching(false);
+		if ((!isCreate || isClone) && monitor._id) {
+			if (!isAdvancedMatchingInitialized) {
+				if (monitor.matchMethod) {
+					setUseAdvancedMatching(true);
+				} else {
+					setUseAdvancedMatching(false);
+				}
+
+				setIsAdvancedMatchingInitialized(true);
 			}
 		}
-	}, [monitor, isCreate]);
+	}, [monitor._id, isCreate, isClone, isAdvancedMatchingInitialized]);
 
 	if (Object.keys(monitor).length === 0) {
 		return <SkeletonLayout />;


### PR DESCRIPTION
## Describe your changes
I implemented a mechanism to correctly initialize the `useAdvancedMatching` state on the configuration/clone page 
`(!isCreate || isClone)` only after the asynchronous monitor data fetch is complete and only once per component lifetime.


## Write your issue number after "Fixes "

Fixes #3011 

[Screencast From 2025-10-16 16-41-55.webm](https://github.com/user-attachments/assets/b4a3ac28-b401-4c49-ab62-ff48b601879a)

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization of advanced matching when creating or cloning uptime monitors so it correctly initializes once per monitor lifecycle and only when the monitor exists, preventing repeated or premature toggling of the setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->