### PR TITLE
fix: remove <> from allowed password characters and display allowed special chars

### DIFF
--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -483,7 +483,7 @@
 		"newPassword": "New password",
 		"enterNewPassword": "Enter your new password",
 		"confirmNewPassword": "Confirm new password",
-		"passwordRequirements": "New password must contain at least 8 characters and must have at least one uppercase letter, one lowercase letter, one number and one special character.",
+		"passwordRequirements": "New password must contain at least 8 characters and must have at least one uppercase letter, one lowercase letter, one number and one special character (!?@#$%^&*()-_=+[]{}|;:'\",./\\~`).",
 		"saving": "Saving..."
 	},
 	"emailSent": "Email sent successfully",
@@ -542,7 +542,7 @@
 						},
 						"special": {
 							"beginning": "Must contain at least",
-							"highlighted": "one special character"
+							"highlighted": "one special character (!?@#$%^&*()-_=+[]{}|;:'\",./\\~`)"
 						},
 						"number": {
 							"beginning": "Must contain at least",
@@ -567,7 +567,7 @@
 						"uppercase": "Password must contain at least 1 uppercase letter",
 						"lowercase": "Password must contain at least 1 lowercase letter",
 						"number": "Password must contain at least 1 number",
-						"special": "Password must contain at least 1 special character",
+						"special": "Password must contain at least 1 special character (!?@#$%^&*()-_=+[]{}|;:'\",./\\~`)",
 						"incorrect": "The password you provided does not match our records"
 					}
 				},

--- a/server/src/validation/joi.js
+++ b/server/src/validation/joi.js
@@ -17,8 +17,7 @@ const roleValidatior = (role) => (value, helpers) => {
 // Auth
 //****************************************
 
-const passwordPattern =
-	/^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!?@#$%^&*()\-_=+[\]{};:'",.<>~`|\\/])[A-Za-z0-9!?@#$%^&*()\-_=+[\]{};:'",.<>~`|\\/]+$/;
+const passwordPattern = /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!?@#$%^&*()\-_=+[\]{};:'",.~`|\\/])[A-Za-z0-9!?@#$%^&*()\-_=+[\]{};:'",.~`|\\/]+$/;
 
 const loginValidation = joi.object({
 	email: joi.string().email().required().lowercase(),


### PR DESCRIPTION
## Summary
- Remove `<` and `>` from password regex pattern (these chars are stripped by DOMPurify sanitization which caused confusing validation errors)
- Update locale strings to display the list of allowed special characters in password tooltip, error messages, and password panel requirements

## Test plan
- [ ] Verify registration form shows allowed special characters in password tooltip
- [ ] Verify password change panel shows allowed special characters in requirements
- [ ] Confirm passwords with `<` or `>` are now properly rejected with clear feedback
- [ ] Confirm passwords with other special characters still work correctly

Fixes #3010