### PR TITLE
Fix incidents page issues

### DIFF
--- a/client/src/Pages/Incidents2/Components/StatisticsPanel/index.jsx
+++ b/client/src/Pages/Incidents2/Components/StatisticsPanel/index.jsx
@@ -26,6 +26,18 @@ import SummaryCard from "../SummaryCard/index.jsx";
  * @param {boolean} props.isLoading - Loading state
  * @param {Object} props.error - Error object if any
  */
+const formatResolutionTime = (hours) => {
+	if (!hours || hours === 0) return "0m";
+
+	const totalMinutes = Math.round(hours * 60);
+	const h = Math.floor(totalMinutes / 60);
+	const m = totalMinutes % 60;
+
+	if (h === 0) return `${m}m`;
+	if (m === 0) return `${h}h`;
+	return `${h}h ${m}m`;
+};
+
 const StatisticsPanel = ({ isLoading = false, error = null, summary = {} }) => {
 	const theme = useTheme();
 	const { t } = useTranslation();
@@ -150,7 +162,7 @@ const StatisticsPanel = ({ isLoading = false, error = null, summary = {} }) => {
 					>
 						{t("incidentsPage.avgResolutionTime")}:{" "}
 						{summary.total > 0
-							? `${summary.avgResolutionTimeHours || 0} ${t("incidentsPage.hours")}`
+							? formatResolutionTime(summary.avgResolutionTimeHours)
 							: "N/A"}
 					</Typography>
 				</Stack>

--- a/client/src/Pages/Incidents2/index.jsx
+++ b/client/src/Pages/Incidents2/index.jsx
@@ -8,7 +8,7 @@ import IncidentsSummaryPanel from "./Components/IncidentsSummaryPanel/index.jsx"
 
 //Utils
 import { useTheme } from "@emotion/react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import NetworkError from "@/Components/v1/GenericFallback/NetworkError.jsx";
 import { useTranslation } from "react-i18next";
 
@@ -53,16 +53,33 @@ const Incidents2 = () => {
 
 	const theme = useTheme();
 
-	useEffect(() => {
-		setPage(0);
-	}, [selectedMonitor, filter, dateRange]);
+	// Track previous filter values to detect changes and reset page
+	const prevFiltersRef = useRef({ selectedMonitor, filter, dateRange });
 
 	useEffect(() => {
+		const prevFilters = prevFiltersRef.current;
+		const filtersChanged =
+			prevFilters.selectedMonitor !== selectedMonitor ||
+			prevFilters.filter !== filter ||
+			prevFilters.dateRange !== dateRange;
+
+		// Determine the effective page - reset to 0 if filters changed
+		const effectivePage = filtersChanged ? 0 : page;
+
+		// Update the ref for next comparison
+		if (filtersChanged) {
+			prevFiltersRef.current = { selectedMonitor, filter, dateRange };
+			// Also update the page state (for pagination component)
+			if (page !== 0) {
+				setPage(0);
+			}
+		}
+
 		const config = {
 			monitorId: selectedMonitor !== "0" ? selectedMonitor : undefined,
 			sortOrder: "desc",
 			dateRange,
-			page,
+			page: effectivePage,
 			rowsPerPage,
 		};
 

--- a/client/src/Pages/PageSpeed/Details/Components/PageSpeedStatusBoxes/index.jsx
+++ b/client/src/Pages/PageSpeed/Details/Components/PageSpeedStatusBoxes/index.jsx
@@ -10,12 +10,16 @@ const PageSpeedStatusBoxes = ({ shouldRender, monitor }) => {
 	// Calculate time since first check (checks since)
 	const checks = monitor?.checks || [];
 	const oldestCheck = checks.length > 0 ? checks[checks.length - 1] : null;
-	const oldestCheckTime = oldestCheck?.createdAt ? new Date(oldestCheck.createdAt).getTime() : null;
+	const oldestCheckTime = oldestCheck?.createdAt
+		? new Date(oldestCheck.createdAt).getTime()
+		: null;
 	const checksSinceDuration = oldestCheckTime ? Date.now() - oldestCheckTime : 0;
 
 	// Calculate time since last check
 	const latestCheck = checks.length > 0 ? checks[0] : null;
-	const latestCheckTime = latestCheck?.createdAt ? new Date(latestCheck.createdAt).getTime() : null;
+	const latestCheckTime = latestCheck?.createdAt
+		? new Date(latestCheck.createdAt).getTime()
+		: null;
 	const lastCheckDuration = latestCheckTime ? Date.now() - latestCheckTime : 0;
 
 	const uptimeDuration = getHumanReadableDuration(checksSinceDuration);

--- a/client/src/Pages/PageSpeed/Details/Components/PageSpeedStatusBoxes/index.jsx
+++ b/client/src/Pages/PageSpeed/Details/Components/PageSpeedStatusBoxes/index.jsx
@@ -4,26 +4,23 @@ import { Typography } from "@mui/material";
 import { getHumanReadableDuration } from "../../../../../Utils/timeUtils.js";
 import { useTranslation } from "react-i18next";
 
-const PageSpeedStatusBoxes = ({ shouldRender, monitor }) => {
+const PageSpeedStatusBoxes = ({ shouldRender, monitorStats }) => {
+	const lastChecked = monitorStats?.lastCheckTimestamp
+		? Date.now() - monitorStats.lastCheckTimestamp
+		: 0;
+
+	// Determine time since last failure
+	const timeOfLastFailure = monitorStats?.timeOfLastFailure;
+	const timeSinceLastFailure =
+		timeOfLastFailure > 0
+			? Date.now() - timeOfLastFailure
+			: Date.now() - new Date(monitorStats?.createdAt);
+
+	const streakTime = getHumanReadableDuration(timeSinceLastFailure);
+
+	const time = getHumanReadableDuration(lastChecked);
+
 	const { t } = useTranslation();
-
-	// Calculate time since first check (checks since)
-	const checks = monitor?.checks || [];
-	const oldestCheck = checks.length > 0 ? checks[checks.length - 1] : null;
-	const oldestCheckTime = oldestCheck?.createdAt
-		? new Date(oldestCheck.createdAt).getTime()
-		: null;
-	const checksSinceDuration = oldestCheckTime ? Date.now() - oldestCheckTime : 0;
-
-	// Calculate time since last check
-	const latestCheck = checks.length > 0 ? checks[0] : null;
-	const latestCheckTime = latestCheck?.createdAt
-		? new Date(latestCheck.createdAt).getTime()
-		: null;
-	const lastCheckDuration = latestCheckTime ? Date.now() - latestCheckTime : 0;
-
-	const uptimeDuration = getHumanReadableDuration(checksSinceDuration);
-	const time = getHumanReadableDuration(lastCheckDuration);
 
 	return (
 		<StatusBoxes shouldRender={shouldRender}>
@@ -31,7 +28,7 @@ const PageSpeedStatusBoxes = ({ shouldRender, monitor }) => {
 				heading="checks since"
 				subHeading={
 					<>
-						{uptimeDuration}
+						{streakTime}
 						<Typography component="span">{t("ago")}</Typography>
 					</>
 				}

--- a/client/src/Pages/PageSpeed/Details/Components/PageSpeedStatusBoxes/index.jsx
+++ b/client/src/Pages/PageSpeed/Details/Components/PageSpeedStatusBoxes/index.jsx
@@ -5,10 +5,21 @@ import { getHumanReadableDuration } from "../../../../../Utils/timeUtils.js";
 import { useTranslation } from "react-i18next";
 
 const PageSpeedStatusBoxes = ({ shouldRender, monitor }) => {
-	const uptimeDuration = getHumanReadableDuration(monitor?.uptimeDuration);
-	const time = getHumanReadableDuration(monitor?.lastChecked);
-
 	const { t } = useTranslation();
+
+	// Calculate time since first check (checks since)
+	const checks = monitor?.checks || [];
+	const oldestCheck = checks.length > 0 ? checks[checks.length - 1] : null;
+	const oldestCheckTime = oldestCheck?.createdAt ? new Date(oldestCheck.createdAt).getTime() : null;
+	const checksSinceDuration = oldestCheckTime ? Date.now() - oldestCheckTime : 0;
+
+	// Calculate time since last check
+	const latestCheck = checks.length > 0 ? checks[0] : null;
+	const latestCheckTime = latestCheck?.createdAt ? new Date(latestCheck.createdAt).getTime() : null;
+	const lastCheckDuration = latestCheckTime ? Date.now() - latestCheckTime : 0;
+
+	const uptimeDuration = getHumanReadableDuration(checksSinceDuration);
+	const time = getHumanReadableDuration(lastCheckDuration);
 
 	return (
 		<StatusBoxes shouldRender={shouldRender}>


### PR DESCRIPTION
## Summary
- Fix incidents "Avg. Resolution Time" displaying decimal hours instead of human-readable format
- Fix incidents monitor filter dropdown showing no results when selecting a specific monitor

## Changes

### Incidents resolution time format
Added `formatResolutionTime()` function that converts decimal hours to human-readable format:
- "0.86 hours" → "52m"
- "2.25 hours" → "2h 15m"
- Shows "N/A" when there are no incidents

### Incidents monitor filter fix
Fixed a race condition where selecting a monitor from the dropdown would fetch with the wrong page number. Consolidated page reset and fetch logic into a single useEffect to ensure page 0 is used immediately when filters change.

---

**Note:** The PageSpeed stats fix was removed from this PR as it has already been fixed differently on develop by Alex Holliday (commit 6447c315c).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Pagination now only resets to page 1 when filters or date ranges actually change.
  - Status boxes for PageSpeed now show updated "checks since" and last-check timings derived from check history.

* **Refactor**
  - Average resolution time is shown in a human-readable format (e.g., "2h 15m" instead of decimal hours).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->