### PR TITLE
Add i18n support for password reset flow (follow-up to #3185)

### DIFF
--- a/client/src/Pages/Account/components/PasswordPanel.jsx
+++ b/client/src/Pages/Account/components/PasswordPanel.jsx
@@ -87,7 +87,10 @@ const PasswordPanel = () => {
 		// Check for expired/invalid token before submitting
 		if (!authToken) {
 			createToast({
-				body: "Your session has expired. Please log in again.",
+				body: t(
+					"passwordPanel.sessionExpired",
+					"Your session has expired. Please log in again to continue."
+				),
 			});
 			dispatch(clearAuthState());
 			navigate("/login");
@@ -268,8 +271,8 @@ const PasswordPanel = () => {
 					alignItems="center"
 				>
 					<TextLink
-						text={"Forgot password?"}
-						linkText={"Reset password"}
+						text={t("passwordPanel.forgotPassword", "Forgot password?")}
+						linkText={t("passwordPanel.resetPassword", "Reset password")}
 						state={{ from: location.pathname }}
 						href={"/forgot-password"}
 					/>

--- a/client/src/Pages/Auth/CheckEmail.jsx
+++ b/client/src/Pages/Auth/CheckEmail.jsx
@@ -224,7 +224,7 @@ const CheckEmail = () => {
 					<Trans
 						i18nKey={
 							location.state?.from === "/account/password"
-								? "Go back to <a>Account Password</a>"
+								? "auth.forgotPassword.links.accountPassword"
 								: "auth.forgotPassword.links.login"
 						}
 						components={{

--- a/client/src/Pages/Auth/ForgotPassword.jsx
+++ b/client/src/Pages/Auth/ForgotPassword.jsx
@@ -219,7 +219,7 @@ const ForgotPassword = () => {
 					<Trans
 						i18nKey={
 							location.state?.from
-								? "Go back to <a>Account Password</a>"
+								? "auth.forgotPassword.links.accountPassword"
 								: "auth.forgotPassword.links.login"
 						}
 						components={{

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -98,6 +98,7 @@
 		"forgotPassword": {
 			"buttons": {
 				"openEmail": "Open email app",
+				"accountPassword": "Go back to <a>Account Password</a>",
 				"resetPassword": "Reset password"
 			},
 			"heading": "Forgot password?",
@@ -1134,10 +1135,13 @@
 		"currentPassword": "Current password",
 		"enterCurrentPassword": "Enter your current password",
 		"enterNewPassword": "Enter your new password",
+		"forgotPassword": "Forgot password?",
 		"newPassword": "New password",
 		"passwordChangedSuccess": "Your password was changed successfully.",
 		"passwordInputIncorrect": "Your password input was incorrect.",
-		"passwordRequirements": "New password must contain at least 8 characters and must have at least one uppercase letter, one lowercase letter, one number and one special character (!?@#$%^&*()-_=+[]{}|;:'\",./\\~`)."
+		"passwordRequirements": "New password must contain at least 8 characters and must have at least one uppercase letter, one lowercase letter, one number and one special character.",
+		"resetPassword": "Reset password",
+		"sessionExpired": "Your session has expired. Please log in again to change your password."
 	},
 	"pause": "Pause",
 	"PhotoDescriptionText": "This photo will be displayed in your profile page.",


### PR DESCRIPTION
## Describe your changes

As discussed with @ajhollid :
- Temporarily hardcoded the new strings to resolve persistent en.json conflicts during review/merge #3185. 
- Now restoring proper i18n support by extracting those strings back into en.json.

Changes:
- Replaces hardcoded strings in ForgotPassword.jsx, CheckEmail.jsx, and PasswordPanel.jsx with i18n strings.
- Adds the following new keys to `en.json`:
  - "accountPassword": "Go back to <a>Account Password</a>", 
  - "forgotPassword": "Forgot password?"
  - "resetPassword": "Reset password"
  - "sessionExpired": "Your session has expired, please log in again to continue."
  - "passwordRequirements": "New password must contain at least 8 characters and must have at least one uppercase letter, one lowercase letter, one number and one special character."

No functional changes — UI/behavior is identical to the merged version, just now fully translatable.

## Write your issue number after "Fixes "

Fixes #3185 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [X] (Do not skip this or your PR will be closed) I deployed the application locally.
- [X] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [X] I have included the issue # in the PR.
- [X] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [X] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [X] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [X] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [X] My PR is granular and targeted to one specific feature.
- [X] I ran `npm run format` in server and client directories, which automatically formats your code.
- [X] I took a screenshot or a video and attached to this PR if there is a UI change.

