### PR TITLE
fix: updating swagger for createMonitor and /monitor/teams

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -511,41 +511,23 @@
 				"description": "Get monitors filtered by team with optional parameters",
 				"parameters": [
 					{
-						"name": "status",
-						"in": "query",
-						"description": "Filter by monitor status (up/down)",
-						"schema": {
-							"type": "boolean"
-						}
-					},
-					{
 						"name": "type",
 						"in": "query",
 						"description": "Filter by monitor type",
 						"schema": {
-							"type": "string",
-							"enum": ["http", "ping", "pagespeed", "hardware", "docker", "port"]
-						}
-					},
-					{
-						"name": "page",
-						"in": "query",
-						"description": "Page number for pagination",
-						"schema": {
-							"type": "integer",
-							"minimum": 1,
-							"default": 1
-						}
-					},
-					{
-						"name": "rowsPerPage",
-						"in": "query",
-						"description": "Number of monitors per page",
-						"schema": {
-							"type": "integer",
-							"minimum": 1,
-							"maximum": 100,
-							"default": 10
+							"oneOf": [
+								{
+									"type": "string",
+									"enum": ["http", "ping", "pagespeed", "docker", "hardware", "port", "game", "grpc", "websocket"]
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": ["http", "ping", "pagespeed", "docker", "hardware", "port", "game", "grpc", "websocket"]
+									}
+								}
+							]
 						}
 					},
 					{
@@ -554,15 +536,6 @@
 						"description": "Search filter value",
 						"schema": {
 							"type": "string"
-						}
-					},
-					{
-						"name": "field",
-						"in": "query",
-						"description": "Field to filter on",
-						"schema": {
-							"type": "string",
-							"enum": ["name", "url", "description"]
 						}
 					}
 				],
@@ -3568,22 +3541,19 @@
 			},
 			"CreateMonitorRequest": {
 				"type": "object",
-				"required": ["name", "description", "type", "url", "interval"],
+				"required": ["name", "type", "url"],
 				"properties": {
 					"name": {
 						"type": "string",
-						"minLength": 1,
-						"maxLength": 100,
 						"example": "My Website Monitor"
 					},
 					"description": {
 						"type": "string",
-						"maxLength": 500,
 						"example": "Monitors the main website homepage"
 					},
 					"type": {
 						"type": "string",
-						"enum": ["http", "ping", "pagespeed", "hardware", "docker", "port"],
+						"enum": ["http", "ping", "pagespeed", "hardware", "docker", "port", "game", "grpc", "websocket"],
 						"example": "http"
 					},
 					"url": {
@@ -3593,14 +3563,34 @@
 					},
 					"interval": {
 						"type": "integer",
-						"minimum": 30,
-						"maximum": 3600,
 						"example": 300,
 						"description": "Check interval in seconds"
 					},
+					"statusWindowSize": {
+						"type": "integer",
+						"minimum": 1,
+						"maximum": 20,
+						"default": 5
+					},
+					"statusWindowThreshold": {
+						"type": "integer",
+						"minimum": 1,
+						"maximum": 100,
+						"default": 60
+					},
 					"isActive": {
+						"type": "boolean"
+					},
+					"ignoreTlsErrors": {
 						"type": "boolean",
-						"default": true
+						"default": false
+					},
+					"useAdvancedMatching": {
+						"type": "boolean",
+						"default": false
+					},
+					"port": {
+						"type": "integer"
 					},
 					"notifications": {
 						"type": "array",
@@ -3609,51 +3599,62 @@
 						},
 						"description": "Array of notification IDs to associate with this monitor"
 					},
-					"httpOptions": {
-						"type": "object",
-						"properties": {
-							"method": {
-								"type": "string",
-								"enum": ["GET", "POST", "PUT", "DELETE", "HEAD"],
-								"default": "GET"
-							},
-							"headers": {
-								"type": "object",
-								"additionalProperties": {
-									"type": "string"
-								}
-							},
-							"body": {
-								"type": "string",
-								"description": "Request body for POST/PUT requests"
-							},
-							"timeout": {
-								"type": "integer",
-								"minimum": 1000,
-								"maximum": 30000,
-								"default": 5000,
-								"description": "Request timeout in milliseconds"
-							}
-						}
+					"secret": {
+						"type": "string"
 					},
-					"assertions": {
+					"jsonPath": {
+						"type": "string"
+					},
+					"expectedValue": {
+						"type": "string"
+					},
+					"matchMethod": {
+						"type": "string",
+						"enum": ["equal", "include", "regex", ""]
+					},
+					"cpuAlertThreshold": {
+						"type": "number"
+					},
+					"memoryAlertThreshold": {
+						"type": "number"
+					},
+					"diskAlertThreshold": {
+						"type": "number"
+					},
+					"tempAlertThreshold": {
+						"type": "number"
+					},
+					"gameId": {
+						"type": "string"
+					},
+					"grpcServiceName": {
+						"type": "string",
+						"default": ""
+					},
+					"selectedDisks": {
 						"type": "array",
 						"items": {
-							"type": "object",
-							"properties": {
-								"type": {
-									"type": "string",
-									"enum": ["status-code", "response-time", "body-contains", "header-contains"]
-								},
-								"comparison": {
-									"type": "string",
-									"enum": ["equals", "not-equals", "greater-than", "less-than", "contains", "not-contains"]
-								},
-								"value": {
-									"type": "string"
-								}
-							}
+							"type": "string"
 						}
+					},
+					"group": {
+						"type": "string",
+						"nullable": true,
+						"maxLength": 50
+					},
+					"geoCheckEnabled": {
+						"type": "boolean"
+					},
+					"geoCheckLocations": {
+						"type": "array",
+						"items": {
+							"type": "string",
+							"enum": ["northAmerica", "southAmerica", "europe", "asia", "africa", "oceania"]
+						}
+					},
+					"geoCheckInterval": {
+						"type": "integer",
+						"minimum": 300000
 					}
 				}
 			},


### PR DESCRIPTION
Modifications for fixing swagger for create monitor and GET /monitors/teams

Fixes #3355 , #3354 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [ ] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

