### PR TITLE
fix(client): implement refresh token handling for seamless session renewal

### DIFF
--- a/client/src/Features/Auth/authSlice.js
+++ b/client/src/Features/Auth/authSlice.js
@@ -5,6 +5,7 @@ import axios from "axios";
 const initialState = {
 	isLoading: false,
 	authToken: "",
+	refreshToken: "",
 	user: "",
 	success: null,
 	msg: null,
@@ -138,6 +139,7 @@ const handleAuthFulfilled = (state, action) => {
 	state.success = action.payload.success;
 	state.msg = action.payload.msg;
 	state.authToken = action.payload.data.token;
+	state.refreshToken = action.payload.data.refreshToken || "";
 	state.user = action.payload.data.user;
 };
 const handleAuthRejected = (state, action) => {
@@ -188,10 +190,14 @@ const authSlice = createSlice({
 	reducers: {
 		clearAuthState: (state) => {
 			state.authToken = "";
+			state.refreshToken = "";
 			state.user = "";
 			state.isLoading = false;
 			state.success = true;
 			state.msg = "Logged out successfully";
+		},
+		setAuthToken: (state, action) => {
+			state.authToken = action.payload;
 		},
 	},
 	extraReducers: (builder) => {
@@ -246,4 +252,4 @@ const authSlice = createSlice({
 });
 
 export default authSlice.reducer;
-export const { clearAuthState } = authSlice.actions;
+export const { clearAuthState, setAuthToken } = authSlice.actions;

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -2,7 +2,7 @@ import axios from "axios";
 import i18next from "i18next";
 const BASE_URL = import.meta.env.VITE_APP_API_BASE_URL;
 const FALLBACK_BASE_URL = "http://localhost:5000/api/v1";
-import { clearAuthState } from "../Features/Auth/authSlice";
+import { clearAuthState, setAuthToken } from "../Features/Auth/authSlice";
 class NetworkService {
 	constructor(store, dispatch, navigate) {
 		this.store = store;
@@ -26,11 +26,12 @@ class NetworkService {
 			(config) => {
 				const currentLanguage = i18next.language || "en";
 
-				const { authToken } = store.getState().auth;
+				const { authToken, refreshToken } = store.getState().auth;
 
 				config.headers = {
 					Authorization: `Bearer ${authToken}`,
 					"Accept-Language": currentLanguage === "gb" ? "en" : currentLanguage,
+					...(refreshToken && { "x-refresh-token": refreshToken }),
 					...config.headers,
 				};
 
@@ -40,9 +41,24 @@ class NetworkService {
 				return Promise.reject(error);
 			}
 		);
+		// Track if we're currently refreshing to prevent multiple refresh calls
+		this.isRefreshing = false;
+		this.failedQueue = [];
+
+		const processQueue = (error, token = null) => {
+			this.failedQueue.forEach((prom) => {
+				if (error) {
+					prom.reject(error);
+				} else {
+					prom.resolve(token);
+				}
+			});
+			this.failedQueue = [];
+		};
+
 		this.axiosInstance.interceptors.response.use(
 			(response) => response,
-			(error) => {
+			async (error) => {
 				// Handle network errors (server unreachable)
 				if (error.code === "ERR_NETWORK") {
 					// Navigate to server unreachable page
@@ -51,8 +67,51 @@ class NetworkService {
 					return Promise.reject(error);
 				}
 
-				// Handle authentication errors
+				const originalRequest = error.config;
 
+				// Handle 403 - server is telling us to request a new access token
+				if (error.response && error.response.status === 403 && !originalRequest._retry) {
+					if (this.isRefreshing) {
+						// If already refreshing, queue this request
+						return new Promise((resolve, reject) => {
+							this.failedQueue.push({ resolve, reject });
+						})
+							.then((token) => {
+								originalRequest.headers["Authorization"] = `Bearer ${token}`;
+								return this.axiosInstance(originalRequest);
+							})
+							.catch((err) => Promise.reject(err));
+					}
+
+					originalRequest._retry = true;
+					this.isRefreshing = true;
+
+					try {
+						// Call refresh endpoint
+						const response = await this.axiosInstance.post("/auth/refresh");
+						const newToken = response.data.data.token;
+
+						// Update the auth token in store
+						dispatch(setAuthToken(newToken));
+
+						// Process queued requests
+						processQueue(null, newToken);
+
+						// Retry original request with new token
+						originalRequest.headers["Authorization"] = `Bearer ${newToken}`;
+						return this.axiosInstance(originalRequest);
+					} catch (refreshError) {
+						// Refresh failed, clear auth and redirect to login
+						processQueue(refreshError, null);
+						dispatch(clearAuthState());
+						navigate("/login");
+						return Promise.reject(refreshError);
+					} finally {
+						this.isRefreshing = false;
+					}
+				}
+
+				// Handle 401 - authentication failed (invalid/expired refresh token or no token)
 				if (error.response && error.response.status === 401) {
 					dispatch(clearAuthState());
 					navigate("/login");

--- a/client/src/Utils/NetworkService.js
+++ b/client/src/Utils/NetworkService.js
@@ -31,9 +31,13 @@ class NetworkService {
 				config.headers = {
 					Authorization: `Bearer ${authToken}`,
 					"Accept-Language": currentLanguage === "gb" ? "en" : currentLanguage,
-					...(refreshToken && { "x-refresh-token": refreshToken }),
 					...config.headers,
 				};
+
+				// Only send refresh token to the refresh endpoint
+				if (refreshToken && config.url?.includes("/auth/refresh")) {
+					config.headers["x-refresh-token"] = refreshToken;
+				}
 
 				return config;
 			},
@@ -70,7 +74,22 @@ class NetworkService {
 				const originalRequest = error.config;
 
 				// Handle 403 - server is telling us to request a new access token
-				if (error.response && error.response.status === 403 && !originalRequest._retry) {
+				// Skip refresh logic for the refresh endpoint itself to prevent circular dependency
+				const isRefreshEndpoint = originalRequest.url?.includes("/auth/refresh");
+				if (
+					error.response &&
+					error.response.status === 403 &&
+					!originalRequest._retry &&
+					!isRefreshEndpoint
+				) {
+					// Check if we have a refresh token before attempting refresh
+					const { refreshToken } = store.getState().auth;
+					if (!refreshToken) {
+						dispatch(clearAuthState());
+						navigate("/login");
+						return Promise.reject(error);
+					}
+
 					if (this.isRefreshing) {
 						// If already refreshing, queue this request
 						return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary

Fixes #3101

The server already supports refresh tokens but the client was not using them. This caused users to be logged out after 2 hours (default TOKEN_TTL) even though the refresh token is valid for 7 days.

## Changes

### `client/src/Features/Auth/authSlice.js`
- Store `refreshToken` from login/register responses
- Add `setAuthToken` action for updating token after refresh
- Clear `refreshToken` on logout

### `client/src/Utils/NetworkService.js`
- Send `x-refresh-token` header with all requests
- On 403 response, call `/auth/refresh` to get new token
- Retry failed requests with new token
- Queue concurrent requests during refresh to prevent race conditions

## Refresh Flow

1. Access token expires, server returns 403 "Request new access token"
2. Client calls `POST /auth/refresh` with refresh token in header
3. Server returns new access token
4. Client updates store and retries original request
5. If refresh fails (expired/invalid), redirect to login

## Test Plan

- [ ] Login and verify both `token` and `refreshToken` are stored in Redux
- [ ] Wait for access token to expire (or set short `TOKEN_TTL`)
- [ ] Verify 403 triggers refresh flow, not immediate logout
- [ ] Verify original request is retried with new token
- [ ] Verify concurrent requests are queued during refresh
- [ ] Verify expired refresh token redirects to login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic token refresh for expired sessions, enabling seamless continuation without unexpected logouts.
  * Intelligent request queuing and retry during refresh to avoid duplicate refresh attempts and reduce interruptions.

* **Bug Fixes**
  * More reliable session clearing on logout to ensure stale tokens are removed.
  * Improved stability when refreshing tokens and handling network/server errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->