### PR TITLE
fix: prevent advanced matching checkbox from resetting on form changes

### DIFF
--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
@@ -188,9 +188,13 @@ const CreateMonitorPage = () => {
 	});
 	const { control, watch, handleSubmit, clearErrors } = form;
 
+	const hasInitialized = useRef(false);
 	useEffect(() => {
-		form.reset(defaults);
-	}, [defaults, form]);
+		if (!hasInitialized.current && existingMonitor) {
+			form.reset(defaults);
+			hasInitialized.current = true;
+		}
+	}, [defaults, form, existingMonitor]);
 
 	const watchedType = watch("type") as MonitorType;
 


### PR DESCRIPTION
## Summary
- Added `useRef` guard to prevent `form.reset()` from overwriting the advanced matching checkbox after initial load
- The checkbox no longer unchecks when typing in the expected value field

## Closes
Fixes #3093

## Test plan
- [ ] Create a new HTTP monitor, enable "Advanced matching", type in the expected value field — checkbox should stay checked
- [ ] Edit an existing monitor with advanced matching enabled — checkbox should remain checked on page load
- [ ] Save and reload — verify checkbox state persists correctly