### PR TITLE
fix: language selector not applying on auth pages

### DIFF
--- a/client/src/Components/inputs/LanguageSelector.tsx
+++ b/client/src/Components/inputs/LanguageSelector.tsx
@@ -26,6 +26,7 @@ export const LanguageSelector = () => {
 	const handleChange = (event: any) => {
 		const newLang = event.target.value;
 		dispatch(setLanguage(newLang));
+		i18n.changeLanguage(newLang); // ← added this line to change the language in i18n as well
 	};
 
 	const languages = Object.keys(i18n.options.resources || {});

--- a/client/src/locales/ar.json
+++ b/client/src/locales/ar.json
@@ -1104,5 +1104,41 @@
 	"packetsReceivedRate": "",
 	"packetsSent": "",
 	"rate": "",
-	"selectInterface": ""
+	"selectInterface": "",
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "البريد الإلكتروني", "placeholder": "me@example.com" },
+						"password": { "label": "كلمة المرور", "placeholder": "********" },
+						"confirmPassword": { "label": "تأكيد كلمة المرور" }
+					}
+				}
+			},
+			"login": {
+				"title": "مرحباً بعودتك إلى Checkmate!",
+				"subtitle": "سجّل الدخول للمتابعة",
+				"submit": "تسجيل الدخول",
+				"links": {
+					"forgotPassword": {
+						"text": "نسيت كلمة المرور؟",
+						"linkText": "إعادة تعيين كلمة المرور"
+					},
+					"register": { "text": "ليس لديك حساب؟", "linkText": "سجّل هنا" }
+				}
+			},
+			"forgotPassword": {
+				"title": "نسيت كلمة المرور؟",
+				"subtitle": "لا تقلق، سنرسل لك تعليمات إعادة التعيين.",
+				"submit": "طلب استرداد",
+				"links": { "login": { "text": "العودة إلى", "linkText": "تسجيل الدخول" } }
+			},
+			"register": {
+				"title": "مرحباً بك في Checkmate!",
+				"subtitle": "سجّل للبدء",
+				"submit": "تسجيل"
+			}
+		}
+	}
 }

--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -1104,5 +1104,41 @@
 	"packetsReceivedRate": "",
 	"packetsSent": "",
 	"rate": "",
-	"selectInterface": ""
+	"selectInterface": "",
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "E-mail", "placeholder": "me@example.com" },
+						"password": { "label": "Heslo", "placeholder": "********" },
+						"confirmPassword": { "label": "Potvrzení hesla" }
+					}
+				}
+			},
+			"login": {
+				"title": "Vítejte zpět v Checkmate!",
+				"subtitle": "Přihlaste se pro pokračování",
+				"submit": "Přihlásit se",
+				"links": {
+					"forgotPassword": {
+						"text": "Zapomněli jste heslo?",
+						"linkText": "Obnovit heslo"
+					},
+					"register": { "text": "Ještě nemáte účet?", "linkText": "Zaregistrujte se zde" }
+				}
+			},
+			"forgotPassword": {
+				"title": "Zapomenuté heslo?",
+				"subtitle": "Nebojte se, zašleme vám pokyny pro obnovení hesla.",
+				"submit": "Požádat o obnovení",
+				"links": { "login": { "text": "Vrátit se na", "linkText": "přihlášení" } }
+			},
+			"register": {
+				"title": "Vítejte v Checkmate!",
+				"subtitle": "Zaregistrujte se a začněte",
+				"submit": "Registrovat"
+			}
+		}
+	}
 }

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -1136,5 +1136,41 @@
 			"disk_selection_info": "Momentan wurde keine Festplatte erkannt.",
 			"disk_selection_description": "Wählen Sie die spezifischen Festplatten aus, die Sie überwachen möchten."
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Email", "placeholder": "me@example.com" },
+						"password": { "label": "Passwort", "placeholder": "********" },
+						"confirmPassword": { "label": "Passwort bestätigen" }
+					}
+				}
+			},
+			"login": {
+				"title": "Willkommen zurück bei Checkmate!",
+				"subtitle": "Einloggen um fortzufahren",
+				"submit": "Anmelden",
+				"links": {
+					"forgotPassword": {
+						"text": "Passwort vergessen?",
+						"linkText": "Passwort zurücksetzen"
+					},
+					"register": { "text": "Noch keinen Account?", "linkText": "Hier registrieren" }
+				}
+			},
+			"forgotPassword": {
+				"title": "Passwort vergessen?",
+				"subtitle": "Kein Problem, wir senden Ihnen Anweisungen zum Zurücksetzen.",
+				"submit": "Wiederherstellung anfordern",
+				"links": { "login": { "text": "Zurück zur", "linkText": "Anmeldung" } }
+			},
+			"register": {
+				"title": "Willkommen bei Checkmate!",
+				"subtitle": "Registrieren Sie sich um zu beginnen",
+				"submit": "Registrieren"
+			}
+		}
 	}
 }

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -1104,5 +1104,41 @@
 	"packetsReceivedRate": "",
 	"packetsSent": "",
 	"rate": "",
