### PR TITLE
fix: use correct route param in deleteStatusPage

### DIFF
--- a/server/src/controllers/statusPageController.ts
+++ b/server/src/controllers/statusPageController.ts
@@ -116,12 +116,12 @@ class StatusPageController {
 
 	deleteStatusPage = async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			const statusPageId = req.params.id as string;
-			if (!statusPageId) {
-				throw new AppError({ message: "Status page ID is required", status: 400 });
+			const statusPageUrl = req.params.url as string;
+			if (!statusPageUrl) {
+				throw new AppError({ message: "Status page URL is required", status: 400 });
 			}
 			const teamId = requireTeamId(req.user?.teamId);
-			await this.statusPageService.deleteStatusPage(statusPageId, teamId);
+			await this.statusPageService.deleteStatusPage(statusPageUrl, teamId);
 			return res.status(200).json({
 				success: true,
 				msg: "Status page deleted successfully",


### PR DESCRIPTION
## Summary

Fixes #3228

The `DELETE /status-page/:url` route defines the parameter as `:url(*)`, but the `deleteStatusPage` controller method was incorrectly reading `req.params.id` instead of `req.params.url`, causing a 400 error when trying to delete status pages.

## Changes

- Changed `req.params.id` to `req.params.url` in the `deleteStatusPage` method
- Renamed variable from `statusPageId` to `statusPageUrl` for clarity
- Updated error message to reference "URL" instead of "ID"

## Root Cause

This regression was introduced in PR #3112 during the JavaScript to TypeScript migration.

## Test Plan

1. Navigate to a status page
2. Click delete
3. Verify the status page is deleted successfully (no 400 error)