### PR TITLE
remove pagespeed from snapshot array, full check list required

### DIFF
--- a/server/src/service/business/monitorService.ts
+++ b/server/src/service/business/monitorService.ts
@@ -388,7 +388,7 @@ export class MonitorService implements IMonitorService {
 		});
 
 		const monitorsList = (monitors ?? []) as Monitor[];
-		const snapshotTypes: MonitorType[] = ["hardware", "pagespeed"];
+		const snapshotTypes: MonitorType[] = ["hardware"];
 		const requestedTypes = Array.isArray(type) ? type : type ? [type] : [];
 		const snapshotOnlyRequest =
 			requestedTypes.length > 0 && requestedTypes.every((requestedType) => snapshotTypes.includes(requestedType as MonitorType));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated monitor check handling to apply snapshot-only checks exclusively to hardware monitors. Pagespeed monitors are no longer eligible for snapshot-only treatment in the monitoring system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->