### PR TITLE
fix: removing GET /monitors from swagger docs

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -432,46 +432,6 @@
 			}
 		},
 		"/monitors": {
-			"get": {
-				"tags": ["monitors"],
-				"summary": "Get all monitors",
-				"description": "Retrieve all monitors for the authenticated user",
-				"responses": {
-					"200": {
-						"description": "Monitors retrieved successfully",
-						"content": {
-							"application/json": {
-								"schema": {
-									"allOf": [
-										{
-											"$ref": "#/components/schemas/SuccessResponse"
-										},
-										{
-											"type": "object",
-											"properties": {
-												"data": {
-													"type": "array",
-													"items": {
-														"$ref": "#/components/schemas/Monitor"
-													}
-												}
-											}
-										}
-									]
-								}
-							}
-						}
-					},
-					"500": {
-						"$ref": "#/components/responses/InternalServerError"
-					}
-				},
-				"security": [
-					{
-						"bearerAuth": []
-					}
-				]
-			},
 			"post": {
 				"tags": ["monitors"],
 				"summary": "Create monitor",


### PR DESCRIPTION
Removing swagger docs for GET /monitor as it is not a valid endpoint anymore.
the actual "get monitors" endpoints used are GET /monitors/team and GET /monitors/team/with-checks

Fixes #3340 

<img width="1911" height="979" alt="image" src="https://github.com/user-attachments/assets/36482627-c5da-490b-8aa8-cc91c5e33cc0" />


## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