-	"selectInterface": ""
+	"selectInterface": "",
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Correo electrónico", "placeholder": "me@example.com" },
+						"password": { "label": "Contraseña", "placeholder": "********" },
+						"confirmPassword": { "label": "Confirmar contraseña" }
+					}
+				}
+			},
+			"login": {
+				"title": "¡Bienvenido de nuevo a Checkmate!",
+				"subtitle": "Inicia sesión para continuar",
+				"submit": "Iniciar sesión",
+				"links": {
+					"forgotPassword": {
+						"text": "¿Olvidaste tu contraseña?",
+						"linkText": "Restablecer contraseña"
+					},
+					"register": { "text": "¿No tienes cuenta?", "linkText": "Regístrate aquí" }
+				}
+			},
+			"forgotPassword": {
+				"title": "¿Olvidaste tu contraseña?",
+				"subtitle": "No te preocupes, te enviaremos instrucciones para restablecerla.",
+				"submit": "Solicitar recuperación",
+				"links": { "login": { "text": "Volver a", "linkText": "iniciar sesión" } }
+			},
+			"register": {
+				"title": "¡Bienvenido a Checkmate!",
+				"subtitle": "Regístrate para comenzar",
+				"submit": "Registrarse"
+			}
+		}
+	}
 }

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -1104,5 +1104,41 @@
 	"packetsReceivedRate": "",
 	"packetsSent": "",
 	"rate": "",
-	"selectInterface": ""
+	"selectInterface": "",
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Sähköposti", "placeholder": "me@example.com" },
+						"password": { "label": "Salasana", "placeholder": "********" },
+						"confirmPassword": { "label": "Vahvista salasana" }
+					}
+				}
+			},
+			"login": {
+				"title": "Tervetuloa takaisin Checkmaten!",
+				"subtitle": "Kirjaudu sisään jatkaaksesi",
+				"submit": "Kirjaudu sisään",
+				"links": {
+					"forgotPassword": {
+						"text": "Unohditko salasanasi?",
+						"linkText": "Palauta salasana"
+					},
+					"register": { "text": "Ei tiliä?", "linkText": "Rekisteröidy tästä" }
+				}
+			},
+			"forgotPassword": {
+				"title": "Unohditko salasanasi?",
+				"subtitle": "Ei hätää, lähetämme sinulle ohjeet palautusta varten.",
+				"submit": "Pyydä palautusta",
+				"links": { "login": { "text": "Takaisin", "linkText": "kirjautumiseen" } }
+			},
+			"register": {
+				"title": "Tervetuloa Checkmateen!",
+				"subtitle": "Rekisteröidy aloittaaksesi",
+				"submit": "Rekisteröidy"
+			}
+		}
+	}
 }

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -1136,5 +1136,44 @@
 			"disk_selection_info": "Aucun disque détecté pour le moment.",
 			"disk_selection_description": "Sélectionnez les disques spécifiques que vous souhaitez surveiller."
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Email", "placeholder": "me@example.com" },
+						"password": { "label": "Mot de passe", "placeholder": "********" },
+						"confirmPassword": { "label": "Confirmer le mot de passe" }
+					}
+				}
+			},
+			"login": {
+				"title": "Bon retour sur Checkmate !",
+				"subtitle": "Connectez-vous pour continuer",
+				"submit": "Connexion",
+				"links": {
+					"forgotPassword": {
+						"text": "Mot de passe oublié ?",
+						"linkText": "Réinitialiser le mot de passe"
+					},
+					"register": {
+						"text": "Pas encore de compte ?",
+						"linkText": "Inscrivez-vous ici"
+					}
+				}
+			},
+			"forgotPassword": {
+				"title": "Mot de passe oublié ?",
+				"subtitle": "Pas d'inquiétude, nous allons vous envoyer des instructions pour réinitialiser votre mot de passe.",
+				"submit": "Demander une récupération",
+				"links": { "login": { "text": "Retourner à la", "linkText": "connexion" } }
+			},
+			"register": {
+				"title": "Bienvenue sur Checkmate !",
+				"subtitle": "Inscrivez-vous pour commencer",
+				"submit": "S'inscrire"
+			}
+		}
 	}
 }

