### PR TITLE
Fix password tooltip theme contrast issues

### DIFF
--- a/client/src/Components/v1/Check/Check.jsx
+++ b/client/src/Components/v1/Check/Check.jsx
@@ -56,7 +56,14 @@ const Check = ({ text, noHighlightText, variant = "info", outlined = false }) =>
 					fontWeight: 450,
 				}}
 			>
-				{noHighlightText && <Typography component="span">{noHighlightText}</Typography>}{" "}
+				{noHighlightText && (
+					<Typography
+						component="span"
+						sx={{ color: "inherit" }}
+					>
+						{noHighlightText}
+					</Typography>
+				)}{" "}
 				{text}
 			</Typography>
 		</Stack>

--- a/client/src/Pages/Account/components/PasswordPanel.jsx
+++ b/client/src/Pages/Account/components/PasswordPanel.jsx
@@ -167,7 +167,11 @@ const PasswordPanel = () => {
 						value={localData.password}
 						onChange={handleChange}
 						error={errors[idToName["edit-current-password"]] ? true : false}
-						helperText={errors[idToName["edit-current-password"]]}
+						helperText={
+							errors[idToName["edit-current-password"]]
+								? t(errors[idToName["edit-current-password"]])
+								: ""
+						}
 						endAdornment={<PasswordEndAdornment />}
 						flex={1}
 					/>
@@ -193,7 +197,11 @@ const PasswordPanel = () => {
 						value={localData.newPassword}
 						onChange={handleChange}
 						error={errors[idToName["edit-new-password"]] ? true : false}
-						helperText={errors[idToName["edit-new-password"]]}
+						helperText={
+							errors[idToName["edit-new-password"]]
+								? t(errors[idToName["edit-new-password"]])
+								: ""
+						}
 						endAdornment={<PasswordEndAdornment />}
 						flex={1}
 					/>
@@ -219,7 +227,11 @@ const PasswordPanel = () => {
 						value={localData.confirm}
 						onChange={handleChange}
 						error={errors[idToName["edit-confirm-password"]] ? true : false}
-						helperText={errors[idToName["edit-confirm-password"]]}
+						helperText={
+							errors[idToName["edit-confirm-password"]]
+								? t(errors[idToName["edit-confirm-password"]])
+								: ""
+						}
 						endAdornment={<PasswordEndAdornment />}
 						flex={1}
 					/>

--- a/client/src/Pages/Account/components/ProfilePanel.jsx
+++ b/client/src/Pages/Account/components/ProfilePanel.jsx
@@ -210,7 +210,11 @@ const ProfilePanel = () => {
 						autoComplete="given-name"
 						onChange={handleChange}
 						error={errors[idToName["edit-first-name"]] ? true : false}
-						helperText={errors[idToName["edit-first-name"]]}
+						helperText={
+							errors[idToName["edit-first-name"]]
+								? t(errors[idToName["edit-first-name"]])
+								: ""
+						}
 						flex={1}
 					/>
 				</Stack>
@@ -228,7 +232,11 @@ const ProfilePanel = () => {
 						value={localData.lastName}
 						onChange={handleChange}
 						error={errors[idToName["edit-last-name"]] ? true : false}
-						helperText={errors[idToName["edit-last-name"]]}
+						helperText={
+							errors[idToName["edit-last-name"]]
+								? t(errors[idToName["edit-last-name"]])
+								: ""
+						}
 						flex={1}
 					/>
 				</Stack>

--- a/client/src/Pages/Auth/components/PasswordTooltip.jsx
+++ b/client/src/Pages/Auth/components/PasswordTooltip.jsx
@@ -75,7 +75,7 @@ const PasswordTooltip = ({ feedback, form, children }) => {
 			slotProps={{
 				tooltip: {
 					sx: {
-						backgroundColor: theme.palette.tertiary.background,
+						backgroundColor: theme.palette.tertiary.main,
 						border: `0.5px solid ${theme.palette.primary.lowContrast}90`,
 						borderRadius: theme.spacing(4),
 						color: theme.palette.primary.contrastText,
@@ -88,7 +88,7 @@ const PasswordTooltip = ({ feedback, form, children }) => {
 				},
 				arrow: {
 					sx: {
-						color: theme.palette.tertiary.background,
+						color: theme.palette.tertiary.main,
 					},
 				},
 			}}


### PR DESCRIPTION
## Summary
- Fix tooltip background color in password strength tooltip during registration
- Fix text color inheritance in Check component for proper theme support

## Changes
- **PasswordTooltip.jsx**: Changed `tertiary.background` (non-existent) to `tertiary.main` for tooltip background and arrow colors
- **Check.jsx**: Added `color: inherit` to inner Typography for `noHighlightText` to properly inherit parent color

## Root cause
The `PasswordTooltip` component was referencing `theme.palette.tertiary.background` which doesn't exist in the theme palette (only `tertiary.main` and `tertiary.contrastText` are defined). This caused the tooltip to have an undefined background color, resulting in poor contrast in both light and dark themes.

Additionally, the `Check` component's inner Typography for `noHighlightText` wasn't inheriting the parent's color, causing text to display with default colors instead of themed colors.