### PR TITLE
fix: restore isMaintenance field in status page API response

### DIFF
--- a/server/src/controllers/statusPageController.ts
+++ b/server/src/controllers/statusPageController.ts
@@ -81,7 +81,7 @@ class StatusPageController {
 			const settings = await this.settingsService.getDBSettings();
 			const showURL = settings.showURL;
 
-			const monitors = await this.monitorsRepository.findByIds(statusPage.monitors);
+			const monitors = await this.monitorsRepository.findByIdsWithChecks(statusPage.monitors);
 			// Sort monitors according to the order in statusPage.monitors
 			const monitorOrder = new Map(statusPage.monitors.map((id, index) => [id, index]));
 			const sortedMonitors = [...monitors].sort((a, b) => {

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -396,6 +396,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			gameId: doc.gameId ?? undefined,
 			group: doc.group ?? null,
 			recentChecks: (doc.recentChecks ?? []).map((check: any) => this.toCheckSnapshot(check)),
+			isMaintenance: doc.isMaintenance ?? undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -47,6 +47,7 @@ export interface Monitor {
 	gameId?: string;
 	group: string | null;
 	recentChecks: CheckSnapshot[];
+	isMaintenance?: boolean;
 	createdAt: string;
 	updatedAt: string;
 }


### PR DESCRIPTION
## Describe your changes

Fixes the regression in v3.3 where `isMaintenance` field was missing from the status page API response (`/api/v1/status-page/:url`).

**Root cause:** The `getStatusPageByUrl` controller method was using `findByIds()` which performs a simple query, instead of `findByIdsWithChecks()` which runs the aggregation pipeline that calculates `isMaintenance` from maintenance windows.

**Changes:**
- Changed `findByIds` to `findByIdsWithChecks` in `statusPageController.ts`
- Added `isMaintenance?: boolean` property to `Monitor` type
- Included `isMaintenance` in `toEntityWithChecks` entity mapping

## Write your issue number after "Fixes "

# Related Issue
Closes #3255 