--- a/client/src/locales/ja.json
+++ b/client/src/locales/ja.json
@@ -1115,5 +1115,44 @@
 			"disk_selection_info": "現在ディスクが検出されていません。",
 			"disk_selection_description": "監視したい特定のディスクを選択してください。"
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "メール", "placeholder": "me@example.com" },
+						"password": { "label": "パスワード", "placeholder": "********" },
+						"confirmPassword": { "label": "パスワードの確認" }
+					}
+				}
+			},
+			"login": {
+				"title": "Checkmateへようこそ！",
+				"subtitle": "続けるにはログインしてください",
+				"submit": "ログイン",
+				"links": {
+					"forgotPassword": {
+						"text": "パスワードをお忘れですか？",
+						"linkText": "パスワードをリセット"
+					},
+					"register": {
+						"text": "アカウントをお持ちでないですか？",
+						"linkText": "こちらで登録"
+					}
+				}
+			},
+			"forgotPassword": {
+				"title": "パスワードをお忘れですか？",
+				"subtitle": "ご心配なく、リセット手順をお送りします。",
+				"submit": "回復をリクエスト",
+				"links": { "login": { "text": "戻る", "linkText": "ログイン" } }
+			},
+			"register": {
+				"title": "Checkmateへようこそ！",
+				"subtitle": "登録して始めましょう",
+				"submit": "登録"
+			}
+		}
 	}
 }

--- a/client/src/locales/pt-BR.json
+++ b/client/src/locales/pt-BR.json
@@ -1136,5 +1136,41 @@
 			"disk_selection_info": "Nenhum disco detectado no momento.",
 			"disk_selection_description": "Selecione os discos específicos que você deseja monitorar."
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Email", "placeholder": "me@example.com" },
+						"password": { "label": "Senha", "placeholder": "********" },
+						"confirmPassword": { "label": "Confirmar senha" }
+					}
+				}
+			},
+			"login": {
+				"title": "Bem-vindo de volta ao Checkmate!",
+				"subtitle": "Entre para continuar",
+				"submit": "Entrar",
+				"links": {
+					"forgotPassword": {
+						"text": "Esqueceu sua senha?",
+						"linkText": "Redefinir senha"
+					},
+					"register": { "text": "Não tem uma conta?", "linkText": "Registre-se aqui" }
+				}
+			},
+			"forgotPassword": {
+				"title": "Esqueceu sua senha?",
+				"subtitle": "Não se preocupe, enviaremos instruções de redefinição.",
+				"submit": "Solicitar recuperação",
+				"links": { "login": { "text": "Voltar para o", "linkText": "login" } }
+			},
+			"register": {
+				"title": "Bem-vindo ao Checkmate!",
+				"subtitle": "Registre-se para começar",
+				"submit": "Registrar"
+			}
+		}
 	}
 }

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -1136,5 +1136,38 @@
 			"disk_selection_info": "На данный момент диск не обнаружен.",
 			"disk_selection_description": "Выберите конкретные диски, которые вы хотите отслеживать."
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Электронная почта", "placeholder": "me@example.com" },
+						"password": { "label": "Пароль", "placeholder": "********" },
+						"confirmPassword": { "label": "Подтвердите пароль" }
+					}
+				}
+			},
+			"login": {
+				"title": "Добро пожаловать обратно в Checkmate!",
+				"subtitle": "Войдите, чтобы продолжить",
+				"submit": "Войти",
+				"links": {
+					"forgotPassword": { "text": "Забыли пароль?", "linkText": "Сбросить пароль" },
+					"register": { "text": "Нет аккаунта?", "linkText": "Зарегистрируйтесь здесь" }
+				}
+			},
+			"forgotPassword": {
+				"title": "Забыли пароль?",
+				"subtitle": "Не волнуйтесь, мы вышлем вам инструкции для сброса.",
+				"submit": "Запросить восстановление",
+				"links": { "login": { "text": "Вернуться к", "linkText": "входу" } }
+			},
+			"register": {
+				"title": "Добро пожаловать в Checkmate!",
+				"subtitle": "Зарегистрируйтесь, чтобы начать",
+				"submit": "Зарегистрироваться"
+			}
+		}
 	}
 }

