### PR TITLE
Fix sidebar gap when scrolling on pages with tall content

### DIFF
--- a/client/src/Components/v1/Layouts/HomeLayout/index.css
+++ b/client/src/Components/v1/Layouts/HomeLayout/index.css
@@ -14,15 +14,7 @@
 	}
 } */
 
-/* .home-layout aside {
-	position: sticky;
-	top: 0;
-	left: 0;
-	height: 100vh;
-	max-width: var(--env-var-side-bar-width);
-} */
-
-.home-layout > div {
+.home-layout > .home-content-wrapper {
 	min-height: calc(100vh - var(--env-var-spacing-2) * 2);
 	flex: 1;
 }

--- a/client/src/Components/v1/Layouts/HomeLayout/index.jsx
+++ b/client/src/Components/v1/Layouts/HomeLayout/index.jsx
@@ -1,12 +1,12 @@
 import Sidebar from "../../Sidebar/index.jsx";
 import { Outlet } from "react-router";
 import { Box, Stack } from "@mui/material";
-import { useSelector } from "react-redux";
+import { useSidebar } from "@/Hooks/useSidebar.js";
 
 import "./index.css";
 
 const HomeLayout = () => {
-	const collapsed = useSelector((state) => state.ui.sidebar?.collapsed ?? false);
+	const { width, transition } = useSidebar();
 
 	return (
 		<Stack
@@ -17,11 +17,9 @@ const HomeLayout = () => {
 			{/* Spacer for fixed sidebar */}
 			<Box
 				sx={{
-					width: collapsed
-						? "var(--env-var-side-bar-collapsed-width)"
-						: "var(--env-var-side-bar-width)",
+					width,
 					flexShrink: 0,
-					transition: "width 650ms cubic-bezier(0.36, -0.01, 0, 0.77)",
+					transition,
 				}}
 			/>
 			<Stack className="home-content-wrapper">

--- a/client/src/Components/v1/Layouts/HomeLayout/index.jsx
+++ b/client/src/Components/v1/Layouts/HomeLayout/index.jsx
@@ -1,17 +1,29 @@
 import Sidebar from "../../Sidebar/index.jsx";
 import { Outlet } from "react-router";
-import { Stack } from "@mui/material";
+import { Box, Stack } from "@mui/material";
+import { useSelector } from "react-redux";
 
 import "./index.css";
 
 const HomeLayout = () => {
+	const collapsed = useSelector((state) => state.ui.sidebar?.collapsed ?? false);
+
 	return (
 		<Stack
 			className="home-layout"
 			flexDirection="row"
-			gap={14}
 		>
 			<Sidebar />
+			{/* Spacer for fixed sidebar */}
+			<Box
+				sx={{
+					width: collapsed
+						? "var(--env-var-side-bar-collapsed-width)"
+						: "var(--env-var-side-bar-width)",
+					flexShrink: 0,
+					transition: "width 650ms cubic-bezier(0.36, -0.01, 0, 0.77)",
+				}}
+			/>
 			<Stack className="home-content-wrapper">
 				<Outlet />
 			</Stack>

--- a/client/src/Components/v1/Sidebar/index.jsx
+++ b/client/src/Components/v1/Sidebar/index.jsx
@@ -12,9 +12,9 @@ import Icon from "../Icon";
 
 // Utils
 import { useTheme } from "@mui/material/styles";
-import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router";
+import { useSidebar } from "@/Hooks/useSidebar.js";
 
 const URL_MAP = {
 	support: "https://discord.com/invite/NAb6H3UTjK",
@@ -65,8 +65,7 @@ const Sidebar = () => {
 	const theme = useTheme();
 	const { t } = useTranslation();
 	const navigate = useNavigate();
-	// Redux state
-	const collapsed = useSelector((state) => state.ui.sidebar?.collapsed ?? false);
+	const { collapsed, width, transition } = useSidebar();
 
 	const menu = getMenu(t);
 	const otherMenuItems = getOtherMenuItems(t);
@@ -75,11 +74,7 @@ const Sidebar = () => {
 	return (
 		<Stack
 			height="100vh"
-			width={
-				collapsed
-					? "var(--env-var-side-bar-collapsed-width)"
-					: "var(--env-var-side-bar-width)"
-			}
+			width={width}
 			component="aside"
 			position="fixed"
 			top={0}
@@ -88,7 +83,7 @@ const Sidebar = () => {
 			paddingBottom={theme.spacing(6)}
 			gap={theme.spacing(6)}
 			sx={{
-				transition: "width 650ms cubic-bezier(0.36, -0.01, 0, 0.77)",
+				transition,
 				backgroundColor: "#000000",
 				borderRight: "1px solid #344054",
 				zIndex: 1000,

--- a/client/src/Components/v1/Sidebar/index.jsx
+++ b/client/src/Components/v1/Sidebar/index.jsx
@@ -81,14 +81,17 @@ const Sidebar = () => {
 					: "var(--env-var-side-bar-width)"
 			}
 			component="aside"
-			position="sticky"
+			position="fixed"
 			top={0}
-			borderRight={`1px solid ${theme.palette.primary.lowContrast}`}
+			left={0}
 			paddingTop={theme.spacing(6)}
 			paddingBottom={theme.spacing(6)}
 			gap={theme.spacing(6)}
 			sx={{
 				transition: "width 650ms cubic-bezier(0.36, -0.01, 0, 0.77)",
+				backgroundColor: "#000000",
+				borderRight: "1px solid #344054",
+				zIndex: 1000,
 			}}
 		>
 			<CollapseButton collapsed={collapsed} />

--- a/client/src/Hooks/useSidebar.js
+++ b/client/src/Hooks/useSidebar.js
@@ -1,0 +1,29 @@
+import { useSelector } from "react-redux";
+
+// CSS variable names for sidebar widths
+const SIDEBAR_WIDTH_VAR = "var(--env-var-side-bar-width)";
+const SIDEBAR_COLLAPSED_WIDTH_VAR = "var(--env-var-side-bar-collapsed-width)";
+
+// Transition timing for sidebar width changes
+const SIDEBAR_TRANSITION = "width 650ms cubic-bezier(0.36, -0.01, 0, 0.77)";
+
+/**
+ * Hook to get sidebar state and computed width
+ * Centralizes sidebar width logic to avoid duplication between Sidebar and HomeLayout
+ *
+ * @returns {Object} Sidebar state and styles
+ * @returns {boolean} collapsed - Whether the sidebar is collapsed
+ * @returns {string} width - CSS width value based on collapsed state
+ * @returns {string} transition - CSS transition for width changes
+ */
+export const useSidebar = () => {
+	const collapsed = useSelector((state) => state.ui.sidebar?.collapsed ?? false);
+
+	return {
+		collapsed,
+		width: collapsed ? SIDEBAR_COLLAPSED_WIDTH_VAR : SIDEBAR_WIDTH_VAR,
+		transition: SIDEBAR_TRANSITION,
+	};
+};
+
+export default useSidebar;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -4,6 +4,12 @@
 	box-sizing: border-box;
 }
 
+html,
+body {
+	background-color: #000000;
+	overscroll-behavior: none;
+}
+
 html {
 	scroll-behavior: smooth;
 }


### PR DESCRIPTION
## Summary
- Fixed the sidebar showing a visible gap at the bottom when scrolling on pages with tall tables (e.g., /checks page)
- Changed sidebar positioning from sticky to fixed to avoid issues with parent container's overflow-x: hidden
- Added a spacer element to maintain proper layout spacing for the content area
- Disabled overscroll bounce effect and set black background on html/body

## Changes
- `Sidebar/index.jsx`: Changed from `position: sticky` to `position: fixed`, added background and border styles
- `HomeLayout/index.jsx`: Added spacer Box element that responds to sidebar collapsed state  
- `HomeLayout/index.css`: Removed unused selectors and cleaned up CSS
- `index.css`: Added `background-color: #000000` and `overscroll-behavior: none` to html/body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar now stays fixed while scrolling.
  * Layout adds a responsive spacer so content shifts when the sidebar is collapsed or expanded.

* **Style**
  * Updated sidebar background color, border, and stacking order for consistent appearance.
  * Enforced a dark page background and adjusted home layout spacing to match the new structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->