### PR TITLE
add cacheable dns, stagger start times

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
 		"axios": "^1.7.2",
 		"bcryptjs": "3.0.2",
 		"bullmq": "5.41.2",
+		"cacheable-lookup": "7.0.0",
 		"compression": "1.8.1",
 		"cookie-parser": "^1.4.7",
 		"cors": "^2.8.5",
@@ -51,7 +52,7 @@
 		"ping": "0.4.4",
 		"sharp": "0.33.5",
 		"ssl-checker": "2.0.10",
-		"super-simple-scheduler": "1.4.4",
+		"super-simple-scheduler": "1.4.5",
 		"swagger-ui-express": "5.0.1",
 		"winston": "^3.13.0"
 	},

--- a/server/src/service/v1/infrastructure/SuperSimpleQueue/SuperSimpleQueue.js
+++ b/server/src/service/v1/infrastructure/SuperSimpleQueue/SuperSimpleQueue.js
@@ -35,8 +35,12 @@ class SuperSimpleQueue {
 			this.scheduler.addTemplate("monitor-job", this.helper.getMonitorJob());
 			const monitors = await this.db.monitorModule.getAllMonitors();
 			for (const monitor of monitors) {
-				await this.addJob(monitor._id, monitor);
+				const randomOffset = Math.floor(Math.random() * monitor.interval);
+				setTimeout(() => {
+					this.addJob(monitor);
+				}, randomOffset);
 			}
+
 			return true;
 		} catch (error) {
 			this.logger.error({

--- a/server/src/service/v1/infrastructure/networkService.js
+++ b/server/src/service/v1/infrastructure/networkService.js
@@ -1,3 +1,4 @@
+import CacheableLookup from "cacheable-lookup";
 const SERVICE_NAME = "NetworkService";
 
 class NetworkService {
@@ -15,7 +16,6 @@ class NetworkService {
 		this.NETWORK_ERROR = 5000;
 		this.PING_ERROR = 5001;
 		this.axios = axios;
-		this.got = got;
 		this.https = https;
 		this.jmespath = jmespath;
 		this.GameDig = GameDig;
@@ -26,6 +26,16 @@ class NetworkService {
 		this.net = net;
 		this.stringService = stringService;
 		this.settingsService = settingsService;
+
+		const cacheable = new CacheableLookup();
+
+		this.got = got.extend({
+			dnsCache: cacheable,
+			timeout: {
+				request: 30000,
+			},
+			retry: { limit: 1 },
+		});
 	}
 
 	// Helper functions


### PR DESCRIPTION
Add a DNS cache, stagger monitor start times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DNS caching and automatic request retry logic for improved network resilience.

* **Improvements**
  * Implemented 30-second request timeout for better reliability.
  * Enhanced job scheduling with staggered delays to distribute load more evenly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->