### PR TITLE
fix: sidebar and body background not adapting to light mode

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -22,9 +22,18 @@ function App() {
 		};
 	}, []);
 
+	const theme = mode === "light" ? lightTheme : darkTheme;
+
 	return (
-		<ThemeProvider theme={mode === "light" ? lightTheme : darkTheme}>
+		<ThemeProvider theme={theme}>
 			<CssBaseline />
+			<GlobalStyles
+				styles={{
+					body: {
+						backgroundColor: theme.palette.background.main,
+					},
+				}}
+			/>
 			<AppLayout>
 				<Routes />
 			</AppLayout>

--- a/client/src/Components/v1/Sidebar/index.jsx
+++ b/client/src/Components/v1/Sidebar/index.jsx
@@ -84,8 +84,8 @@ const Sidebar = () => {
 			gap={theme.spacing(6)}
 			sx={{
 				transition,
-				backgroundColor: "#000000",
-				borderRight: "1px solid #344054",
+				backgroundColor: theme.palette.background.main,
+				borderRight: `1px solid ${theme.palette.border.light}`,
 				zIndex: 1000,
 			}}
 		>

--- a/client/src/Components/v1/Sidebar/index.jsx
+++ b/client/src/Components/v1/Sidebar/index.jsx
@@ -85,7 +85,7 @@ const Sidebar = () => {
 			sx={{
 				transition,
 				backgroundColor: theme.palette.background.main,
-				borderRight: `1px solid ${theme.palette.border.light}`,
+				borderRight: `1px solid ${theme.palette.primary.lowContrast}`,
 				zIndex: 1000,
 			}}
 		>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -6,7 +6,6 @@
 
 html,
 body {
-	background-color: #000000;
 	overscroll-behavior: none;
 }
 


### PR DESCRIPTION
## Summary
Fixed sidebar and body background displaying dark colors in light mode.

## Changes

### Sidebar (index.jsx)
- Changed hardcoded `backgroundColor: "#000000"` to `theme.palette.background.main`
- Updated hardcoded border color to use `theme.palette.border.light`

### Body Background
- Removed hardcoded `background-color: #000000` from index.css
- Added GlobalStyles component in App.jsx to apply theme background color to body element