### PR TITLE
Ability to BYOK for GlobalPing integration

### DIFF
--- a/client/src/Hooks/useSettingsForm.ts
+++ b/client/src/Hooks/useSettingsForm.ts
@@ -41,6 +41,7 @@ export const useSettingsForm = ({ data = null }: UseSettingsFormOptions = {}) =>
 			},
 			checkTTL: data?.checkTTL ?? 30,
 			pagespeedApiKey: "",
+			globalpingApiKey: "",
 			systemEmailPassword: "",
 		};
 

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -311,7 +311,9 @@ export const SettingsPage = () => {
 	};
 
 	const credentialStateLabel = globalpingStatus
-		? t(`pages.settings.form.globalping.option.status.credentialStates.${globalpingStatus.credentialState}`)
+		? t(
+				`pages.settings.form.globalping.option.status.credentialStates.${globalpingStatus.credentialState}`
+			)
 		: t("common.labels.na");
 	const globalpingStatusMessage = !globalpingStatus
 		? t("pages.settings.form.globalping.option.status.messages.unavailable")
@@ -452,8 +454,7 @@ export const SettingsPage = () => {
 						subtitle={t("pages.settings.form.globalping.description")}
 						rightContent={
 							<Stack gap={theme.spacing(LAYOUT.MD)}>
-								{(isGlobalpingKeySet === false ||
-									globalpingKeyHasBeenReset === true) && (
+								{(isGlobalpingKeySet === false || globalpingKeyHasBeenReset === true) && (
 									<Controller
 										name="globalpingApiKey"
 										control={form.control}
@@ -475,23 +476,20 @@ export const SettingsPage = () => {
 									/>
 								)}
 
-								{isGlobalpingKeySet === true &&
-									globalpingKeyHasBeenReset === false && (
-										<Box>
-											<FieldLabel>
-												{t(
-													"pages.settings.form.globalping.option.apiKey.labelSet"
-												)}
-											</FieldLabel>
-											<Button
-												onClick={handleResetGlobalpingKey}
-												variant="contained"
-												color="error"
-											>
-												{t("common.buttons.reset")}
-											</Button>
-										</Box>
-									)}
+								{isGlobalpingKeySet === true && globalpingKeyHasBeenReset === false && (
+									<Box>
+										<FieldLabel>
+											{t("pages.settings.form.globalping.option.apiKey.labelSet")}
+										</FieldLabel>
+										<Button
+											onClick={handleResetGlobalpingKey}
+											variant="contained"
+											color="error"
+										>
+											{t("common.buttons.reset")}
+										</Button>
+									</Box>
+								)}
 								<Alert
 									severity={
 										globalpingStatus?.credentialState === "valid"
@@ -515,15 +513,14 @@ export const SettingsPage = () => {
 									}
 								>
 									<Stack gap={theme.spacing(1)}>
-										<Typography variant="body2">
-											{globalpingStatusMessage}
-										</Typography>
+										<Typography variant="body2">{globalpingStatusMessage}</Typography>
 										<Typography variant="caption">
 											{t("pages.settings.form.globalping.option.status.summary", {
 												credentialState: credentialStateLabel,
 												remainingCredits:
 													globalpingStatus?.remainingCredits ?? t("common.labels.na"),
-												remainingLimit: globalpingStatus?.remainingLimit ?? t("common.labels.na"),
+												remainingLimit:
+													globalpingStatus?.remainingLimit ?? t("common.labels.na"),
 											})}
 										</Typography>
 									</Stack>

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -47,6 +47,7 @@ interface Timezone {
 interface SettingsResponse {
 	settings: any;
 	pagespeedKeySet: boolean;
+	globalpingKeySet: boolean;
 	emailPasswordSet: boolean;
 }
 
@@ -73,6 +74,10 @@ export const SettingsPage = () => {
 		fetchedSettings?.pagespeedKeySet ?? false
 	);
 	const [apiKeyHasBeenReset, setApiKeyHasBeenReset] = useState(false);
+	const [isGlobalpingKeySet, setIsGlobalpingKeySet] = useState(
+		fetchedSettings?.globalpingKeySet ?? false
+	);
+	const [globalpingKeyHasBeenReset, setGlobalpingKeyHasBeenReset] = useState(false);
 	// Local state for email password reset
 	const [isEmailPasswordSet, setIsEmailPasswordSet] = useState(
 		fetchedSettings?.emailPasswordSet ?? false
@@ -104,6 +109,7 @@ export const SettingsPage = () => {
 	useEffect(() => {
 		if (fetchedSettings) {
 			setIsApiKeySet(fetchedSettings.pagespeedKeySet);
+			setIsGlobalpingKeySet(fetchedSettings.globalpingKeySet);
 			setIsEmailPasswordSet(fetchedSettings.emailPasswordSet);
 		}
 	}, [fetchedSettings]);
@@ -146,6 +152,11 @@ export const SettingsPage = () => {
 	const handleResetApiKey = () => {
 		form.setValue("pagespeedApiKey", "");
 		setApiKeyHasBeenReset(true);
+	};
+
+	const handleResetGlobalpingKey = () => {
+		form.setValue("globalpingApiKey", "");
+		setGlobalpingKeyHasBeenReset(true);
 	};
 
 	const handleResetEmailPassword = () => {
@@ -252,6 +263,9 @@ export const SettingsPage = () => {
 		if (isApiKeySet && !apiKeyHasBeenReset) {
 			delete (dataToSend as any).pagespeedApiKey;
 		}
+		if (isGlobalpingKeySet && !globalpingKeyHasBeenReset) {
+			delete (dataToSend as any).globalpingApiKey;
+		}
 		if (isEmailPasswordSet && !emailPasswordHasBeenReset) {
 			delete (dataToSend as any).systemEmailPassword;
 		}
@@ -284,6 +298,8 @@ export const SettingsPage = () => {
 			if (result.data) {
 				setIsApiKeySet(result.data.pagespeedKeySet);
 				setApiKeyHasBeenReset(false);
+				setIsGlobalpingKeySet(result.data.globalpingKeySet);
+				setGlobalpingKeyHasBeenReset(false);
 				setIsEmailPasswordSet(result.data.emailPasswordSet);
 				setEmailPasswordHasBeenReset(false);
 			}
@@ -409,6 +425,56 @@ export const SettingsPage = () => {
 										</Button>
 									</Box>
 								)}
+							</>
+						}
+					/>
+				)}
+				{isAdmin && (
+					<ConfigBox
+						title={t("pages.settings.form.globalping.title")}
+						subtitle={t("pages.settings.form.globalping.description")}
+						rightContent={
+							<>
+								{(isGlobalpingKeySet === false ||
+									globalpingKeyHasBeenReset === true) && (
+									<Controller
+										name="globalpingApiKey"
+										control={form.control}
+										defaultValue={defaults.globalpingApiKey}
+										render={({ field, fieldState }) => (
+											<TextField
+												{...field}
+												fieldLabel={t(
+													"pages.settings.form.globalping.option.apiKey.label"
+												)}
+												type="password"
+												placeholder={t(
+													"pages.settings.form.globalping.option.apiKey.placeholder"
+												)}
+												error={!!fieldState.error}
+												helperText={fieldState.error?.message}
+											/>
+										)}
+									/>
+								)}
+
+								{isGlobalpingKeySet === true &&
+									globalpingKeyHasBeenReset === false && (
+										<Box>
+											<FieldLabel>
+												{t(
+													"pages.settings.form.globalping.option.apiKey.labelSet"
+												)}
+											</FieldLabel>
+											<Button
+												onClick={handleResetGlobalpingKey}
+												variant="contained"
+												color="error"
+											>
+												{t("common.buttons.reset")}
+											</Button>
+										</Box>
+									)}
 							</>
 						}
 					/>

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -26,7 +26,7 @@ import { Controller } from "react-hook-form";
 import { TextField, Button, FieldLabel, SliderWithLabel } from "@/Components/inputs";
 import { Box, Typography } from "@mui/material";
 import { useDelete } from "@/Hooks/UseApi";
-import type { AppSettingsResponse, GlobalpingStatus } from "@/Types/Settings";
+import type { GlobalpingStatus } from "@/Types/Settings";
 
 import {
 	setTimezone,
@@ -45,6 +45,13 @@ interface Timezone {
 	name: string;
 }
 
+interface SettingsResponse {
+	settings: any;
+	pagespeedKeySet: boolean;
+	globalpingKeySet: boolean;
+	emailPasswordSet: boolean;
+}
+
 export const SettingsPage = () => {
 	const theme = useTheme();
 	const { t, i18n } = useTranslation();
@@ -59,14 +66,14 @@ export const SettingsPage = () => {
 	const { post: importMonitors, loading: isImportingMonitors } = usePost();
 
 	// Fetch settings data from API
-	const { data: fetchedSettings } = useGet<AppSettingsResponse>("/settings");
+	const { data: fetchedSettings } = useGet<SettingsResponse>("/settings");
 	const {
 		data: globalpingStatus,
 		isLoading: isGlobalpingStatusLoading,
 		refetch: refetchGlobalpingStatus,
 	} = useGet<GlobalpingStatus>(isAdmin ? "/settings/globalping-status" : null);
 	// Form submission
-	const { patch, loading: isSaving } = usePatch<SettingsFormData, AppSettingsResponse>();
+	const { patch, loading: isSaving } = usePatch<SettingsFormData, SettingsResponse>();
 
 	// Local state for API key reset
 	const [isApiKeySet, setIsApiKeySet] = useState(

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -26,6 +26,7 @@ import { Controller } from "react-hook-form";
 import { TextField, Button, FieldLabel, SliderWithLabel } from "@/Components/inputs";
 import { Box, Typography } from "@mui/material";
 import { useDelete } from "@/Hooks/UseApi";
+import type { AppSettingsResponse, GlobalpingStatus } from "@/Types/Settings";
 
 import {
 	setTimezone,
@@ -44,13 +45,6 @@ interface Timezone {
 	name: string;
 }
 
-interface SettingsResponse {
-	settings: any;
-	pagespeedKeySet: boolean;
-	globalpingKeySet: boolean;
-	emailPasswordSet: boolean;
-}
-
 export const SettingsPage = () => {
 	const theme = useTheme();
 	const { t, i18n } = useTranslation();
@@ -65,9 +59,14 @@ export const SettingsPage = () => {
 	const { post: importMonitors, loading: isImportingMonitors } = usePost();
 
 	// Fetch settings data from API
-	const { data: fetchedSettings } = useGet<SettingsResponse>("/settings");
+	const { data: fetchedSettings } = useGet<AppSettingsResponse>("/settings");
+	const {
+		data: globalpingStatus,
+		isLoading: isGlobalpingStatusLoading,
+		refetch: refetchGlobalpingStatus,
+	} = useGet<GlobalpingStatus>(isAdmin ? "/settings/globalping-status" : null);
 	// Form submission
-	const { patch, loading: isSaving } = usePatch<SettingsFormData, SettingsResponse>();
+	const { patch, loading: isSaving } = usePatch<SettingsFormData, AppSettingsResponse>();
 
 	// Local state for API key reset
 	const [isApiKeySet, setIsApiKeySet] = useState(
@@ -303,12 +302,30 @@ export const SettingsPage = () => {
 				setIsEmailPasswordSet(result.data.emailPasswordSet);
 				setEmailPasswordHasBeenReset(false);
 			}
+			void refetchGlobalpingStatus();
 		}
 	};
 
 	const onError = (errors: unknown) => {
 		logger.debug("Form validation errors", errors);
 	};
+
+	const credentialStateLabel = globalpingStatus
+		? t(`pages.settings.form.globalping.option.status.credentialStates.${globalpingStatus.credentialState}`)
+		: t("common.labels.na");
+	const globalpingStatusMessage = !globalpingStatus
+		? t("pages.settings.form.globalping.option.status.messages.unavailable")
+		: globalpingStatus.credentialState === "missing"
+			? t("pages.settings.form.globalping.option.status.messages.missing")
+			: globalpingStatus.credentialState === "invalid"
+				? t("pages.settings.form.globalping.option.status.messages.invalid")
+				: globalpingStatus.credentialState === "forbidden"
+					? t("pages.settings.form.globalping.option.status.messages.forbidden")
+					: globalpingStatus.credentialState === "upstream_unavailable"
+						? t("pages.settings.form.globalping.option.status.messages.unavailable")
+						: globalpingStatus.creditState === "exhausted"
+							? t("pages.settings.form.globalping.option.status.messages.exhausted")
+							: t("pages.settings.form.globalping.option.status.messages.valid");
 
 	const languages = Object.keys(i18n.options.resources || {});
 
@@ -434,7 +451,7 @@ export const SettingsPage = () => {
 						title={t("pages.settings.form.globalping.title")}
 						subtitle={t("pages.settings.form.globalping.description")}
 						rightContent={
-							<>
+							<Stack gap={theme.spacing(LAYOUT.MD)}>
 								{(isGlobalpingKeySet === false ||
 									globalpingKeyHasBeenReset === true) && (
 									<Controller
@@ -475,7 +492,43 @@ export const SettingsPage = () => {
 											</Button>
 										</Box>
 									)}
-							</>
+								<Alert
+									severity={
+										globalpingStatus?.credentialState === "valid"
+											? globalpingStatus.creditState === "healthy"
+												? "success"
+												: globalpingStatus.creditState === "exhausted"
+													? "warning"
+													: "info"
+											: globalpingStatus?.credentialState === "missing"
+												? "info"
+												: "error"
+									}
+									action={
+										<Button
+											size="small"
+											onClick={() => void refetchGlobalpingStatus()}
+											disabled={isGlobalpingStatusLoading}
+										>
+											{t("pages.settings.form.globalping.option.status.refresh")}
+										</Button>
+									}
+								>
+									<Stack gap={theme.spacing(1)}>
+										<Typography variant="body2">
+											{globalpingStatusMessage}
+										</Typography>
+										<Typography variant="caption">
+											{t("pages.settings.form.globalping.option.status.summary", {
+												credentialState: credentialStateLabel,
+												remainingCredits:
+													globalpingStatus?.remainingCredits ?? t("common.labels.na"),
+												remainingLimit: globalpingStatus?.remainingLimit ?? t("common.labels.na"),
+											})}
+										</Typography>
+									</Stack>
+								</Alert>
+							</Stack>
 						}
 					/>
 				)}

--- a/client/src/Types/Settings.ts
+++ b/client/src/Types/Settings.ts
@@ -33,3 +33,11 @@ export interface AppSettingsResponse {
 	emailPasswordSet: boolean;
 	settings: Settings;
 }
+
+export interface GlobalpingStatus {
+	keyConfigured: boolean;
+	credentialState: "missing" | "valid" | "invalid" | "forbidden" | "upstream_unavailable";
+	creditState: "unknown" | "healthy" | "exhausted";
+	remainingCredits?: number | null;
+	remainingLimit?: number | null;
+}

--- a/client/src/Types/Settings.ts
+++ b/client/src/Types/Settings.ts
@@ -35,7 +35,6 @@ export interface AppSettingsResponse {
 }
 
 export interface GlobalpingStatus {
-	keyConfigured: boolean;
 	credentialState: "missing" | "valid" | "invalid" | "forbidden" | "upstream_unavailable";
 	creditState: "unknown" | "healthy" | "exhausted";
 	remainingCredits?: number | null;

--- a/client/src/Types/Settings.ts
+++ b/client/src/Types/Settings.ts
@@ -29,6 +29,7 @@ export interface Settings {
 
 export interface AppSettingsResponse {
 	pagespeedKeySet: boolean;
+	globalpingKeySet: boolean;
 	emailPasswordSet: boolean;
 	settings: Settings;
 }

--- a/client/src/Validation/settings.ts
+++ b/client/src/Validation/settings.ts
@@ -21,6 +21,13 @@ export const settingsSchema = z.object({
 		.string()
 		.transform((val) => (val.trim() === "" ? undefined : val.trim()))
 		.optional(),
+	globalpingApiKey: z
+		.string()
+		.refine((val) => val.trim() === "" || !/\s/.test(val.trim()), {
+			message: "Globalping API key cannot contain spaces",
+		})
+		.transform((val) => (val.trim() === "" ? undefined : val.trim()))
+		.optional(),
 	systemEmailHost: z
 		.string()
 		.regex(/^[a-zA-Z0-9.-]*$/, "Invalid hostname or IP address")

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1170,6 +1170,25 @@
 							"label": "Globalping API key",
 							"labelSet": "API key is set. Click Reset to change it.",
 							"placeholder": "Enter your Globalping API key"
+						},
+						"status": {
+							"refresh": "Refresh",
+							"messages": {
+								"missing": "Globalping credit and limit status is only available for authenticated usage.",
+								"invalid": "The configured Globalping API key was rejected.",
+								"forbidden": "The configured Globalping API key is not allowed to access this resource.",
+								"unavailable": "Globalping status is currently unavailable.",
+								"exhausted": "Globalping credits are exhausted.",
+								"valid": "Globalping status fetched successfully."
+							},
+							"summary": "Credential state: {{credentialState}} | Remaining credits: {{remainingCredits}} | Remaining limit: {{remainingLimit}}",
+							"credentialStates": {
+								"missing": "No key configured",
+								"valid": "Valid key",
+								"invalid": "Invalid key",
+								"forbidden": "Forbidden",
+								"upstream_unavailable": "Upstream error"
+							}
 						}
 					}
 				}

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1161,6 +1161,17 @@
 				},
 				"validation": {
 					"errorMessage": "Please fix the following validation errors:"
+				},
+				"globalping": {
+					"title": "Globalping API key",
+					"description": "Enter your Globalping API key to use your own Globalping credits and rate limits. Click Reset to update the key.",
+					"option": {
+						"apiKey": {
+							"label": "Globalping API key",
+							"labelSet": "API key is set. Click Reset to change it.",
+							"placeholder": "Enter your Globalping API key"
+						}
+					}
 				}
 			}
 		},

--- a/server/src/config/controllers.ts
+++ b/server/src/config/controllers.ts
@@ -32,7 +32,7 @@ export const initializeControllers = (services: InitializedServices): Initialize
 	return {
 		authController: new AuthController(services.userService),
 		monitorController: new MonitorController(services.monitorService),
-		settingsController: new SettingsController(services.settingsService, services.emailService),
+		settingsController: new SettingsController(services.settingsService, services.emailService, services.globalPingService),
 		checkController: new CheckController(services.checkService),
 		geoCheckController: new GeoCheckController(services.geoChecksService),
 		inviteController: new InviteController(services.inviteService),

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -38,6 +38,7 @@ import {
 	IMonitorService,
 	IUserService,
 	ICheckService,
+	IGlobalPingService,
 	IGeoChecksService,
 	IDiagnosticService,
 	IInviteService,
@@ -121,6 +122,7 @@ export type InitializedServices = {
 	jobQueue: ISuperSimpleQueue;
 	userService: IUserService;
 	checkService: ICheckService;
+	globalPingService: IGlobalPingService;
 	geoChecksService: IGeoChecksService;
 	diagnosticService: IDiagnosticService;
 	inviteService: IInviteService;
@@ -318,6 +320,7 @@ export const initializeServices = async ({
 		jobQueue: superSimpleQueue,
 		userService,
 		checkService,
+		globalPingService,
 		geoChecksService,
 		diagnosticService,
 		inviteService,

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -209,7 +209,7 @@ export const initializeServices = async ({
 
 	const checkService = new CheckService(monitorsRepository, logger, checksRepository);
 
-	const globalPingService = new GlobalPingService(logger);
+	const globalPingService = new GlobalPingService(logger, settingsService);
 
 	const geoChecksService = new GeoChecksService({
 		logger,

--- a/server/src/controllers/settingsController.ts
+++ b/server/src/controllers/settingsController.ts
@@ -24,6 +24,7 @@ class SettingsController {
 		delete sanitizedSettings.jwtSecret;
 		const returnSettings = {
 			pagespeedKeySet: false,
+			globalpingKeySet: false,
 			emailPasswordSet: false,
 			settings: null,
 		};
@@ -31,6 +32,10 @@ class SettingsController {
 		if (typeof sanitizedSettings.pagespeedApiKey !== "undefined") {
 			returnSettings.pagespeedKeySet = true;
 			delete sanitizedSettings.pagespeedApiKey;
+		}
+		if (typeof sanitizedSettings.globalpingApiKey !== "undefined") {
+			returnSettings.globalpingKeySet = true;
+			delete sanitizedSettings.globalpingApiKey;
 		}
 		if (typeof sanitizedSettings.systemEmailPassword !== "undefined") {
 			returnSettings.emailPasswordSet = true;
@@ -57,9 +62,9 @@ class SettingsController {
 
 	updateAppSettings = async (req: Request, res: Response, next: NextFunction) => {
 		try {
-			updateAppSettingsBodyValidation.parse(req.body);
+			const parsedSettings = updateAppSettingsBodyValidation.parse(req.body);
 
-			const updatedSettings = await this.settingsService.updateDbSettings(req.body);
+			const updatedSettings = await this.settingsService.updateDbSettings(parsedSettings);
 			const returnSettings = this.buildAppSettings(updatedSettings);
 			return res.status(200).json({
 				success: true,

--- a/server/src/controllers/settingsController.ts
+++ b/server/src/controllers/settingsController.ts
@@ -2,6 +2,8 @@ import { Request, Response, NextFunction } from "express";
 import { updateAppSettingsBodyValidation } from "@/validation/settingsValidation.js";
 import { sendTestEmailBodyValidation } from "@/validation/notificationValidation.js";
 import { AppError } from "@/utils/AppError.js";
+import type { IGlobalPingService } from "@/service/infrastructure/globalPingService.js";
+import type { ISettingsService } from "@/service/system/settingsService.js";
 
 const SERVICE_NAME = "SettingsController";
 
@@ -9,9 +11,11 @@ class SettingsController {
 	static SERVICE_NAME = SERVICE_NAME;
 	private settingsService: any;
 	private emailService: any;
-	constructor(settingsService: any, emailService: any) {
+	private globalPingService: IGlobalPingService;
+	constructor(settingsService: any, emailService: any, globalPingService: IGlobalPingService) {
 		this.settingsService = settingsService;
 		this.emailService = emailService;
+		this.globalPingService = globalPingService;
 	}
 
 	get serviceName() {
@@ -54,6 +58,19 @@ class SettingsController {
 				success: true,
 				msg: "App settings fetched successfully",
 				data: returnSettings,
+			});
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	getGlobalpingStatus = async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			const status = await this.globalPingService.getUsageStatus();
+			return res.status(200).json({
+				success: true,
+				msg: "Globalping status fetched successfully",
+				data: status,
 			});
 		} catch (error) {
 			next(error);

--- a/server/src/controllers/settingsController.ts
+++ b/server/src/controllers/settingsController.ts
@@ -3,7 +3,6 @@ import { updateAppSettingsBodyValidation } from "@/validation/settingsValidation
 import { sendTestEmailBodyValidation } from "@/validation/notificationValidation.js";
 import { AppError } from "@/utils/AppError.js";
 import type { IGlobalPingService } from "@/service/infrastructure/globalPingService.js";
-import type { ISettingsService } from "@/service/system/settingsService.js";
 
 const SERVICE_NAME = "SettingsController";
 

--- a/server/src/db/models/AppSettings.ts
+++ b/server/src/db/models/AppSettings.ts
@@ -23,6 +23,7 @@ const AppSettingsSchema = new Schema<AppSettingsDocument>(
 		language: { type: String, default: "gb" },
 		jwtSecret: { type: String },
 		pagespeedApiKey: { type: String },
+		globalpingApiKey: { type: String },
 		systemEmailHost: { type: String },
 		systemEmailPort: { type: Number },
 		systemEmailAddress: { type: String },

--- a/server/src/repositories/settings/MongoSettingsRepository.ts
+++ b/server/src/repositories/settings/MongoSettingsRepository.ts
@@ -25,6 +25,7 @@ class MongoSettingsRepository implements ISettingsRepository {
 			language: doc.language,
 			jwtSecret: doc.jwtSecret ?? undefined,
 			pagespeedApiKey: doc.pagespeedApiKey ?? undefined,
+			globalpingApiKey: doc.globalpingApiKey ?? undefined,
 			systemEmailHost: doc.systemEmailHost ?? undefined,
 			systemEmailPort: doc.systemEmailPort ?? undefined,
 			systemEmailAddress: doc.systemEmailAddress ?? undefined,

--- a/server/src/routes/settingsRoute.ts
+++ b/server/src/routes/settingsRoute.ts
@@ -13,6 +13,7 @@ class SettingsRoutes {
 
 	initRoutes() {
 		this.router.get("/", this.settingsController.getAppSettings);
+		this.router.get("/globalping-status", isAllowed(["admin", "superadmin"]), this.settingsController.getGlobalpingStatus);
 		this.router.patch("/", isAllowed(["admin", "superadmin"]), this.settingsController.updateAppSettings);
 		this.router.post("/test-email", isAllowed(["admin", "superadmin"]), this.settingsController.sendTestEmail);
 	}

--- a/server/src/service/infrastructure/globalPingService.ts
+++ b/server/src/service/infrastructure/globalPingService.ts
@@ -1,6 +1,7 @@
 import type { GeoContinent, GeoCheckResult, GeoCheckTimings, GeoCheckLocation } from "@/types/geoCheck.js";
 import { supportsGeoCheck } from "@/types/monitor.js";
 import { MonitorType } from "@/types/index.js";
+import type { ISettingsService } from "@/service/system/settingsService.js";
 import type { ILogger } from "@/utils/logger.js";
 import got from "got";
 
@@ -69,13 +70,40 @@ export class GlobalPingService implements IGlobalPingService {
 	static SERVICE_NAME = SERVICE_NAME;
 
 	private logger: ILogger;
+	private settingsService: ISettingsService;
 
-	constructor(logger: ILogger) {
+	constructor(logger: ILogger, settingsService: ISettingsService) {
 		this.logger = logger;
+		this.settingsService = settingsService;
 	}
 
 	get serviceName() {
 		return GlobalPingService.SERVICE_NAME;
+	}
+
+	private async getApiKey() {
+		const dbSettings = await this.settingsService.getDBSettings();
+		return dbSettings.globalpingApiKey?.trim() || null;
+	}
+
+	private buildHeaders(apiKey: string | null) {
+		if (!apiKey) {
+			return undefined;
+		}
+
+		return {
+			Authorization: `Bearer ${apiKey}`,
+		};
+	}
+
+	private isRejectedCredential(error: unknown) {
+		const statusCode =
+			typeof error === "object" && error !== null
+				? (error as { response?: { statusCode?: number }; statusCode?: number }).response
+						?.statusCode ?? (error as { statusCode?: number }).statusCode
+				: undefined;
+
+		return statusCode === 401 || statusCode === 403;
 	}
 
 	async createMeasurement(monitorType: MonitorType, url: string, locations: GeoContinent[]): Promise<string | null> {
@@ -83,6 +111,7 @@ export class GlobalPingService implements IGlobalPingService {
 			if (!supportsGeoCheck(monitorType)) {
 				throw new Error(`Unsupported monitor type for GlobalPing: ${monitorType}`);
 			}
+			const apiKey = await this.getApiKey();
 			// GlobalPing API expects target without protocol (http:// or https://)
 			const cleanTarget = url.replace(/^https?:\/\//, "");
 
@@ -97,6 +126,7 @@ export class GlobalPingService implements IGlobalPingService {
 				json: requestBody,
 				responseType: "json",
 				timeout: { request: 10000 },
+				headers: this.buildHeaders(apiKey),
 			});
 
 			const measurementId = response.body.id;
@@ -121,12 +151,14 @@ export class GlobalPingService implements IGlobalPingService {
 
 	async pollForResults(measurementId: string, timeoutMs: number = MAX_POLL_TIMEOUT_MS): Promise<GeoCheckResult[]> {
 		const startTime = Date.now();
+		const apiKey = await this.getApiKey();
 
 		while (Date.now() - startTime < timeoutMs) {
 			try {
 				const response = await got.get<GlobalPingMeasurementResponse>(`${GLOBAL_PING_API_BASE}/measurements/${measurementId}`, {
 					responseType: "json",
 					timeout: { request: 5000 },
+					headers: this.buildHeaders(apiKey),
 				});
 
 				const measurement = response.body;

--- a/server/src/service/infrastructure/globalPingService.ts
+++ b/server/src/service/infrastructure/globalPingService.ts
@@ -262,11 +262,11 @@ export class GlobalPingService implements IGlobalPingService {
 			this.logFailure("createMeasurement", error, failure);
 
 			if (failure.runtimeBehavior === "fail") {
-					throw new AppError({
-						message: failure.message,
-						service: SERVICE_NAME,
-						method: "createMeasurement",
-						status: 502,
+				throw new AppError({
+					message: failure.message,
+					service: SERVICE_NAME,
+					method: "createMeasurement",
+					status: 502,
 				});
 			}
 
@@ -280,12 +280,9 @@ export class GlobalPingService implements IGlobalPingService {
 
 		while (Date.now() - startTime < timeoutMs) {
 			try {
-				const response = await this.requestGlobalping<GlobalPingMeasurementResponse>(
-					"get",
-					`/measurements/${measurementId}`,
-					apiKey,
-					{ timeoutMs: 5000 }
-				);
+				const response = await this.requestGlobalping<GlobalPingMeasurementResponse>("get", `/measurements/${measurementId}`, apiKey, {
+					timeoutMs: 5000,
+				});
 				const measurement = response.body;
 
 				if (measurement.status === "finished") {
@@ -447,12 +444,7 @@ export class GlobalPingService implements IGlobalPingService {
 		const totalLimit = this.toNullableNumber(payload.totalLimit ?? createRateLimit?.limit);
 		const resetAt = this.normalizeDate(payload.resetAt) ?? this.normalizeResetSeconds(createRateLimit?.reset);
 
-		if (
-			remainingCredits === null &&
-			remainingLimit === null &&
-			totalLimit === null &&
-			resetAt === null
-		) {
+		if (remainingCredits === null && remainingLimit === null && totalLimit === null && resetAt === null) {
 			throw new AppError({
 				message: "Malformed Globalping limits response",
 				service: SERVICE_NAME,

--- a/server/src/service/infrastructure/globalPingService.ts
+++ b/server/src/service/infrastructure/globalPingService.ts
@@ -23,7 +23,7 @@ export type GlobalpingFailureClassification =
 	| "unsupported_monitor"
 	| "invalid_location"
 	| "unknown";
-export type GlobalpingRuntimeBehavior = "fail" | "retryable" | "fallback-allowed-only-without-key";
+export type GlobalpingRuntimeBehavior = "fail" | "retryable";
 
 interface GlobalPingMeasurementRequest {
 	type: MonitorType;

--- a/server/src/service/infrastructure/globalPingService.ts
+++ b/server/src/service/infrastructure/globalPingService.ts
@@ -79,10 +79,7 @@ interface GlobalpingLimitsResponse {
 	rateLimit?: {
 		measurements?: {
 			create?: {
-				type?: "ip" | "user";
-				limit?: number | null;
 				remaining?: number | null;
-				reset?: number | null;
 			};
 		};
 	};
@@ -91,18 +88,13 @@ interface GlobalpingLimitsResponse {
 	};
 	remainingCredits?: number | null;
 	remainingLimit?: number | null;
-	totalLimit?: number | null;
-	resetAt?: string | null;
 }
 
 export interface GlobalpingStatus {
-	keyConfigured: boolean;
 	credentialState: GlobalpingCredentialState;
 	creditState: GlobalpingCreditState;
 	remainingCredits?: number | null;
 	remainingLimit?: number | null;
-	totalLimit?: number | null;
-	resetAt?: string | null;
 }
 
 export interface GlobalpingFailureDetails {
@@ -110,7 +102,6 @@ export interface GlobalpingFailureDetails {
 	credentialState: GlobalpingCredentialState;
 	message: string;
 	runtimeBehavior: GlobalpingRuntimeBehavior;
-	retryable: boolean;
 }
 
 export interface IGlobalPingService {
@@ -144,7 +135,6 @@ export class GlobalPingService implements IGlobalPingService {
 				credentialState: "invalid",
 				message: "The configured Globalping API key was rejected.",
 				runtimeBehavior: "fail",
-				retryable: false,
 			};
 		}
 
@@ -154,7 +144,6 @@ export class GlobalPingService implements IGlobalPingService {
 				credentialState: "forbidden",
 				message: "The configured Globalping API key is not allowed to access this resource.",
 				runtimeBehavior: "fail",
-				retryable: false,
 			};
 		}
 
@@ -164,7 +153,6 @@ export class GlobalPingService implements IGlobalPingService {
 				credentialState: "upstream_unavailable",
 				message: "Globalping rate limit hit.",
 				runtimeBehavior: "retryable",
-				retryable: true,
 			};
 		}
 
@@ -173,7 +161,6 @@ export class GlobalPingService implements IGlobalPingService {
 			credentialState: "upstream_unavailable",
 			message: "Globalping status is currently unavailable.",
 			runtimeBehavior: "retryable",
-			retryable: true,
 		};
 	}
 
@@ -182,7 +169,6 @@ export class GlobalPingService implements IGlobalPingService {
 
 		if (!apiKey) {
 			return {
-				keyConfigured: false,
 				credentialState: "missing",
 				creditState: "unknown",
 			};
@@ -196,7 +182,6 @@ export class GlobalPingService implements IGlobalPingService {
 			const creditState = this.deriveCreditState(parsed.remainingCredits);
 
 			return {
-				keyConfigured: true,
 				credentialState: "valid",
 				creditState,
 				...parsed,
@@ -206,7 +191,6 @@ export class GlobalPingService implements IGlobalPingService {
 			this.logFailure("getUsageStatus", error, failure);
 
 			return {
-				keyConfigured: true,
 				credentialState: failure.credentialState,
 				creditState: "unknown",
 			};
@@ -236,7 +220,7 @@ export class GlobalPingService implements IGlobalPingService {
 			}
 
 			const apiKey = await this.getApiKey();
-			const cleanTarget = url.replace(/^https?:\/\//, "");
+			const cleanTarget = url.replace(/^https?:\/\//, ""); // GlobalPing API expects target without protocol (http:// or https://)
 			const requestBody: GlobalPingMeasurementRequest = {
 				type: monitorType,
 				target: cleanTarget,
@@ -416,23 +400,6 @@ export class GlobalPingService implements IGlobalPingService {
 		};
 	}
 
-	private normalizeDate(value?: string | null) {
-		if (!value) {
-			return null;
-		}
-
-		const parsed = new Date(value);
-		return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-	}
-
-	private normalizeResetSeconds(value?: number | null) {
-		if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
-			return null;
-		}
-
-		return new Date(Date.now() + value * 1000).toISOString();
-	}
-
 	private toNullableNumber(value: unknown) {
 		return typeof value === "number" && Number.isFinite(value) ? value : null;
 	}
@@ -441,10 +408,8 @@ export class GlobalPingService implements IGlobalPingService {
 		const createRateLimit = payload.rateLimit?.measurements?.create;
 		const remainingCredits = this.toNullableNumber(payload.remainingCredits ?? payload.credits?.remaining);
 		const remainingLimit = this.toNullableNumber(payload.remainingLimit ?? createRateLimit?.remaining);
-		const totalLimit = this.toNullableNumber(payload.totalLimit ?? createRateLimit?.limit);
-		const resetAt = this.normalizeDate(payload.resetAt) ?? this.normalizeResetSeconds(createRateLimit?.reset);
 
-		if (remainingCredits === null && remainingLimit === null && totalLimit === null && resetAt === null) {
+		if (remainingCredits === null && remainingLimit === null) {
 			throw new AppError({
 				message: "Malformed Globalping limits response",
 				service: SERVICE_NAME,
@@ -456,8 +421,6 @@ export class GlobalPingService implements IGlobalPingService {
 		return {
 			remainingCredits,
 			remainingLimit,
-			totalLimit,
-			resetAt,
 		};
 	}
 
@@ -504,7 +467,8 @@ export class GlobalPingService implements IGlobalPingService {
 				longitude: probeResult.probe.longitude,
 				latitude: probeResult.probe.latitude,
 			};
-
+			
+			// HTTP results have statusCode and timings, ping results have stats
 			if (probeResult.result.statusCode && probeResult.result.timings) {
 				const timings: GeoCheckTimings = {
 					total: probeResult.result.timings.total,

--- a/server/src/service/infrastructure/globalPingService.ts
+++ b/server/src/service/infrastructure/globalPingService.ts
@@ -1,14 +1,29 @@
-import type { GeoContinent, GeoCheckResult, GeoCheckTimings, GeoCheckLocation } from "@/types/geoCheck.js";
-import { supportsGeoCheck } from "@/types/monitor.js";
-import { MonitorType } from "@/types/index.js";
+import got, { type Got } from "got";
 import type { ISettingsService } from "@/service/system/settingsService.js";
+import { MonitorType } from "@/types/index.js";
+import type { GeoCheckLocation, GeoCheckResult, GeoCheckTimings, GeoContinent } from "@/types/geoCheck.js";
+import { supportsGeoCheck } from "@/types/monitor.js";
 import type { ILogger } from "@/utils/logger.js";
-import got from "got";
+import { AppError } from "@/utils/AppError.js";
 
 const SERVICE_NAME = "GlobalPingService";
 const GLOBAL_PING_API_BASE = "https://api.globalping.io/v1";
 const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_TIMEOUT_MS = 30000;
+const SETTINGS_STATUS_TIMEOUT_MS = 10000;
+
+// Types
+type GlobalpingCredentialState = "missing" | "valid" | "invalid" | "forbidden" | "upstream_unavailable";
+type GlobalpingCreditState = "unknown" | "healthy" | "exhausted";
+export type GlobalpingFailureClassification =
+	| "missing_key"
+	| "invalid_key"
+	| "forbidden"
+	| "rate_limited"
+	| "unsupported_monitor"
+	| "invalid_location"
+	| "unknown";
+export type GlobalpingRuntimeBehavior = "fail" | "retryable" | "fallback-allowed-only-without-key";
 
 interface GlobalPingMeasurementRequest {
 	type: MonitorType;
@@ -60,27 +75,273 @@ interface GlobalPingProbeResult {
 	};
 }
 
+interface GlobalpingLimitsResponse {
+	rateLimit?: {
+		measurements?: {
+			create?: {
+				type?: "ip" | "user";
+				limit?: number | null;
+				remaining?: number | null;
+				reset?: number | null;
+			};
+		};
+	};
+	credits?: {
+		remaining?: number | null;
+	};
+	remainingCredits?: number | null;
+	remainingLimit?: number | null;
+	totalLimit?: number | null;
+	resetAt?: string | null;
+}
+
+export interface GlobalpingStatus {
+	keyConfigured: boolean;
+	credentialState: GlobalpingCredentialState;
+	creditState: GlobalpingCreditState;
+	remainingCredits?: number | null;
+	remainingLimit?: number | null;
+	totalLimit?: number | null;
+	resetAt?: string | null;
+}
+
+export interface GlobalpingFailureDetails {
+	classification: GlobalpingFailureClassification;
+	credentialState: GlobalpingCredentialState;
+	message: string;
+	runtimeBehavior: GlobalpingRuntimeBehavior;
+	retryable: boolean;
+}
+
 export interface IGlobalPingService {
 	readonly serviceName: string;
 	createMeasurement(monitorType: MonitorType, url: string, locations: GeoContinent[]): Promise<string | null>;
 	pollForResults(measurementId: string, timeoutMs?: number): Promise<GeoCheckResult[]>;
+	getUsageStatus(): Promise<GlobalpingStatus>;
+	classifyError(error: unknown): GlobalpingFailureDetails;
 }
 
 export class GlobalPingService implements IGlobalPingService {
 	static SERVICE_NAME = SERVICE_NAME;
 
-	private logger: ILogger;
-	private settingsService: ISettingsService;
-
-	constructor(logger: ILogger, settingsService: ISettingsService) {
-		this.logger = logger;
-		this.settingsService = settingsService;
-	}
+	constructor(
+		private logger: ILogger,
+		private settingsService: ISettingsService,
+		private httpClient: Got = got
+	) {}
 
 	get serviceName() {
 		return GlobalPingService.SERVICE_NAME;
 	}
 
+	// Public API
+	classifyError(error: unknown): GlobalpingFailureDetails {
+		const statusCode = this.getStatusCode(error);
+
+		if (statusCode === 401) {
+			return {
+				classification: "invalid_key",
+				credentialState: "invalid",
+				message: "The configured Globalping API key was rejected.",
+				runtimeBehavior: "fail",
+				retryable: false,
+			};
+		}
+
+		if (statusCode === 403) {
+			return {
+				classification: "forbidden",
+				credentialState: "forbidden",
+				message: "The configured Globalping API key is not allowed to access this resource.",
+				runtimeBehavior: "fail",
+				retryable: false,
+			};
+		}
+
+		if (statusCode === 429) {
+			return {
+				classification: "rate_limited",
+				credentialState: "upstream_unavailable",
+				message: "Globalping rate limit hit.",
+				runtimeBehavior: "retryable",
+				retryable: true,
+			};
+		}
+
+		return {
+			classification: "unknown",
+			credentialState: "upstream_unavailable",
+			message: "Globalping status is currently unavailable.",
+			runtimeBehavior: "retryable",
+			retryable: true,
+		};
+	}
+
+	async getUsageStatus(): Promise<GlobalpingStatus> {
+		const apiKey = await this.getApiKey();
+
+		if (!apiKey) {
+			return {
+				keyConfigured: false,
+				credentialState: "missing",
+				creditState: "unknown",
+			};
+		}
+
+		try {
+			const response = await this.requestGlobalping<GlobalpingLimitsResponse>("get", "/limits", apiKey, {
+				timeoutMs: SETTINGS_STATUS_TIMEOUT_MS,
+			});
+			const parsed = this.parseLimitsPayload(response.body);
+			const creditState = this.deriveCreditState(parsed.remainingCredits);
+
+			return {
+				keyConfigured: true,
+				credentialState: "valid",
+				creditState,
+				...parsed,
+			};
+		} catch (error) {
+			const failure = this.classifyError(error);
+			this.logFailure("getUsageStatus", error, failure);
+
+			return {
+				keyConfigured: true,
+				credentialState: failure.credentialState,
+				creditState: "unknown",
+			};
+		}
+	}
+
+	async createMeasurement(monitorType: MonitorType, url: string, locations: GeoContinent[]): Promise<string | null> {
+		try {
+			if (!supportsGeoCheck(monitorType)) {
+				this.logger.warn({
+					message: `Unsupported monitor type for Globalping: ${monitorType}`,
+					service: SERVICE_NAME,
+					method: "createMeasurement",
+					details: { classification: "unsupported_monitor" satisfies GlobalpingFailureClassification },
+				});
+				return null;
+			}
+
+			if (!locations.length) {
+				this.logger.warn({
+					message: "No valid Globalping locations provided for measurement",
+					service: SERVICE_NAME,
+					method: "createMeasurement",
+					details: { classification: "invalid_location" satisfies GlobalpingFailureClassification },
+				});
+				return null;
+			}
+
+			const apiKey = await this.getApiKey();
+			const cleanTarget = url.replace(/^https?:\/\//, "");
+			const requestBody: GlobalPingMeasurementRequest = {
+				type: monitorType,
+				target: cleanTarget,
+				locations: locations.map((continent) => ({ continent })),
+				limit: locations.length,
+			};
+
+			const response = await this.requestGlobalping<GlobalPingMeasurementResponse>("post", "/measurements", apiKey, {
+				timeoutMs: 10000,
+				json: requestBody,
+			});
+
+			const measurementId = response.body.id;
+			this.logger.debug({
+				message: `Created GlobalPing measurement: ${measurementId} for target: ${cleanTarget}`,
+				service: SERVICE_NAME,
+				method: "createMeasurement",
+			});
+
+			return measurementId;
+		} catch (error) {
+			const failure = this.classifyError(error);
+			this.logFailure("createMeasurement", error, failure);
+
+			if (failure.runtimeBehavior === "fail") {
+					throw new AppError({
+						message: failure.message,
+						service: SERVICE_NAME,
+						method: "createMeasurement",
+						status: 502,
+				});
+			}
+
+			return null;
+		}
+	}
+
+	async pollForResults(measurementId: string, timeoutMs: number = MAX_POLL_TIMEOUT_MS): Promise<GeoCheckResult[]> {
+		const startTime = Date.now();
+		const apiKey = await this.getApiKey();
+
+		while (Date.now() - startTime < timeoutMs) {
+			try {
+				const response = await this.requestGlobalping<GlobalPingMeasurementResponse>(
+					"get",
+					`/measurements/${measurementId}`,
+					apiKey,
+					{ timeoutMs: 5000 }
+				);
+				const measurement = response.body;
+
+				if (measurement.status === "finished") {
+					const results = this.transformResults(measurement.results || []);
+					if (measurement.results && results.length < measurement.results.length) {
+						this.logger.warn({
+							message: "Globalping returned partial or unsupported results",
+							service: SERVICE_NAME,
+							method: "pollForResults",
+							details: {
+								classification: "unknown" satisfies GlobalpingFailureClassification,
+								measurementId,
+								resultsCount: results.length,
+								rawResultsCount: measurement.results.length,
+							},
+						});
+					}
+					return results;
+				}
+
+				if (measurement.status === "failed") {
+					this.logger.warn({
+						message: `Globalping measurement failed: ${measurementId}`,
+						service: SERVICE_NAME,
+						method: "pollForResults",
+						details: { classification: "unknown" satisfies GlobalpingFailureClassification },
+					});
+					return [];
+				}
+
+				await this.sleep(POLL_INTERVAL_MS);
+			} catch (error) {
+				const failure = this.classifyError(error);
+				this.logFailure("pollForResults", error, failure, { measurementId });
+				if (failure.runtimeBehavior === "fail") {
+					throw new AppError({
+						message: failure.message,
+						service: SERVICE_NAME,
+						method: "pollForResults",
+						status: 502,
+					});
+				}
+				return [];
+			}
+		}
+
+		this.logger.warn({
+			message: `Globalping measurement polling timeout: ${measurementId}`,
+			service: SERVICE_NAME,
+			method: "pollForResults",
+			details: { classification: "unknown" satisfies GlobalpingFailureClassification, measurementId, timeoutMs },
+		});
+		return [];
+	}
+
+	// Request helpers
 	private async getApiKey() {
 		const dbSettings = await this.settingsService.getDBSettings();
 		return dbSettings.globalpingApiKey?.trim() || null;
@@ -96,116 +357,144 @@ export class GlobalPingService implements IGlobalPingService {
 		};
 	}
 
-	private isRejectedCredential(error: unknown) {
-		const statusCode =
-			typeof error === "object" && error !== null
-				? (error as { response?: { statusCode?: number }; statusCode?: number }).response
-						?.statusCode ?? (error as { statusCode?: number }).statusCode
-				: undefined;
+	private async requestGlobalping<T>(
+		method: "get" | "post",
+		path: string,
+		apiKey: string | null,
+		options: {
+			timeoutMs: number;
+			json?: unknown;
+		}
+	) {
+		const url = `${GLOBAL_PING_API_BASE}${path}`;
 
-		return statusCode === 401 || statusCode === 403;
-	}
-
-	async createMeasurement(monitorType: MonitorType, url: string, locations: GeoContinent[]): Promise<string | null> {
-		try {
-			if (!supportsGeoCheck(monitorType)) {
-				throw new Error(`Unsupported monitor type for GlobalPing: ${monitorType}`);
-			}
-			const apiKey = await this.getApiKey();
-			// GlobalPing API expects target without protocol (http:// or https://)
-			const cleanTarget = url.replace(/^https?:\/\//, "");
-
-			const requestBody: GlobalPingMeasurementRequest = {
-				type: monitorType,
-				target: cleanTarget,
-				locations: locations.map((continent) => ({ continent })),
-				limit: locations.length,
-			};
-
-			const response = await got.post<GlobalPingMeasurementResponse>(`${GLOBAL_PING_API_BASE}/measurements`, {
-				json: requestBody,
+		if (method === "get") {
+			return this.httpClient.get<T>(url, {
 				responseType: "json",
-				timeout: { request: 10000 },
+				timeout: { request: options.timeoutMs },
 				headers: this.buildHeaders(apiKey),
 			});
+		}
 
-			const measurementId = response.body.id;
+		return this.httpClient.post<T>(url, {
+			json: options.json,
+			responseType: "json",
+			timeout: { request: options.timeoutMs },
+			headers: this.buildHeaders(apiKey),
+		});
+	}
 
-			this.logger.debug({
-				message: `Created GlobalPing measurement: ${measurementId} for target: ${cleanTarget}`,
-				service: SERVICE_NAME,
-				method: "createMeasurement",
-			});
+	// Status helpers
+	private getStatusCode(error: unknown) {
+		if (typeof error !== "object" || error === null) {
+			return undefined;
+		}
 
-			return measurementId;
-		} catch (error: unknown) {
-			this.logger.error({
-				message: "GlobalPing API unavailable, skipping geo check",
-				service: SERVICE_NAME,
-				method: "createMeasurement",
-				stack: error instanceof Error ? error.stack : undefined,
-			});
+		const maybeError = error as { response?: { statusCode?: number }; statusCode?: number };
+		return maybeError.response?.statusCode ?? maybeError.statusCode;
+	}
+
+	private getErrorDetails(error: unknown) {
+		if (!(error instanceof Error) && (typeof error !== "object" || error === null)) {
+			return {
+				message: "Unknown error",
+			};
+		}
+
+		const maybeError = error as {
+			name?: string;
+			message?: string;
+			code?: string;
+			response?: { statusCode?: number; body?: unknown };
+			options?: { url?: URL; method?: string };
+		};
+
+		return {
+			name: maybeError.name ?? (error instanceof Error ? error.name : undefined),
+			message: maybeError.message ?? (error instanceof Error ? error.message : "Unknown error"),
+			code: maybeError.code,
+			statusCode: maybeError.response?.statusCode,
+			method: maybeError.options?.method,
+			url: maybeError.options?.url?.toString(),
+		};
+	}
+
+	private normalizeDate(value?: string | null) {
+		if (!value) {
 			return null;
 		}
+
+		const parsed = new Date(value);
+		return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
 	}
 
-	async pollForResults(measurementId: string, timeoutMs: number = MAX_POLL_TIMEOUT_MS): Promise<GeoCheckResult[]> {
-		const startTime = Date.now();
-		const apiKey = await this.getApiKey();
-
-		while (Date.now() - startTime < timeoutMs) {
-			try {
-				const response = await got.get<GlobalPingMeasurementResponse>(`${GLOBAL_PING_API_BASE}/measurements/${measurementId}`, {
-					responseType: "json",
-					timeout: { request: 5000 },
-					headers: this.buildHeaders(apiKey),
-				});
-
-				const measurement = response.body;
-
-				if (measurement.status === "finished") {
-					const results = this.transformResults(measurement.results || []);
-					this.logger.debug({
-						message: `GlobalPing measurement completed: ${measurementId}`,
-						service: SERVICE_NAME,
-						method: "pollForResults",
-						details: { measurementId, resultsCount: results.length },
-					});
-					return results;
-				}
-
-				if (measurement.status === "failed") {
-					this.logger.warn({
-						message: `GlobalPing measurement failed: ${measurementId}`,
-						service: SERVICE_NAME,
-						method: "pollForResults",
-					});
-					return [];
-				}
-
-				// Still in-progress, wait and poll again
-				await this.sleep(POLL_INTERVAL_MS);
-			} catch (error: unknown) {
-				this.logger.error({
-					message: "Error polling GlobalPing API",
-					service: SERVICE_NAME,
-					method: "pollForResults",
-					stack: error instanceof Error ? error.stack : undefined,
-				});
-				return [];
-			}
+	private normalizeResetSeconds(value?: number | null) {
+		if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+			return null;
 		}
 
-		// Timeout reached
-		this.logger.warn({
-			message: `GlobalPing measurement polling timeout: ${measurementId}`,
-			service: SERVICE_NAME,
-			method: "pollForResults",
-			details: { measurementId, timeoutMs },
-		});
-		return [];
+		return new Date(Date.now() + value * 1000).toISOString();
 	}
 
+	private toNullableNumber(value: unknown) {
+		return typeof value === "number" && Number.isFinite(value) ? value : null;
+	}
+
+	private parseLimitsPayload(payload: GlobalpingLimitsResponse) {
+		const createRateLimit = payload.rateLimit?.measurements?.create;
+		const remainingCredits = this.toNullableNumber(payload.remainingCredits ?? payload.credits?.remaining);
+		const remainingLimit = this.toNullableNumber(payload.remainingLimit ?? createRateLimit?.remaining);
+		const totalLimit = this.toNullableNumber(payload.totalLimit ?? createRateLimit?.limit);
+		const resetAt = this.normalizeDate(payload.resetAt) ?? this.normalizeResetSeconds(createRateLimit?.reset);
+
+		if (
+			remainingCredits === null &&
+			remainingLimit === null &&
+			totalLimit === null &&
+			resetAt === null
+		) {
+			throw new AppError({
+				message: "Malformed Globalping limits response",
+				service: SERVICE_NAME,
+				method: "parseLimitsPayload",
+				status: 502,
+			});
+		}
+
+		return {
+			remainingCredits,
+			remainingLimit,
+			totalLimit,
+			resetAt,
+		};
+	}
+
+	private deriveCreditState(remainingCredits: number | null): GlobalpingCreditState {
+		if (remainingCredits === null) {
+			return "unknown";
+		}
+		if (remainingCredits <= 0) {
+			return "exhausted";
+		}
+		return "healthy";
+	}
+
+	private logFailure(method: string, error: unknown, failure: GlobalpingFailureDetails, extraDetails?: Record<string, unknown>) {
+		this.logger.warn({
+			message: failure.message,
+			service: SERVICE_NAME,
+			method,
+			details: {
+				classification: failure.classification,
+				runtimeBehavior: failure.runtimeBehavior,
+				...extraDetails,
+				error: this.getErrorDetails(error),
+			},
+			stack: error instanceof Error ? error.stack : undefined,
+		});
+	}
+
+	// Measurement helpers
 	private transformResults(probeResults: GlobalPingProbeResult[]): GeoCheckResult[] {
 		const successfulResults: GeoCheckResult[] = [];
 
@@ -224,7 +513,6 @@ export class GlobalPingService implements IGlobalPingService {
 				latitude: probeResult.probe.latitude,
 			};
 
-			// HTTP results have statusCode and timings, ping results have stats
 			if (probeResult.result.statusCode && probeResult.result.timings) {
 				const timings: GeoCheckTimings = {
 					total: probeResult.result.timings.total,
@@ -241,7 +529,10 @@ export class GlobalPingService implements IGlobalPingService {
 					statusCode: probeResult.result.statusCode,
 					timings,
 				});
-			} else if (probeResult.result.stats) {
+				continue;
+			}
+
+			if (probeResult.result.stats) {
 				successfulResults.push({
 					location,
 					status: probeResult.result.stats.loss === 0,

--- a/server/src/types/settings.ts
+++ b/server/src/types/settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
 	language: string;
 	jwtSecret?: string;
 	pagespeedApiKey?: string;
+	globalpingApiKey?: string;
 	systemEmailHost?: string;
 	systemEmailPort?: number;
 	systemEmailAddress?: string;

--- a/server/src/validation/settingsValidation.ts
+++ b/server/src/validation/settingsValidation.ts
@@ -10,6 +10,7 @@ export const updateAppSettingsBodyValidation = z
 		checkTTL: z.union([z.number().int().min(1).max(CHECK_TTL_SENTINEL), z.literal("")]).optional(),
 		systemEmailPort: z.union([z.number(), z.literal("")]).optional(),
 		pagespeedApiKey: z.union([z.string(), z.literal("")]).optional(),
+		globalpingApiKey: z.union([z.string(), z.literal("")]).optional(),
 		language: z.union([z.string(), z.literal("")]).optional(),
 		timezone: z.union([z.string(), z.literal("")]).optional(),
 		systemEmailHost: z.union([z.string(), z.literal("")]).optional(),


### PR DESCRIPTION
## Describe your changes
<img width="976" height="390" alt="pr-checkmate-byok" src="https://github.com/user-attachments/assets/be070c4f-aac9-4363-8e4f-fdf4e9c8c518" />

Added support for admins to provide their own GlobalPing API key, aligning the implementation closely with the existing Google PageSpeed key integration. When a key is saved, the server automatically attaches an Authorization header to each GlobalPing request.

As an additional improvement, I exposed an admin-only settings route that provides status information related to the configured API key:
1. Whether the key is valid or rejected
2. Remaining credits associated with the key
3. Remaining limit (per hour, according to the GlobalPing API documentation)

This information could later be used to further enhance the integration. For example:
- Defining a threshold for notifications
- Creating an incident when credits are low or exhausted

I + AI also refactored GlobalPingService to some extent to improve readability and structure due to the additional logic introduced by the feature. Everything related to GlobalPing appears to function as expected.

I did my best to align the implementation as closely as possible with the existing codebase, so please be gentle — this is my first PR 🙂

Let me know if there are improvements I could make or if there is anything I might have missed. Any feedback is appreciated.

## Write your issue number after "Fixes "
Partially Fixes #3413

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.

