### PR TITLE
Fix pagespeed monitor deletion failing with undefined ID

### DIFF
--- a/client/src/Pages/PageSpeed/Create/index.jsx
+++ b/client/src/Pages/PageSpeed/Create/index.jsx
@@ -178,8 +178,7 @@ const PageSpeedSetup = () => {
 
 	const handleRemove = async (event) => {
 		event.preventDefault();
-		const TEMP_MONITOR = { id: monitor._id };
-		await deleteMonitor({ monitor: TEMP_MONITOR, redirect: "/pagespeed" });
+		await deleteMonitor({ monitor: { id: monitorId }, redirect: "/pagespeed" });
 	};
 
 	const isBusy = isLoading || isCreating || isDeleting || isUpdating || isPausing;


### PR DESCRIPTION
## Summary
Fixed "Failed to delete monitor" error when trying to delete a pagespeed monitor.

## Problem
The delete handler was using `monitor._id` from component state, which was `undefined` because the fetched monitor object didn't have `_id` populated.

## Solution
Changed to use `monitorId` directly from URL params (`useParams`), which is already available and used by other handlers in the same component (e.g., `handlePause`).

## Test plan
- [ ] Navigate to a pagespeed monitor's configure page
- [ ] Click delete button
- [ ] Verify monitor is deleted successfully