### PR TITLE
Remove unused CSS variables

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -15,15 +15,11 @@ html {
 	-moz-osx-font-smoothing: grayscale;
 
 	/* Generalized Stylings */
-	--env-var-radius-1: 4px;
 	--env-var-radius-2: 8px;
 
-	--env-var-width-1: 100vw;
 	--env-var-width-2: 360px;
-	--env-var-width-3: 250px;
 	--env-var-width-4: 100px;
 
-	--env-var-height-1: 100vh;
 	--env-var-height-2: 34px;
 
 	--env-var-nav-bar-height: 70px;
@@ -35,9 +31,6 @@ html {
 	--env-var-spacing-1-plus: 16px;
 	--env-var-spacing-1-minus: 10px;
 	--env-var-spacing-2: 24px;
-	--env-var-spacing-3: 32px;
-	--env-var-spacing-4: 40px;
-	--env-var-spacing-5: 65px;
 
 	--env-var-font-size-small: 11px;
 	--env-var-font-size-small-plus: 12px;
@@ -46,16 +39,6 @@ html {
 	--env-var-font-size-large: 16px;
 	--env-var-font-size-large-plus: 22px;
 	--env-var-font-size-xlarge: 30px;
-
-	--env-var-img-width-1: 20px;
-	--env-var-img-width-2: 16px;
-	--env-var-img-width-3: 12px;
-
-	--env-var-default-1: 24px;
-	--env-var-default-2: 40px;
-
-	--env-var-shadow-1:
-		0px 4px 24px -4px rgba(16, 24, 40, 0.08), 0px 3px 3px -3px rgba(16, 24, 40, 0.03);
 }
 
 .MuiInputBase-root.Mui-disabled input {


### PR DESCRIPTION
## Summary
Removes 13 unused CSS variables that were leftovers from when the project switched to the MUI theme system.

## Changes
- Removed unused CSS variables from `client/src/index.css`
- Kept 19 variables that are still actively used

Fixes #1025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused CSS design token variables from the styling system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->