### PR TITLE
Feat: Pagespeed Graph Pagination Backend

### DIFF
--- a/client/src/Hooks/v1/monitorHooks.js
+++ b/client/src/Hooks/v1/monitorHooks.js
@@ -170,7 +170,7 @@ const useFetchStatsByMonitorId = ({
 	dateRange,
 	numToDisplay,
 	normalize,
-	pageOffset,
+	page,
 	updateTrigger,
 }) => {
 	const [monitor, setMonitor] = useState(undefined);
@@ -188,7 +188,7 @@ const useFetchStatsByMonitorId = ({
 					dateRange,
 					numToDisplay,
 					normalize,
-					pageOffset,
+					page,
 				});
 				setMonitor(res?.data?.data ?? undefined);
 				setAudits(res?.data?.data?.checks?.[0]?.audits ?? undefined);
@@ -200,7 +200,16 @@ const useFetchStatsByMonitorId = ({
 			}
 		};
 		fetchMonitor();
-	}, [monitorId, dateRange, numToDisplay, normalize, sortOrder, limit, pageOffset, updateTrigger]);
+	}, [
+		monitorId,
+		dateRange,
+		numToDisplay,
+		normalize,
+		sortOrder,
+		limit,
+		page,
+		updateTrigger,
+	]);
 	return [monitor, audits, isLoading, networkError];
 };
 

