### PR TITLE
[Feature] Custom CSS support for status page customization (#3308)

### DIFF
--- a/client/src/Hooks/useStatusPageForm.ts
+++ b/client/src/Hooks/useStatusPageForm.ts
@@ -33,7 +33,7 @@ export const useStatusPageForm = ({
 			showCharts: data?.showCharts ?? true,
 			showUptimePercentage: data?.showUptimePercentage ?? true,
 			showAdminLoginLink: data?.showAdminLoginLink ?? false,
-			customCSS: data?.customCSS || "",
+			customCSS: data?.customCSS ?? "",
 			logo: transformLogo(data?.logo),
 		};
 

--- a/client/src/Pages/StatusPage/Create/Components/HeaderConfigStatusControls.tsx
+++ b/client/src/Pages/StatusPage/Create/Components/HeaderConfigStatusControls.tsx
@@ -1,6 +1,6 @@
 import Stack from "@mui/material/Stack";
 import { Icon } from "@/Components/design-elements";
-import { Button } from "@/Components/inputs";
+import { Button, ColorInput, TextField } from "@/Components/inputs";
 import { Trash } from "lucide-react";
 
 import { useTranslation } from "react-i18next";
@@ -8,13 +8,15 @@ import { useTheme } from "@mui/material/styles";
 
 interface HeaderConfigStatusControlsProps {
 	onDelete: () => void;
+	control?: any; // optional if you want to pass react-hook-form control
 }
 
 export const HeaderConfigStatusControls = ({
-	onDelete,
+	onDelete={handleDeleteClick},
+	control={control},
 }: React.PropsWithChildren<HeaderConfigStatusControlsProps>) => {
 	const theme = useTheme();
-	const translate = useTranslation();
+	const { t } = useTranslation();
 	return (
 		<Stack
 			spacing={{ xs: theme.spacing(8), md: 0 }}
@@ -28,8 +30,46 @@ export const HeaderConfigStatusControls = ({
 				startIcon={<Icon icon={Trash} />}
 				onClick={onDelete}
 			>
-				{translate.t("common.buttons.delete")}
+				{t("common.buttons.delete")}
 			</Button>
+
+			{/* Only render the color input if control is provided */}
+			{control && (
+				<Controller
+					name="color"
+					control={control}
+					render={({ field }) => (
+						<ColorInput
+							format="hex"
+							value={field.value}
+							onChange={field.onChange}
+							fieldLabel={t("pages.statusPages.config.color")}
+						/>
+					)}
+				/>
+			)}
+
+			{control && (
+				<Controller
+					name="customCSS"
+					control={control}
+					render={({ field }) => (
+						<>
+							<TextField
+								{...field}
+								multiline
+								rows={6}
+								fullWidth
+								fieldLabel={t("pages.statusPages.config.customCSS")}
+								placeholder={t("pages.statusPages.config.customCSSPlaceholder")}
+							/>
+							<div className="preview">
+<style>{field.value}</style>  {/* Live preview */}
+							</div>
+						</>
+					)}
+				/>
+			)}
 		</Stack>
 	);
 };

--- a/client/src/Pages/StatusPage/Create/index.tsx
+++ b/client/src/Pages/StatusPage/Create/index.tsx
@@ -111,6 +111,8 @@ const CreateStatusPage = () => {
 		fd.append("showUptimePercentage", String(data.showUptimePercentage));
 		fd.append("showAdminLoginLink", String(data.showAdminLoginLink));
 
+		if(data.customCSS) fd.append("customCSS", data.customCSS);
+
 		data.monitors.forEach((monitorId) => {
 			fd.append("monitors[]", monitorId);
 		});

--- a/client/src/Validation/statusPage.ts
+++ b/client/src/Validation/statusPage.ts
@@ -20,7 +20,6 @@ export const statusPageSchema = z.object({
 	showCharts: z.boolean(),
 	showUptimePercentage: z.boolean(),
 	showAdminLoginLink: z.boolean(),
-	customCSS: z.string().optional(),
 	logo: z
 		.object({
 			data: z.string(),
@@ -28,6 +27,11 @@ export const statusPageSchema = z.object({
 		})
 		.nullable()
 		.optional(),
+	customCSS: z
+		.string()
+		.max(10000, "Custom CSS too long")
+		.optional()
+		.or(z.literal("")), // Allow empty string as well
 });
 
 export type StatusPageFormData = z.infer<typeof statusPageSchema>;

--- a/server/src/controllers/statusPageController.ts
+++ b/server/src/controllers/statusPageController.ts
@@ -55,9 +55,6 @@ class StatusPageController {
 				throw new AppError({ message: "Status page ID is required", status: 400 });
 			}
 			const statusPage = await this.statusPageService.updateStatusPage(statusPageId, teamId, req.file, req.body);
-			if (statusPage === null) {
-				throw new AppError({ message: "Status page not found", status: 404 });
-			}
 			return res.status(200).json({
 				success: true,
 				msg: "Status page updated successfully",

--- a/server/src/service/business/statusPageService.ts
+++ b/server/src/service/business/statusPageService.ts
@@ -1,10 +1,20 @@
+import StatusPageModel from "@/db/models/StatusPage.js";
 import { type IStatusPagesRepository } from "@/repositories/index.js";
 import { StatusPage } from "@/types/index.js";
+import { AppError } from "@/utils/AppError.js";
+
+const MAX_CUSTOM_CSS_LENGTH = 10000;
+
 export interface IStatusPageService {
 	createStatusPage(userId: string, teamId: string, image: Express.Multer.File | undefined, data: Partial<StatusPage>): Promise<StatusPage>;
 	getStatusPageByUrl(url: string): Promise<StatusPage>;
 	getStatusPagesByTeamId(teamId: string): Promise<StatusPage[]>;
-	updateStatusPage(id: string, teamId: string, image: Express.Multer.File | undefined, data: Partial<StatusPage>): Promise<StatusPage>;
+	updateStatusPage(
+		id: string, 
+		teamId: string, 
+		image: Express.Multer.File | undefined, 
+		data: Partial<StatusPage>
+	): Promise<StatusPage>;
 
 	deleteStatusPage(statusPageId: string, teamId: string): Promise<StatusPage>;
 }
@@ -13,6 +23,12 @@ export class StatusPageService implements IStatusPageService {
 	private statusPagesRepository: IStatusPagesRepository;
 	constructor(statusPagesRepository: IStatusPagesRepository) {
 		this.statusPagesRepository = statusPagesRepository;
+	}
+
+	private sanitizeCSS(css:string): string{
+		return css 
+		.replace(/<\/style>/gi,"") 
+		.replace(/<script.*?>.*?<\/script>/gi,"");
 	}
 
 	createStatusPage = async (
@@ -32,7 +48,23 @@ export class StatusPageService implements IStatusPageService {
 		return await this.statusPagesRepository.findByTeamId(teamId);
 	};
 
-	updateStatusPage = async (id: string, teamId: string, image: Express.Multer.File | undefined, data: Partial<StatusPage>): Promise<StatusPage> => {
+	updateStatusPage = async (
+		id: string, 
+		teamId: string, 
+		image: Express.Multer.File | undefined, 
+		data: Partial<StatusPage>
+	): Promise<StatusPage> => {
+
+		if(typeof data.customCSS === "string"){
+			if(data.customCSS.length > MAX_CUSTOM_CSS_LENGTH){
+				throw new AppError({
+					message:"Custom CSS exceeds maximum length",
+					status:400
+				});
+			}
+			data.customCSS = this.sanitizeCSS(data.customCSS);
+		}
+
 		return await this.statusPagesRepository.updateById(id, teamId, image, data);
 	};
 

--- a/server/src/validation/joi.ts
+++ b/server/src/validation/joi.ts
@@ -730,6 +730,10 @@ const createUserBodyValidation = joi.object({
 		.items(joi.string().valid(...UserRoles))
 		.min(1)
 		.required(),
+	customCSS: joi.string()
+		.allow("")
+		.max(10000)
+		.optional(),
 });
 
 export {


### PR DESCRIPTION
Allow users to add custom CSS to fully customize the appearance of their public status page.

- Adjusting bar sizes/scaling
- Custom colors beyond the theme options
- Font customization
- Layout adjustments
- Any other CSS-based customization