--- a/client/src/locales/th.json
+++ b/client/src/locales/th.json
@@ -1136,5 +1136,38 @@
 			"disk_selection_info": "ไม่พบดิสก์ในขณะนี้",
 			"disk_selection_description": "เลือกดิสก์ที่คุณต้องการตรวจสอบ"
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "อีเมล", "placeholder": "me@example.com" },
+						"password": { "label": "รหัสผ่าน", "placeholder": "********" },
+						"confirmPassword": { "label": "ยืนยันรหัสผ่าน" }
+					}
+				}
+			},
+			"login": {
+				"title": "ยินดีต้อนรับกลับสู่ Checkmate!",
+				"subtitle": "เข้าสู่ระบบเพื่อดำเนินการต่อ",
+				"submit": "เข้าสู่ระบบ",
+				"links": {
+					"forgotPassword": { "text": "ลืมรหัสผ่าน?", "linkText": "รีเซ็ตรหัสผ่าน" },
+					"register": { "text": "ยังไม่มีบัญชี?", "linkText": "สมัครสมาชิกที่นี่" }
+				}
+			},
+			"forgotPassword": {
+				"title": "ลืมรหัสผ่าน?",
+				"subtitle": "ไม่ต้องกังวล เราจะส่งคำแนะนำในการรีเซ็ตให้คุณ",
+				"submit": "ขอการกู้คืน",
+				"links": { "login": { "text": "กลับไป", "linkText": "เข้าสู่ระบบ" } }
+			},
+			"register": {
+				"title": "ยินดีต้อนรับสู่ Checkmate!",
+				"subtitle": "สมัครสมาชิกเพื่อเริ่มต้น",
+				"submit": "สมัครสมาชิก"
+			}
+		}
 	}
 }

--- a/client/src/locales/tr.json
+++ b/client/src/locales/tr.json
@@ -1104,5 +1104,41 @@
 	"packetsReceivedRate": "",
 	"packetsSent": "",
 	"rate": "",
-	"selectInterface": ""
+	"selectInterface": "",
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Eposta", "placeholder": "me@example.com" },
+						"password": { "label": "Parola", "placeholder": "********" },
+						"confirmPassword": { "label": "Parolayı onayla" }
+					}
+				}
+			},
+			"login": {
+				"title": "Checkmate'e tekrar hoşgeldiniz!",
+				"subtitle": "Devam etmek için giriş yapın",
+				"submit": "Giriş yap",
+				"links": {
+					"forgotPassword": {
+						"text": "Parolanızı mı unuttunuz?",
+						"linkText": "Parolayı sıfırla"
+					},
+					"register": { "text": "Hesabınız yok mu?", "linkText": "Buradan kayıt olun" }
+				}
+			},
+			"forgotPassword": {
+				"title": "Parolanızı mı unuttunuz?",
+				"subtitle": "Endişelenmeyin, sıfırlama talimatları göndereceğiz.",
+				"submit": "Kurtarma talep et",
+				"links": { "login": { "text": "Geri dön", "linkText": "giriş" } }
+			},
+			"register": {
+				"title": "Checkmate'e hoşgeldiniz!",
+				"subtitle": "Başlamak için kayıt olun",
+				"submit": "Kayıt ol"
+			}
+		}
+	}
 }

