### PR TITLE
Fix dark mode background to use neutral gray

### DIFF
--- a/client/src/Components/layout/AppLayout.tsx
+++ b/client/src/Components/layout/AppLayout.tsx
@@ -1,9 +1,6 @@
 import Box from "@mui/material/Box";
 import { useState, useEffect, useRef } from "react";
 import { useTheme } from "@mui/material/styles";
-import { useSelector } from "react-redux";
-import BackgroundSVG from "@/assets/Images/background.svg";
-import type { RootState } from "@/Types/state";
 import { OfflineBanner } from "@/Components/design-elements";
 import { setServerUnreachableCallback, get } from "@/Utils/ApiClient";
 
@@ -13,7 +10,6 @@ interface AppLayoutProps {
 
 const AppLayout = ({ children }: AppLayoutProps) => {
 	const theme = useTheme();
-	const mode = useSelector((state: RootState) => state.ui.mode);
 	const [serverUnreachable, setServerUnreachable] = useState(false);
 	const retryIntervalRef = useRef<number | null>(null);
 

--- a/client/src/Components/layout/AppLayout.tsx
+++ b/client/src/Components/layout/AppLayout.tsx
@@ -47,10 +47,6 @@ const AppLayout = ({ children }: AppLayoutProps) => {
 			sx={{
 				minHeight: "100vh",
 				backgroundColor: theme.palette.background.default,
-				backgroundImage: mode === "dark" ? `url("${BackgroundSVG}")` : "none",
-				backgroundSize: "100% 100%",
-				backgroundPosition: "center",
-				backgroundRepeat: "no-repeat",
 			}}
 		>
 			<OfflineBanner visible={serverUnreachable} />

--- a/client/src/Utils/Theme/Palette.ts
+++ b/client/src/Utils/Theme/Palette.ts
@@ -31,4 +31,8 @@ export const darkPalette = {
 	secondary: {
 		main: colors.gray700,
 	},
+	background: {
+		default: "#151518",
+		paper: "#1c1c21",
+	},
 };

--- a/client/src/Utils/Theme/Palette.ts
+++ b/client/src/Utils/Theme/Palette.ts
@@ -12,6 +12,8 @@ export const typographyLevels = {
 export const colors = {
 	gray200: "#EFEFEF",
 	gray700: "#313131",
+	gray900: "#151518",
+	gray850: "#1c1c21",
 	blueBlueWave: "#1570EF",
 };
 
@@ -32,7 +34,7 @@ export const darkPalette = {
 		main: colors.gray700,
 	},
 	background: {
-		default: "#151518",
-		paper: "#1c1c21",
+		default: colors.gray900,
+		paper: colors.gray850,
 	},
 };


### PR DESCRIPTION
## Summary
- Replace blue-tinted dark mode background with clean neutral grays
- Remove decorative blue/purple SVG blob overlay

## Changes
- `Palette.ts`: Added explicit `background.default` (#151518) and `background.paper` (#1c1c21) to dark palette
- `AppLayout.tsx`: Removed SVG background image overlay in dark mode

## Test plan
- [ ] Toggle dark mode and verify background is neutral gray without blue tint
- [ ] Verify cards/papers have slightly lighter gray background
- [ ] Verify light mode is unaffected