### PR TITLE
Fix: restore PORT env var

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,9 +50,8 @@ const startApp = async () => {
 		openApiSpec,
 	});
 
-	const port = 52345;
-	const server = app.listen(port, () => {
-		logger.info({ message: `Server started on port:${port}` });
+	const server = app.listen(env.PORT, () => {
+		logger.info({ message: `Server started on port:${env.PORT}` });
 	});
 
 	initShutdownListener(server, services);

--- a/server/src/validation/envValidation.ts
+++ b/server/src/validation/envValidation.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 const envSchema = z.object({
 	// Server Configuration
+	PORT: z.string().default("52345"),
 	NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
 	LOG_LEVEL: z.enum(["error", "warn", "info", "debug"]).default("debug"),
 


### PR DESCRIPTION
A regression occured whereby the PORT env var was removed.  This PR restores that functionality

- Add a PORT env var and validation to allow for custom server ports to be set.