### PR TITLE
fix: empty email body due to TSC ignoring .mjml templates

### DIFF
--- a/docker/dist-mono/server.Dockerfile
+++ b/docker/dist-mono/server.Dockerfile
@@ -24,6 +24,8 @@ RUN npm install
 
 RUN npm run build
 
+RUN cp -r ./src/templates ./dist/templates
+
 COPY --from=frontend-build /app/client/dist ./public
 
 RUN chmod +x ./scripts/inject-vars.sh

--- a/docker/dist-mono/server.Dockerfile
+++ b/docker/dist-mono/server.Dockerfile
@@ -24,8 +24,6 @@ RUN npm install
 
 RUN npm run build
 
-RUN cp -r ./src/templates ./dist/templates
-
 COPY --from=frontend-build /app/client/dist ./public
 
 RUN chmod +x ./scripts/inject-vars.sh

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
 		"test": "NODE_OPTIONS=--experimental-vm-modules c8 jest --runInBand",
 		"dev": "nodemon --exec tsx src/index.js",
 		"start": "node --watch ./dist/index.js",
-		"build": "tsc && tsc-alias",
+		"build": "tsc && tsc-alias && cp -r src/templates dist/templates",
 		"lint": "eslint .",
 		"lint-fix": "eslint --fix .",
 		"format": "prettier --write .",


### PR DESCRIPTION

Typescript compiler seems to ignore .mjml templates resulting in empty Email body. Hence adding a manual step to copy the same to the proper directory.

Fixes #3359

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