--- a/client/src/locales/uk.json
+++ b/client/src/locales/uk.json
@@ -834,5 +834,41 @@
 			"selectEnabled": "",
 			"title": ""
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Електронна пошта", "placeholder": "me@example.com" },
+						"password": { "label": "Пароль", "placeholder": "********" },
+						"confirmPassword": { "label": "Підтвердіть пароль" }
+					}
+				}
+			},
+			"login": {
+				"title": "Ласкаво просимо назад до Checkmate!",
+				"subtitle": "Увійдіть, щоб продовжити",
+				"submit": "Увійти",
+				"links": {
+					"forgotPassword": { "text": "Забули пароль?", "linkText": "Скинути пароль" },
+					"register": {
+						"text": "Немає облікового запису?",
+						"linkText": "Зареєструйтесь тут"
+					}
+				}
+			},
+			"forgotPassword": {
+				"title": "Забули пароль?",
+				"subtitle": "Не хвилюйтесь, ми надішлемо інструкції для скидання.",
+				"submit": "Запросити відновлення",
+				"links": { "login": { "text": "Повернутись до", "linkText": "входу" } }
+			},
+			"register": {
+				"title": "Ласкаво просимо до Checkmate!",
+				"subtitle": "Зареєструйтесь, щоб почати",
+				"submit": "Зареєструватись"
+			}
+		}
 	}
 }

--- a/client/src/locales/vi.json
+++ b/client/src/locales/vi.json
@@ -834,5 +834,38 @@
 			"selectEnabled": "",
 			"title": ""
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "Email", "placeholder": "me@example.com" },
+						"password": { "label": "Mật khẩu", "placeholder": "********" },
+						"confirmPassword": { "label": "Xác nhận mật khẩu" }
+					}
+				}
+			},
+			"login": {
+				"title": "Chào mừng trở lại Checkmate!",
+				"subtitle": "Đăng nhập để tiếp tục",
+				"submit": "Đăng nhập",
+				"links": {
+					"forgotPassword": { "text": "Quên mật khẩu?", "linkText": "Đặt lại mật khẩu" },
+					"register": { "text": "Chưa có tài khoản?", "linkText": "Đăng ký tại đây" }
+				}
+			},
+			"forgotPassword": {
+				"title": "Quên mật khẩu?",
+				"subtitle": "Đừng lo, chúng tôi sẽ gửi hướng dẫn đặt lại cho bạn.",
+				"submit": "Yêu cầu khôi phục",
+				"links": { "login": { "text": "Quay lại", "linkText": "đăng nhập" } }
+			},
+			"register": {
+				"title": "Chào mừng đến với Checkmate!",
+				"subtitle": "Đăng ký để bắt đầu",
+				"submit": "Đăng ký"
+			}
+		}
 	}
 }

--- a/client/src/locales/zh-CN.json
+++ b/client/src/locales/zh-CN.json
@@ -1128,5 +1128,38 @@
 			"disk_selection_info": "目前没有检测到磁盘。",
 			"disk_selection_description": "选择您要监控的特定磁盘。"
 		}
+	},
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "电子邮件", "placeholder": "me@example.com" },
+						"password": { "label": "密码", "placeholder": "********" },
+						"confirmPassword": { "label": "确认密码" }
+					}
+				}
+			},
+			"login": {
+				"title": "欢迎回到 Checkmate！",
+				"subtitle": "登录以继续",
+				"submit": "登录",
+				"links": {
+					"forgotPassword": { "text": "忘记密码？", "linkText": "重置密码" },
+					"register": { "text": "没有账号？", "linkText": "在此注册" }
+				}
+			},
+			"forgotPassword": {
+				"title": "忘记密码？",
+				"subtitle": "别担心，我们会发送重置说明给您。",
+				"submit": "请求恢复",
+				"links": { "login": { "text": "返回", "linkText": "登录" } }
+			},
+			"register": {
+				"title": "欢迎来到 Checkmate！",
+				"subtitle": "注册以开始使用",
+				"submit": "注册"
+			}
+		}
 	}
 }

