### PR TITLE
fix: prevent 500 error when editing status page with undefined monitor IDs

### DIFF
--- a/client/src/Pages/StatusPage/Create/Components/Tabs/Content.jsx
+++ b/client/src/Pages/StatusPage/Create/Components/Tabs/Content.jsx
@@ -23,10 +23,11 @@ const Content = ({
 
 	// Handlers
 	const handleMonitorsChange = (selectedMonitors) => {
+		const validMonitors = selectedMonitors.filter((monitor) => monitor?.id);
 		handleFormChange({
-			target: { name: "monitors", value: selectedMonitors.map((monitor) => monitor.id) },
+			target: { name: "monitors", value: validMonitors.map((monitor) => monitor.id) },
 		});
-		setSelectedMonitors(selectedMonitors);
+		setSelectedMonitors(validMonitors);
 	};
 
 	// Utils

--- a/client/src/Pages/StatusPage/Create/index.jsx
+++ b/client/src/Pages/StatusPage/Create/index.jsx
@@ -186,7 +186,7 @@ const CreateStatusPage = () => {
 	// If we are configuring, populate fields
 	useEffect(() => {
 		if (isCreate) return;
-		if (typeof statusPage === "undefined") {
+		if (typeof statusPage === "undefined" || !Array.isArray(statusPageMonitors)) {
 			return;
 		}
 
@@ -205,7 +205,9 @@ const CreateStatusPage = () => {
 				companyName: statusPage?.companyName,
 				isPublished: statusPage?.isPublished,
 				timezone: statusPage?.timezone,
-				monitors: statusPageMonitors.map((monitor) => monitor.id),
+				monitors: statusPageMonitors
+					.filter((monitor) => monitor?.id)
+					.map((monitor) => monitor.id),
 				color: statusPage?.color,
 				logo: newLogo,
 				showCharts: statusPage?.showCharts ?? true,
@@ -213,7 +215,7 @@ const CreateStatusPage = () => {
 				showAdminLoginLink: statusPage?.showAdminLoginLink ?? false,
 			};
 		});
-		setSelectedMonitors(statusPageMonitors);
+		setSelectedMonitors(statusPageMonitors.filter((monitor) => monitor?.id));
 	}, [isCreate, statusPage, statusPageMonitors]);
 
 	if (networkError === true) {


### PR DESCRIPTION
## Summary
- Fix 500 error that occurs when editing an existing status page due to undefined monitor IDs being sent to the server

## Changes
- `client/src/Pages/StatusPage/Create/index.jsx`: Add null check for statusPageMonitors array and filter out monitors with undefined IDs
- `client/src/Pages/StatusPage/Create/Components/Tabs/Content.jsx`: Add filter in handleMonitorsChange to prevent invalid monitors from being selected