### PR TITLE
fix: set DNS cache TTL to prevent stale lookups

### DIFF
--- a/server/src/service/infrastructure/network/HttpProvider.ts
+++ b/server/src/service/infrastructure/network/HttpProvider.ts
@@ -15,7 +15,7 @@ export class HttpProvider implements IStatusProvider<HttpStatusPayload> {
 		private got: Got,
 		private advancedMatcher: AdvancedMatcher
 	) {
-		const cacheable = new CacheableLookup();
+		const cacheable = new CacheableLookup({ maxTtl: 300, errorTtl: 30 });
 		this.got = got.extend({
 			dnsCache: cacheable,
 			timeout: {


### PR DESCRIPTION
## Summary
- Set `maxTtl: 300` (5 min) and `errorTtl: 30` (30s) on `CacheableLookup` in `HttpProvider`
- Fixes DNS lookups being cached forever (`maxTtl: Infinity` default), causing HTTP monitors to fail permanently after DNS changes or resolver outages

## Problem
`CacheableLookup` with default options caches successful DNS lookups indefinitely. If a resolver goes down temporarily (returning ENOTFOUND) or a monitored server's IP changes, all HTTP checks continue to fail until the Checkmate process is restarted.

## Fix
- Successful lookups now expire after 5 minutes, picking up DNS changes automatically
- Failed lookups expire after 30 seconds, allowing quick recovery after resolver outages

## Test plan
- [ ] Verify HTTP monitors continue to resolve correctly
- [ ] Confirm that after a simulated DNS failure, monitors recover within 30 seconds without process restart