### PR TITLE
fix: make dateRange optional for hardware details endpoint

### DIFF
--- a/server/src/controllers/monitorController.ts
+++ b/server/src/controllers/monitorController.ts
@@ -97,7 +97,7 @@ class MonitorController {
 			await getHardwareDetailsByIdQueryValidation.validateAsync(req.query);
 
 			const monitorId = requireString(req?.params?.monitorId, "Monitor ID");
-			const dateRange = requireString(req?.query?.dateRange, "dateRange");
+			const dateRange = optionalString(req?.query?.dateRange, "dateRange") || "recent";
 			const teamId = requireTeamId(req?.user?.teamId);
 
 			const monitor = await this.monitorService.getHardwareDetailsById({


### PR DESCRIPTION
## Summary
- Make `dateRange` query parameter optional for `/monitors/hardware/details/{id}` endpoint
- Default to `"recent"` when not provided

## Problem
The Joi validation schema marks `dateRange` as optional, but the controller used `requireString()` which throws a 400 error when `dateRange` is missing. This caused the infrastructure configure page (`/infrastructure/configure/{id}`) to fail with:

```json
{"success":false,"msg":"dateRange is required","data":null}
```

## Solution
Changed from `requireString()` to `optionalString()` with `"recent"` as the default value, matching the Joi validation schema and the behavior of similar endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardware details retrieval no longer requires specifying a date range; the system now defaults to displaying recent data when a date range is not provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->