### PR TITLE
Fix infrastructure threshold defaults via migration (#3327)

### DIFF
--- a/server/src/db/migration/0004_fixInfrastructureThresholds.ts
+++ b/server/src/db/migration/0004_fixInfrastructureThresholds.ts
@@ -1,0 +1,65 @@
+import { MonitorModel } from "../models/Monitor.js";
+import { logger } from "@/utils/logger.js";
+
+/**
+ * Fix infrastructure monitors that had thresholds incorrectly set to 5
+ * due to the old default value. Updates them to 100 (disabled).
+ */
+export async function fixInfrastructureThresholds(): Promise<void> {
+	const SERVICE_NAME = "Migration:FixInfrastructureThresholds";
+
+	try {
+		logger.info({ service: SERVICE_NAME, message: "Starting infrastructure threshold fix" });
+
+		const thresholdFields = [
+			"cpuAlertThreshold",
+			"memoryAlertThreshold",
+			"diskAlertThreshold",
+			"tempAlertThreshold",
+		];
+
+		// Find hardware monitors with any threshold set to 5
+		const filter = {
+			type: "hardware",
+			$or: thresholdFields.map((field) => ({ [field]: 5 })),
+		};
+
+		const monitors = await MonitorModel.find(filter);
+
+		if (monitors.length === 0) {
+			logger.info({ service: SERVICE_NAME, message: "No monitors with threshold value of 5 found" });
+			return;
+		}
+
+		logger.info({
+			service: SERVICE_NAME,
+			message: `Found ${monitors.length} monitors with threshold value of 5`,
+		});
+
+		let updatedCount = 0;
+
+		for (const monitor of monitors) {
+			const update: Record<string, number> = {};
+
+			for (const field of thresholdFields) {
+				if ((monitor as any)[field] === 5) {
+					update[field] = 100;
+				}
+			}
+
+			if (Object.keys(update).length > 0) {
+				await MonitorModel.updateOne({ _id: monitor._id }, { $set: update });
+				updatedCount++;
+			}
+		}
+
+		logger.info({
+			service: SERVICE_NAME,
+			message: `Fixed ${updatedCount} monitors — thresholds updated from 5 to 100`,
+		});
+	} catch (error) {
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		logger.error({ service: SERVICE_NAME, message: `Error fixing thresholds: ${errorMessage}` });
+		throw error;
+	}
+}

--- a/server/src/db/migration/0004_fixInfrastructureThresholds.ts
+++ b/server/src/db/migration/0004_fixInfrastructureThresholds.ts
@@ -2,7 +2,7 @@ import { MonitorModel } from "../models/Monitor.js";
 import { logger } from "@/utils/logger.js";
 
 /**
- * Fix infrastructure monitors that had thresholds incorrectly set to 5
+ * Fix infrastructure monitors that had thresholds incorrectly set to 0 or 5
  * due to the old default value. Updates them to 100 (disabled).
  */
 export async function fixInfrastructureThresholds(): Promise<void> {
@@ -11,29 +11,24 @@ export async function fixInfrastructureThresholds(): Promise<void> {
 	try {
 		logger.info({ service: SERVICE_NAME, message: "Starting infrastructure threshold fix" });
 
-		const thresholdFields = [
-			"cpuAlertThreshold",
-			"memoryAlertThreshold",
-			"diskAlertThreshold",
-			"tempAlertThreshold",
-		];
+		const thresholdFields = ["cpuAlertThreshold", "memoryAlertThreshold", "diskAlertThreshold", "tempAlertThreshold"];
 
-		// Find hardware monitors with any threshold set to 5
+		// Find hardware monitors with any threshold set to 0 or 5
 		const filter = {
 			type: "hardware",
-			$or: thresholdFields.map((field) => ({ [field]: 5 })),
+			$or: thresholdFields.flatMap((field) => [{ [field]: 0 }, { [field]: 5 }]),
 		};
 
 		const monitors = await MonitorModel.find(filter);
 
 		if (monitors.length === 0) {
-			logger.info({ service: SERVICE_NAME, message: "No monitors with threshold value of 5 found" });
+			logger.info({ service: SERVICE_NAME, message: "No monitors with threshold value of 0 or 5 found" });
 			return;
 		}
 
 		logger.info({
 			service: SERVICE_NAME,
-			message: `Found ${monitors.length} monitors with threshold value of 5`,
+			message: `Found ${monitors.length} monitors with threshold value of 0 or 5`,
 		});
 
 		let updatedCount = 0;
@@ -42,7 +37,7 @@ export async function fixInfrastructureThresholds(): Promise<void> {
 			const update: Record<string, number> = {};
 
 			for (const field of thresholdFields) {
-				if ((monitor as any)[field] === 5) {
+				if ((monitor as any)[field] === 0 || (monitor as any)[field] === 5) {
 					update[field] = 100;
 				}
 			}
@@ -55,7 +50,7 @@ export async function fixInfrastructureThresholds(): Promise<void> {
 
 		logger.info({
 			service: SERVICE_NAME,
-			message: `Fixed ${updatedCount} monitors — thresholds updated from 5 to 100`,
+			message: `Fixed ${updatedCount} monitors — thresholds updated from 0/5 to 100`,
 		});
 	} catch (error) {
 		const errorMessage = error instanceof Error ? error.message : String(error);

--- a/server/src/db/migration/index.ts
+++ b/server/src/db/migration/index.ts
@@ -1,6 +1,7 @@
 import { migrateStatusWindowThreshold } from "./0001_migrateStatusWindowThreshold.js";
 import { convertChecksToTimeSeries } from "./0002_convertChecksToTimeSeries.js";
 import { cleanupDuplicateMonitorStats } from "./0003_cleanupDuplicateMonitorStats.js";
+import { fixInfrastructureThresholds } from "./0004_fixInfrastructureThresholds.js";
 import MigrationModel from "../models/Migration.js";
 
 type MigrationEntry = {
@@ -12,6 +13,7 @@ const migrations: MigrationEntry[] = [
 	{ name: "0001_migrateStatusWindowThreshold", execute: migrateStatusWindowThreshold },
 	{ name: "0002_convertChecksToTimeSeries", execute: convertChecksToTimeSeries },
 	{ name: "0003_cleanupDuplicateMonitorStats", execute: cleanupDuplicateMonitorStats },
+	{ name: "0004_fixInfrastructureThresholds", execute: fixInfrastructureThresholds },
 ];
 
 const runMigrations = async (logger?: { info: Function; error: Function }) => {


### PR DESCRIPTION
## Summary
- Adds migration `0004_fixInfrastructureThresholds` that corrects hardware monitors with threshold values of 5 (old default from counter fields) to 100 (disabled)
- Fixes #3327 where infrastructure monitors had incorrect alert thresholds due to schema defaults being applied from counter fields

## Changes
- New migration file: `server/src/db/migration/0004_fixInfrastructureThresholds.ts`
- Registered migration in `server/src/db/migration/index.ts`

## Test plan
- [ ] Verify migration runs on startup without errors
- [ ] Confirm hardware monitors with threshold=5 get updated to 100
- [ ] Verify monitors with correct thresholds are not modified