### PR TITLE
fix: prevent Advanced Matching checkbox from auto-unchecking

### DIFF
--- a/client/src/Pages/v1/Uptime/Create/index.jsx
+++ b/client/src/Pages/v1/Uptime/Create/index.jsx
@@ -261,7 +261,14 @@ const UptimeCreate = ({ isClone = false }) => {
 			value = value * MS_PER_MINUTE;
 		}
 
-		setMonitor((prev) => ({ ...prev, [name]: value }));
+		setMonitor((prev) => {
+			const updatedMonitor = { ...prev, [name]: value };
+			// Automatically check "Advanced matching" checkbox if user enters expectedValue or jsonPath
+			if ((name === "expectedValue" || name === "jsonPath") && value && value.trim()) {
+				setUseAdvancedMatching(true);
+			}
+			return updatedMonitor;
+		});
 
 		if (name === "type") {
 			setErrors({});
@@ -296,14 +303,14 @@ const UptimeCreate = ({ isClone = false }) => {
 	const protocol = parsedUrl?.protocol?.replace(":", "") || "";
 
 	useEffect(() => {
-		if (!isCreate || isClone) {
-			if (monitor.matchMethod) {
-				setUseAdvancedMatching(true);
-			} else {
-				setUseAdvancedMatching(false);
-			}
+		// Automatically check "Advanced matching" checkbox if any value exists in matchMethod, expectedValue, or jsonPath
+		if (monitor.matchMethod || monitor.expectedValue || monitor.jsonPath) {
+			setUseAdvancedMatching(true);
+		} else if (!isCreate || isClone) {
+			// Only uncheck when editing/cloning and no values exist
+			setUseAdvancedMatching(false);
 		}
-	}, [monitor, isCreate]);
+	}, [monitor.matchMethod, monitor.expectedValue, monitor.jsonPath, isCreate, isClone]);
 
 	if (Object.keys(monitor).length === 0) {
 		return <SkeletonLayout />;


### PR DESCRIPTION
## Describe your changes

Briefly describe the changes you made and their purpose. 

Fixes #3093

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Advanced Matching now automatically activates when you configure specific monitor matching fields
  * Advanced Matching state is properly preserved when editing or duplicating monitor configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->