--- a/client/src/Hooks/v1/monitorHooks.js
+++ b/client/src/Hooks/v1/monitorHooks.js
@@ -170,6 +170,7 @@ const useFetchStatsByMonitorId = ({
 	dateRange,
 	numToDisplay,
 	normalize,
+	pageOffset,
 	updateTrigger,
 }) => {
 	const [monitor, setMonitor] = useState(undefined);
@@ -187,6 +188,7 @@ const useFetchStatsByMonitorId = ({
 					dateRange,
 					numToDisplay,
 					normalize,
+					pageOffset,
 				});
 				setMonitor(res?.data?.data ?? undefined);
 				setAudits(res?.data?.data?.checks?.[0]?.audits ?? undefined);
@@ -198,7 +200,7 @@ const useFetchStatsByMonitorId = ({
 			}
 		};
 		fetchMonitor();
-	}, [monitorId, dateRange, numToDisplay, normalize, sortOrder, limit, updateTrigger]);
+	}, [monitorId, dateRange, numToDisplay, normalize, sortOrder, limit, pageOffset, updateTrigger]);
 	return [monitor, audits, isLoading, networkError];
 };
 

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -188,7 +188,7 @@ class NetworkService {
 		if (config.dateRange) params.append("dateRange", config.dateRange);
 		if (config.numToDisplay) params.append("numToDisplay", config.numToDisplay);
 		if (config.normalize) params.append("normalize", config.normalize);
-		if (config.pageOffset) params.append("pageOffset", config.pageOffset);
+		if (config.page) params.append("page", config.page);
 		return this.axiosInstance.get(
 			`/monitors/stats/${config.monitorId}?${params.toString()}`
 		);

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -188,7 +188,7 @@ class NetworkService {
 		if (config.dateRange) params.append("dateRange", config.dateRange);
 		if (config.numToDisplay) params.append("numToDisplay", config.numToDisplay);
 		if (config.normalize) params.append("normalize", config.normalize);
-
+		if (config.pageOffset) params.append("pageOffset", config.pageOffset);
 		return this.axiosInstance.get(
 			`/monitors/stats/${config.monitorId}?${params.toString()}`
 		);

--- a/server/src/controllers/v1/monitorController.js
+++ b/server/src/controllers/v1/monitorController.js
@@ -82,7 +82,7 @@ class MonitorController extends BaseController {
 			await getMonitorStatsByIdParamValidation.validateAsync(req.params);
 			await getMonitorStatsByIdQueryValidation.validateAsync(req.query);
 
-			let { limit, sortOrder, dateRange, numToDisplay, normalize, pageOffset } = req.query;
+			let { limit, sortOrder, dateRange, numToDisplay, normalize, page } = req.query;
 			const monitorId = req?.params?.monitorId;
 
 			const teamId = req?.user?.teamId;
@@ -98,7 +98,7 @@ class MonitorController extends BaseController {
 				dateRange,
 				numToDisplay,
 				normalize,
-				pageOffset,
+				page,
 			});
 
 			return res.success({

--- a/server/src/controllers/v1/monitorController.js
+++ b/server/src/controllers/v1/monitorController.js
@@ -82,7 +82,7 @@ class MonitorController extends BaseController {
 			await getMonitorStatsByIdParamValidation.validateAsync(req.params);
 			await getMonitorStatsByIdQueryValidation.validateAsync(req.query);
 
-			let { limit, sortOrder, dateRange, numToDisplay, normalize } = req.query;
+			let { limit, sortOrder, dateRange, numToDisplay, normalize, pageOffset } = req.query;
 			const monitorId = req?.params?.monitorId;
 
 			const teamId = req?.user?.teamId;
@@ -98,6 +98,7 @@ class MonitorController extends BaseController {
 				dateRange,
 				numToDisplay,
 				normalize,
+				pageOffset,
 			});
 
 			return res.success({

--- a/server/src/db/v1/modules/monitorModule.js
+++ b/server/src/db/v1/modules/monitorModule.js
@@ -121,6 +121,21 @@ class MonitorModule {
 		};
 	};
 
+	// Helper
+	offsetDatesByPage = (dates, dateRange, pageOffset) => {
+		const dateOffsets = {
+			recent: 60 * 60 * 2 * pageOffset * 1000,
+			day: 60 * 60 * 24 * pageOffset * 1000,
+			week: 60 * 60 * 24 * 7 * pageOffset * 1000,
+			all: 0,
+		};
+
+		return {
+			start: new Date(dates.start.getTime() - dateOffsets[dateRange]),
+			end: new Date(new Date().getTime() - dateOffsets[dateRange]),
+		};
+	};
+
 	//Helper
 	getMonitorChecks = async (monitorId, dateRange, sortOrder) => {
 		const indexSpec = {
@@ -258,7 +273,7 @@ class MonitorModule {
 		}
 	};
 
-	getMonitorStatsById = async ({ monitorId, sortOrder, dateRange, numToDisplay, normalize }) => {
+	getMonitorStatsById = async ({ monitorId, sortOrder, dateRange, numToDisplay, normalize, pageOffset }) => {
 		try {
 			// Get monitor, if we can't find it, abort with error
 			const monitor = await this.Monitor.findById(monitorId);
@@ -269,9 +284,15 @@ class MonitorModule {
 			// Get query params
 			const sort = sortOrder === "asc" ? 1 : -1;
 
+			let dates = this.getDateRange(dateRange);
+
+			if (pageOffset) {
+				dates = this.offsetDatesByPage(dates, dateRange, pageOffset);
+			}
+
 			// Get Checks for monitor in date range requested
-			const dates = this.getDateRange(dateRange);
 			const { checksAll, checksForDateRange } = await this.getMonitorChecks(monitorId, dates, sort);
+			const checksSkipped = checksAll.filter((check) => check.createdAt > dates.end);
 
 			// Build monitor stats
 			const monitorStats = {
@@ -281,6 +302,7 @@ class MonitorModule {
 				latestResponseTime: this.getLatestResponseTime(checksAll),
 				periodIncidents: this.getIncidents(checksForDateRange),
 				periodTotalChecks: checksForDateRange.length,
+				remainingChecks: checksAll.length - checksForDateRange.length - checksSkipped.length,
 				checks: this.processChecksForDisplay(this.NormalizeData, checksForDateRange, numToDisplay, normalize),
 			};
 

--- a/server/src/db/v1/modules/monitorModule.js
+++ b/server/src/db/v1/modules/monitorModule.js
@@ -132,8 +132,8 @@ class MonitorModule {
 
 		if (dateRange == "month") {
 			return {
-				start: new Date(dates.start.setMonth(dates.start.getMonth() - pageOffset)),
-				end: new Date(dates.end.setMonth(dates.end.getMonth() - pageOffset)),
+				start: new Date(new Date(dates.start).setMonth(dates.start.getMonth() - pageOffset)),
+				end: new Date(new Date(dates.end).setMonth(dates.end.getMonth() - pageOffset)),
 			};
 		} else {
 			return {

--- a/server/src/db/v1/modules/monitorModule.js
+++ b/server/src/db/v1/modules/monitorModule.js
@@ -130,10 +130,17 @@ class MonitorModule {
 			all: 0,
 		};
 
-		return {
-			start: new Date(dates.start.getTime() - dateOffsets[dateRange]),
-			end: new Date(new Date().getTime() - dateOffsets[dateRange]),
-		};
+		if (dateRange == "month") {
+			return {
+				start: new Date(dates.start.setMonth(dates.start.getMonth() - pageOffset)),
+				end: new Date(dates.end.setMonth(dates.end.getMonth() - pageOffset)),
+			};
+		} else {
+			return {
+				start: new Date(dates.start.getTime() - dateOffsets[dateRange]),
+				end: new Date(dates.end.getTime() - dateOffsets[dateRange]),
+			};
+		}
 	};
 
 	//Helper

--- a/server/src/db/v1/modules/monitorModule.js
+++ b/server/src/db/v1/modules/monitorModule.js
@@ -122,18 +122,18 @@ class MonitorModule {
 	};
 
 	// Helper
-	offsetDatesByPage = (dates, dateRange, pageOffset) => {
+	offsetDatesByPage = (dates, dateRange, page) => {
 		const dateOffsets = {
-			recent: 60 * 60 * 2 * pageOffset * 1000,
-			day: 60 * 60 * 24 * pageOffset * 1000,
-			week: 60 * 60 * 24 * 7 * pageOffset * 1000,
+			recent: 60 * 60 * 2 * page * 1000,
+			day: 60 * 60 * 24 * page * 1000,
+			week: 60 * 60 * 24 * 7 * page * 1000,
 			all: 0,
 		};
 
 		if (dateRange == "month") {
 			return {
-				start: new Date(new Date(dates.start).setMonth(dates.start.getMonth() - pageOffset)),
-				end: new Date(new Date(dates.end).setMonth(dates.end.getMonth() - pageOffset)),
+				start: new Date(new Date(dates.start).setMonth(dates.start.getMonth() - page)),
+				end: new Date(new Date(dates.end).setMonth(dates.end.getMonth() - page)),
 			};
 		} else {
 			return {
@@ -280,7 +280,7 @@ class MonitorModule {
 		}
 	};
 
-	getMonitorStatsById = async ({ monitorId, sortOrder, dateRange, numToDisplay, normalize, pageOffset }) => {
+	getMonitorStatsById = async ({ monitorId, sortOrder, dateRange, numToDisplay, normalize, page }) => {
 		try {
 			// Get monitor, if we can't find it, abort with error
 			const monitor = await this.Monitor.findById(monitorId);
@@ -293,8 +293,8 @@ class MonitorModule {
 
 			let dates = this.getDateRange(dateRange);
 
-			if (pageOffset) {
-				dates = this.offsetDatesByPage(dates, dateRange, pageOffset);
+			if (page) {
+				dates = this.offsetDatesByPage(dates, dateRange, page);
 			}
 
 			// Get Checks for monitor in date range requested

--- a/server/src/service/v1/business/monitorService.js
+++ b/server/src/service/v1/business/monitorService.js
@@ -43,7 +43,7 @@ class MonitorService {
 		return data;
 	};
 
-	getMonitorStatsById = async ({ teamId, monitorId, limit, sortOrder, dateRange, numToDisplay, normalize, pageOffset }) => {
+	getMonitorStatsById = async ({ teamId, monitorId, limit, sortOrder, dateRange, numToDisplay, normalize, page }) => {
 		await this.verifyTeamAccess({ teamId, monitorId });
 		const monitorStats = await this.db.monitorModule.getMonitorStatsById({
 			monitorId,
@@ -52,7 +52,7 @@ class MonitorService {
 			dateRange,
 			numToDisplay,
 			normalize,
-			pageOffset,
+			page,
 		});
 
 		return monitorStats;

--- a/server/src/service/v1/business/monitorService.js
+++ b/server/src/service/v1/business/monitorService.js
@@ -43,7 +43,7 @@ class MonitorService {
 		return data;
 	};
 
-	getMonitorStatsById = async ({ teamId, monitorId, limit, sortOrder, dateRange, numToDisplay, normalize }) => {
+	getMonitorStatsById = async ({ teamId, monitorId, limit, sortOrder, dateRange, numToDisplay, normalize, pageOffset }) => {
 		await this.verifyTeamAccess({ teamId, monitorId });
 		const monitorStats = await this.db.monitorModule.getMonitorStatsById({
 			monitorId,
@@ -52,6 +52,7 @@ class MonitorService {
 			dateRange,
 			numToDisplay,
 			normalize,
+			pageOffset,
 		});
 
 		return monitorStats;

--- a/server/src/validation/joi.js
+++ b/server/src/validation/joi.js
@@ -144,7 +144,7 @@ const getMonitorStatsByIdQueryValidation = joi.object({
 	dateRange: joi.string().valid("hour", "day", "week", "month", "all"),
 	numToDisplay: joi.number(),
 	normalize: joi.boolean(),
-	pageOffset: joi.number().integer(),
+	pageOffset: joi.number().integer().min(0),
 });
 
 const getCertificateParamValidation = joi.object({

--- a/server/src/validation/joi.js
+++ b/server/src/validation/joi.js
@@ -144,7 +144,7 @@ const getMonitorStatsByIdQueryValidation = joi.object({
 	dateRange: joi.string().valid("hour", "day", "week", "month", "all"),
 	numToDisplay: joi.number(),
 	normalize: joi.boolean(),
-	pageOffset: joi.number().integer().min(0),
+	page: joi.number().integer().min(0),
 });
 
 const getCertificateParamValidation = joi.object({

--- a/server/src/validation/joi.js
+++ b/server/src/validation/joi.js
@@ -144,6 +144,7 @@ const getMonitorStatsByIdQueryValidation = joi.object({
 	dateRange: joi.string().valid("hour", "day", "week", "month", "all"),
 	numToDisplay: joi.number(),
 	normalize: joi.boolean(),
+	pageOffset: joi.number().integer(),
 });
 
 const getCertificateParamValidation = joi.object({


### PR DESCRIPTION
## Describe your changes

This PR adds pagination support for the PageSpeed chart on the backend by introducing an optional variable to FetchStatsByMonitorId/GetMonitorStatsById called `page`, which shifts back the date range depending on it's value.

For example: If `dateRange` is set to "day" and `page` is 4, then it will query data from 4 days ago.

The returned `monitor` object now also includes the number of remaining checks to be used for the frontend implementation.

## Write your issue number after "Fixes "

Fixes #606  

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page-based pagination for monitor statistics so users can navigate older/newer data when reviewing monitor performance.
  * Monitor statistics now include a "remaining checks" count showing how many checks exist beyond the current page.
  * Paging is preserved across requests and respects selected date ranges, improving navigation through historical data.

* **Validation**
  * Query accepts a non-negative integer page parameter to control paging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->