### PR TITLE
fix: dynamically set Swagger UI server URL from request

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -75,7 +75,7 @@ export const createApp = ({
 		})
 	);
 	// Swagger UI — dynamically set server URL from request
-	app.use("/api-docs", swaggerUi.serve, (req, res, next) => {
+	app.use("/api-docs", swaggerUi.serve, (req: express.Request, res: express.Response, next: express.NextFunction) => {
 		const protocol = req.protocol;
 		const host = req.get("host");
 		const dynamicSpec = {

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -74,8 +74,22 @@ export const createApp = ({
 			},
 		})
 	);
-	// Swagger UI
-	app.use("/api-docs", swaggerUi.serve, swaggerUi.setup(openApiSpec));
+	// Swagger UI — dynamically set server URL from request
+	app.use("/api-docs", swaggerUi.serve, (req, res, next) => {
+		const protocol = req.protocol;
+		const host = req.get("host");
+		const dynamicSpec = {
+			...openApiSpec,
+			servers: [
+				{
+					url: `${protocol}://${host}/api/v1`,
+					description: "Current Server",
+				},
+				...openApiSpec.servers,
+			],
+		};
+		swaggerUi.setup(dynamicSpec)(req, res, next);
+	});
 
 	app.use("/api/v1/health", (req, res) => {
 		res.json({


### PR DESCRIPTION
## Summary
- Swagger UI now prepends the current server URL (derived from request protocol and host) to the servers list
- This makes Swagger work correctly in Docker and remote environments instead of always pointing to localhost

## Closes
Fixes #3339

## Test plan
- [ ] Access `/api-docs` locally and verify "Current Server" points to `http://localhost:52345/api/v1`
- [ ] Access `/api-docs` from a remote host and verify it shows the correct remote URL
- [ ] Verify original localhost and demo servers still appear in the dropdown