--- a/client/src/locales/zh-TW.json
+++ b/client/src/locales/zh-TW.json
@@ -1108,5 +1108,38 @@
 	"packetsReceivedRate": "",
 	"packetsSent": "",
 	"rate": "",
-	"selectInterface": ""
+	"selectInterface": "",
+	"pages": {
+		"auth": {
+			"common": {
+				"form": {
+					"option": {
+						"email": { "label": "電子郵件", "placeholder": "me@example.com" },
+						"password": { "label": "密碼", "placeholder": "********" },
+						"confirmPassword": { "label": "確認密碼" }
+					}
+				}
+			},
+			"login": {
+				"title": "歡迎回到 Checkmate！",
+				"subtitle": "登入以繼續",
+				"submit": "登入",
+				"links": {
+					"forgotPassword": { "text": "忘記密碼？", "linkText": "重設密碼" },
+					"register": { "text": "還沒有帳號？", "linkText": "在此註冊" }
+				}
+			},
+			"forgotPassword": {
+				"title": "忘記密碼？",
+				"subtitle": "別擔心，我們會發送重設說明給您。",
+				"submit": "請求恢復",
+				"links": { "login": { "text": "返回", "linkText": "登入" } }
+			},
+			"register": {
+				"title": "歡迎來到 Checkmate！",
+				"subtitle": "註冊以開始使用",
+				"submit": "註冊"
+			}
+		}
+	}
 }


### PR DESCRIPTION
…uage selector

## Describe your changes

The language selector on the welcome/login screen was not applying the selected language. Added i18n.changeLanguage(newLang) to LanguageSelector.tsx so the UI updates immediately when a language is selected. Also added missing pages.auth translation keys to all locale files (ar, cs, de, es, fi, fr, ja, pt-BR, ru, th, tr, uk, vi, zh-CN, zh-TW) which were causing the login page to display raw translation keys instead of translated text.

## Write your issue number after "Fixes "

Fixes #3440

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue #3440 in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1867" height="840" alt="image" src="https://github.com/user-attachments/assets/8db8414c-ff4f-4585-b031-9e9968cdf555" />
<img width="1860" height="948" alt="image" src="https://github.com/user-attachments/assets/b6570e35-204f-4592-bde8-5ea895cb3709" />
<img width="1862" height="867" alt="image" src="https://github.com/user-attachments/assets/bbb388ba-9e57-4cdf-828f-c489a5c7ffea" />
<img width="1862" height="907" alt="image" src="https://github.com/user-attachments/assets/bb972698-f884-4048-9383-773ec88bee24" />
<img width="1863" height="862" alt="image" src="https://github.com/user-attachments/assets/b563be7c-5730-4323-98b4-12b34149fd8f" />
<img width="1856" height="936" alt="image" src="https://github.com/user-attachments/assets/8c28ba83-96a2-4fc3-8913-5274f43d3563" />
<img width="1862" height="870" alt="image" src="https://github.com/user-attachments/assets/50b265b8-a333-4199-9121-92d18677ec64" />
<img width="1860" height="912" alt="image" src="https://github.com/user-attachments/assets/de660503-4915-42d1-8d73-a9af82a951f7" />
<img width="1863" height="895" alt="image" src="https://github.com/user-attachments/assets/f838aed3-2c2e-4fc6-8f23-7462e9223509" />
<img width="1852" height="880" alt="image" src="https://github.com/user-attachments/assets/33b08808-dab6-467d-b976-70ce5a823241" />
<img width="1868" height="915" alt="image" src="https://github.com/user-attachments/assets/5ee0a8dc-6407-4b98-b4d0-2a3e13ceb305" />
<img width="1855" height="921" alt="image" src="https://github.com/user-attachments/assets/73103579-a290-4430-96a8-2d70b1a54a24" />
<img width="1862" height="888" alt="image" src="https://github.com/user-attachments/assets/76625fe7-f629-48d2-abc2-f9a5947c7b5e" />
<img width="1857" height="890" alt="image" src="https://github.com/user-attachments/assets/265d5724-feb0-476e-93fb-31e0bb3b4571" />
<img width="1861" height="907" alt="image" src="https://github.com/user-attachments/assets/47c4b528-927a-41fc-bc12-4f1fdac03b0b" />
