### PR TITLE
Fix IPv6 address handling in ping monitor (#3053)

### DIFF
--- a/server/src/service/infrastructure/networkService.ts
+++ b/server/src/service/infrastructure/networkService.ts
@@ -261,7 +261,8 @@ class NetworkService implements INetworkService {
 			const sanitizedHost = rawUrl
 				.replace(/^https?:\/\//, "")
 				.replace(/\/.*$/, "")
-				.replace(/:.*/, "");
+				.replace(/^\[(.+)\](?::.*)?$/, "$1") // Extract IPv6 from brackets, strip port
+				.replace(/^([^[\]:]+):(\d+)$/, "$1"); // Strip port from IPv4/hostname only
 			const { response, error } = await this.timeRequest(() => this.ping.promise.probe(sanitizedHost));
 
 			if (!response) {


### PR DESCRIPTION
## Summary
- Fixes ping monitor failing for IPv6 addresses by updating the host sanitization regex
- The old regex `.replace(/:.*/, "")` was stripping everything after the first colon, destroying IPv6 addresses
- Fixes #3053

## Changes
- Updated `server/src/service/infrastructure/networkService.ts` to properly handle IPv6 addresses in brackets (e.g., `[::1]`) and avoid stripping colons from IPv6 notation

## Test plan
- [ ] Verify ping works for IPv4 addresses
- [ ] Verify ping works for IPv6 addresses like `::1` or `2001:db8::1`
- [ ] Verify URLs with ports still have ports stripped correctly