### PR TITLE
fix: add missing pluralization strings

### DIFF
--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -603,9 +603,10 @@
 			},
 			"summaryCard": {
 				"activeIncidents": {
-					"active_zero": "No active incidents",
 					"title": "Active Incidents",
-					"active": "active"
+					"active_zero": "No active incidents",
+					"active_one": "{{count}} active incident",
+					"active_other": "{{count}} active incidents"
 				},
 				"incidentStats": {
 					"avgResolutionTime": "Avg Resolution Time",


### PR DESCRIPTION
active_one and active_other pluralization strings were missing from the activeIncidents translation