### PR TITLE
fix: modify heatmap response time conditional text

### DIFF
--- a/client/src/Components/common/charts/HeatmapResponseTimeTooltip.tsx
+++ b/client/src/Components/common/charts/HeatmapResponseTimeTooltip.tsx
@@ -58,7 +58,7 @@ export const HeatmapResponseTimeTooltip = ({
 					</Typography>
 					<Typography>
 						{t("common.labels.responseTime")}:{" "}
-						{check?.originalResponseTime?.toFixed() ?? "-"} ms
+						{check?.originalResponseTime?.toFixed() ?? "N/A"} ms
 					</Typography>
 					<Typography textTransform={"capitalize"}>
 						Status:{" "}

--- a/client/src/Components/common/charts/HeatmapResponseTimeTooltip.tsx
+++ b/client/src/Components/common/charts/HeatmapResponseTimeTooltip.tsx
@@ -57,7 +57,8 @@ export const HeatmapResponseTimeTooltip = ({
 						{formatDateWithTz(check?.createdAt, "ddd, MMMM D, YYYY, HH:mm A", uiTimezone)}
 					</Typography>
 					<Typography>
-						{t("common.labels.responseTime")}: {check.originalResponseTime.toFixed()} ms
+						{t("common.labels.responseTime")}:{" "}
+						{check?.originalResponseTime?.toFixed() ?? "-"} ms
 					</Typography>
 					<Typography textTransform={"capitalize"}>
 						Status:{" "}

--- a/server/src/utils/dataUtils.ts
+++ b/server/src/utils/dataUtils.ts
@@ -45,7 +45,7 @@ export const NormalizeData = <T extends HasResponseTime>(checks: T[], rangeMin: 
 		const min = calculatePercentile(checks, 0);
 		const max = calculatePercentile(checks, 95);
 		const normalizedChecks = checks.map((check) => {
-			const originalResponseTime = check.responseTime;
+			const originalResponseTime = typeof check.responseTime === "number" ? check.responseTime : 0;
 			let normalizedResponseTime = rangeMin + ((check.responseTime - min) * (rangeMax - rangeMin)) / (max - min);
 
 			normalizedResponseTime = Math.max(rangeMin, Math.min(rangeMax, normalizedResponseTime));
@@ -59,7 +59,8 @@ export const NormalizeData = <T extends HasResponseTime>(checks: T[], rangeMin: 
 		return normalizedChecks;
 	} else {
 		return checks.map((check) => {
-			return { ...check, originalResponseTime: check.responseTime };
+			const originalResponseTime = typeof check.responseTime === "number" ? check.responseTime : 0;
+			return { ...check, originalResponseTime: originalResponseTime };
 		});
 	}
 };


### PR DESCRIPTION
PR raised to fix originalResponseTime.toFixed() is not a function by modifying response time display into conditional text.

<img width="1449" height="666" alt="image" src="https://github.com/user-attachments/assets/8574f2b9-5dfa-46ee-a33a-928be759baa5" />

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

