### PR TITLE
Feat(DLQ): Add DLQ service with retry logic and scheduler integration

### DIFF
--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -49,6 +49,8 @@ import {
 	ISettingsService,
 	SettingsService,
 	EnvConfig,
+	DLQService,
+	IDLQService,
 } from "@/service/index.js";
 
 // Network providers
@@ -124,6 +126,8 @@ import {
 	IIncidentsRepository,
 	ITeamsRepository,
 	IMaintenanceWindowsRepository,
+	MongoDLQRepository,
+	IDLQRepository,
 } from "@/repositories/index.js";
 import { ILogger } from "@/utils/logger.js";
 import TimescaleDB from "@/db/TimescaleDB.js";
@@ -149,6 +153,7 @@ export type InitializedServices = {
 	notificationsService: INotificationsService;
 	statusPageService: IStatusPageService;
 	notificationMessageBuilder: INotificationMessageBuilder;
+	dlqService: IDLQService;
 
 	// Repositories
 	monitorsRepository: IMonitorsRepository;
@@ -206,6 +211,7 @@ export const initializeServices = async ({
 	let incidentsRepository: IIncidentsRepository;
 	let teamsRepository: ITeamsRepository;
 	let maintenanceWindowsRepository: IMaintenanceWindowsRepository;
+	let dlqRepository: IDLQRepository;
 
 	// Repositories
 
@@ -223,6 +229,7 @@ export const initializeServices = async ({
 		incidentsRepository = new MongoIncidentsRepository();
 		teamsRepository = new MongoTeamsRepository();
 		maintenanceWindowsRepository = new MongoMaintenanceWindowsRepository();
+		dlqRepository = new MongoDLQRepository();
 	} else {
 		const pool = db.getPool();
 		if (!pool) {
@@ -241,6 +248,7 @@ export const initializeServices = async ({
 		incidentsRepository = new TimescaleIncidentsRepository(pool);
 		teamsRepository = new TimescaleTeamsRepository(pool);
 		maintenanceWindowsRepository = new TimescaleMaintenanceWindowsRepository(pool);
+		dlqRepository = new MongoDLQRepository(); // TODO: Replace with TimescaleDLQRepository(pool) once implemented
 	}
 
 	// Inject settings repository into settings service (now that DB is connected)
@@ -315,6 +323,8 @@ export const initializeServices = async ({
 		notificationMessageBuilder
 	);
 
+	const dlqService = new DLQService(dlqRepository, notificationsService, incidentService, monitorsRepository, logger);
+
 	const superSimpleQueueHelper = new SuperSimpleQueueHelper(
 		logger,
 		networkService,
@@ -331,7 +341,8 @@ export const initializeServices = async ({
 		checksRepository,
 		incidentsRepository,
 		geoChecksService,
-		geoChecksRepository
+		geoChecksRepository,
+		dlqService
 	);
 
 	const superSimpleQueue = await SuperSimpleQueue.create(logger, superSimpleQueueHelper, monitorsRepository);
@@ -397,6 +408,7 @@ export const initializeServices = async ({
 		notificationsService,
 		statusPageService,
 		notificationMessageBuilder,
+		dlqService,
 
 		// Repositories
 		monitorsRepository,

--- a/server/src/service/index.ts
+++ b/server/src/service/index.ts
@@ -19,6 +19,7 @@ export * from "@/service/infrastructure/globalPingService.js";
 export * from "@/service/infrastructure/networkService.js";
 export * from "@/service/infrastructure/notificationsService.js";
 export * from "@/service/infrastructure/statusService.js";
+export * from "@/service/infrastructure/dlqService.js";
 
 // Notification providers
 export * from "@/service/infrastructure/notificationProviders/discord.js";

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
@@ -93,6 +93,8 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 			this.scheduler.addTemplate("geo-check-job", this.helper.getHeartbeatGeoJob());
 			this.scheduler.addTemplate("cleanup-orphaned", this.helper.getCleanupOrphanedJob());
 			this.scheduler.addTemplate("cleanup-retention-job", this.helper.getCleanupRetentionJob());
+			this.scheduler.addTemplate("dlq-retry-job", this.helper.getDLQRetryJob());
+			this.scheduler.addTemplate("dlq-cleanup-job", this.helper.getDLQCleanupJob());
 			const monitors = await this.monitorsRepository.findAll();
 			if (!monitors) {
 				return true;
@@ -106,6 +108,8 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 
 			this.scheduler.addJob({ id: "cleanup-orphaned", template: "cleanup-orphaned", active: true });
 			this.scheduler.addJob({ id: "cleanup-retention", template: "cleanup-retention-job", active: true, repeat: 24 * 60 * 60 * 1000 });
+			this.scheduler.addJob({ id: "dlq-retry", template: "dlq-retry-job", active: true, repeat: 30 * 1000 });
+			this.scheduler.addJob({ id: "dlq-cleanup", template: "dlq-cleanup-job", active: true, repeat: 24 * 60 * 60 * 1000 });
 
 			return true;
 		} catch (error: unknown) {

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -10,6 +10,7 @@ import {
 	IStatusService,
 	IncidentService,
 	type IGeoChecksService,
+	type IDLQService,
 } from "@/service/index.js";
 import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
 import {
@@ -30,6 +31,8 @@ export interface ISuperSimpleQueueHelper {
 	getHeartbeatGeoJob(): (monitor: Monitor) => Promise<void>;
 	getCleanupOrphanedJob(): () => Promise<void>;
 	getCleanupRetentionJob(): () => Promise<void>;
+	getDLQRetryJob(): () => Promise<void>;
+	getDLQCleanupJob(): () => Promise<void>;
 	isInMaintenanceWindow(monitorId: string, teamId: string): Promise<boolean>;
 }
 
@@ -66,6 +69,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	private incidentsRepository: IIncidentsRepository;
 	private geoChecksService: IGeoChecksService;
 	private geoChecksRepository: IGeoChecksRepository;
+	private dlqService: IDLQService;
 
 	constructor(
 		logger: ILogger,
@@ -83,7 +87,8 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		checksRepository: IChecksRepository,
 		incidentsRepository: IIncidentsRepository,
 		geoChecksService: IGeoChecksService,
-		geoChecksRepository: IGeoChecksRepository
+		geoChecksRepository: IGeoChecksRepository,
+		dlqService: IDLQService
 	) {
 		this.logger = logger;
 		this.networkService = networkService;
@@ -101,6 +106,7 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		this.incidentsRepository = incidentsRepository;
 		this.geoChecksService = geoChecksService;
 		this.geoChecksRepository = geoChecksRepository;
+		this.dlqService = dlqService;
 	}
 
 	get serviceName() {
@@ -165,6 +171,21 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 							method: "getMonitorJob",
 							stack: error instanceof Error ? error.stack : undefined,
 						});
+						this.dlqService
+							.enqueue(
+								"notification",
+								{ monitor: statusChangeResult.monitor, monitorStatusResponse: status, decision },
+								monitorId,
+								teamId,
+								error instanceof Error ? error.message : "Unknown error"
+							)
+							.catch((dlqError: unknown) => {
+								this.logger.error({
+									message: `Failed to enqueue notification to DLQ: ${dlqError instanceof Error ? dlqError.message : "Unknown error"}`,
+									service: SERVICE_NAME,
+									method: "getMonitorJob",
+								});
+							});
 					});
 				}
 
@@ -176,6 +197,22 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 						method: "getMonitorJob",
 						stack: error instanceof Error ? error.stack : undefined,
 					});
+					const dlqType = decision.shouldResolveIncident ? "incident_resolve" : "incident_create";
+					this.dlqService
+						.enqueue(
+							dlqType,
+							{ monitor: statusChangeResult.monitor, code: statusChangeResult.code, decision, monitorStatusResponse: status },
+							monitorId,
+							teamId,
+							error instanceof Error ? error.message : "Unknown error"
+						)
+						.catch((dlqError: unknown) => {
+							this.logger.error({
+								message: `Failed to enqueue incident to DLQ: ${dlqError instanceof Error ? dlqError.message : "Unknown error"}`,
+								service: SERVICE_NAME,
+								method: "getMonitorJob",
+							});
+						});
 				});
 			} catch (error: unknown) {
 				this.logger.warn({
@@ -412,6 +449,43 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 					message: error instanceof Error ? error.message : "Unknown error",
 					service: SERVICE_NAME,
 					method: "getCleanupRetentionJob",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			}
+		};
+	};
+
+	getDLQRetryJob = () => {
+		return async () => {
+			try {
+				await this.dlqService.processRetries();
+			} catch (error: unknown) {
+				this.logger.error({
+					message: error instanceof Error ? error.message : "Unknown error",
+					service: SERVICE_NAME,
+					method: "getDLQRetryJob",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			}
+		};
+	};
+
+	getDLQCleanupJob = () => {
+		return async () => {
+			try {
+				const deleted = await this.dlqService.cleanup(7);
+				if (deleted > 0) {
+					this.logger.info({
+						message: `DLQ cleanup: removed ${deleted} expired items`,
+						service: SERVICE_NAME,
+						method: "getDLQCleanupJob",
+					});
+				}
+			} catch (error: unknown) {
+				this.logger.error({
+					message: error instanceof Error ? error.message : "Unknown error",
+					service: SERVICE_NAME,
+					method: "getDLQCleanupJob",
 					stack: error instanceof Error ? error.stack : undefined,
 				});
 			}

--- a/server/src/service/infrastructure/dlqService.ts
+++ b/server/src/service/infrastructure/dlqService.ts
@@ -38,13 +38,7 @@ export class DLQService implements IDLQService {
 		return DLQService.SERVICE_NAME;
 	}
 
-	enqueue = async (
-		type: DLQItemType,
-		payload: Record<string, unknown>,
-		monitorId: string,
-		teamId: string,
-		error: string
-	): Promise<DLQItem> => {
+	enqueue = async (type: DLQItemType, payload: Record<string, unknown>, monitorId: string, teamId: string, error: string): Promise<DLQItem> => {
 		const nextRetryAt = new Date(Date.now() + BASE_DELAY_MS).toISOString();
 		const item = await this.dlqRepository.create({
 			type,
@@ -151,10 +145,7 @@ export class DLQService implements IDLQService {
 	};
 
 	getItems = async (teamId: string, filters: DLQQueryFilters): Promise<{ items: DLQItem[]; count: number }> => {
-		const [items, count] = await Promise.all([
-			this.dlqRepository.findByTeamId(teamId, filters),
-			this.dlqRepository.countByTeamId(teamId),
-		]);
+		const [items, count] = await Promise.all([this.dlqRepository.findByTeamId(teamId, filters), this.dlqRepository.countByTeamId(teamId)]);
 		return { items, count };
 	};
 

--- a/server/src/service/infrastructure/dlqService.ts
+++ b/server/src/service/infrastructure/dlqService.ts
@@ -1,0 +1,230 @@
+const SERVICE_NAME = "DLQService";
+
+import type { DLQItem, DLQItemType } from "@/types/index.js";
+import type { IDLQRepository, DLQQueryFilters, DLQStatusCount } from "@/repositories/index.js";
+import type { INotificationsService } from "@/service/infrastructure/notificationsService.js";
+import type { IIncidentService } from "@/service/business/incidentService.js";
+import type { IMonitorsRepository } from "@/repositories/index.js";
+import type { ILogger } from "@/utils/logger.js";
+
+const BASE_DELAY_MS = 30_000;
+const MAX_DELAY_MS = 3_600_000;
+const DEFAULT_MAX_RETRIES = 5;
+const STALENESS_THRESHOLD_MS = 30 * 60 * 1000;
+const RETRY_BATCH_SIZE = 20;
+
+export interface IDLQService {
+	enqueue(type: DLQItemType, payload: Record<string, unknown>, monitorId: string, teamId: string, error: string): Promise<DLQItem>;
+	processRetries(): Promise<void>;
+	retryItem(id: string): Promise<DLQItem | null>;
+	getItems(teamId: string, filters: DLQQueryFilters): Promise<{ items: DLQItem[]; count: number }>;
+	getSummary(teamId: string): Promise<DLQStatusCount[]>;
+	purge(id: string, teamId: string): Promise<number>;
+	cleanup(ttlDays: number): Promise<number>;
+}
+
+export class DLQService implements IDLQService {
+	static SERVICE_NAME = SERVICE_NAME;
+
+	constructor(
+		private dlqRepository: IDLQRepository,
+		private notificationsService: INotificationsService,
+		private incidentService: IIncidentService,
+		private monitorsRepository: IMonitorsRepository,
+		private logger: ILogger
+	) {}
+
+	get serviceName() {
+		return DLQService.SERVICE_NAME;
+	}
+
+	enqueue = async (
+		type: DLQItemType,
+		payload: Record<string, unknown>,
+		monitorId: string,
+		teamId: string,
+		error: string
+	): Promise<DLQItem> => {
+		const nextRetryAt = new Date(Date.now() + BASE_DELAY_MS).toISOString();
+		const item = await this.dlqRepository.create({
+			type,
+			status: "pending",
+			payload,
+			monitorId,
+			teamId,
+			retryCount: 0,
+			maxRetries: DEFAULT_MAX_RETRIES,
+			lastError: error,
+			nextRetryAt,
+		});
+		this.logger.info({
+			message: `Enqueued DLQ item: type=${type} monitor=${monitorId}`,
+			service: SERVICE_NAME,
+			method: "enqueue",
+		});
+		return item;
+	};
+
+	processRetries = async (): Promise<void> => {
+		const items = await this.dlqRepository.findRetryable(RETRY_BATCH_SIZE);
+		if (items.length === 0) {
+			return;
+		}
+		this.logger.info({
+			message: `Processing ${items.length} DLQ items for retry`,
+			service: SERVICE_NAME,
+			method: "processRetries",
+		});
+		for (const item of items) {
+			try {
+				await this.executeRetry(item);
+				await this.dlqRepository.deleteById(item.id, item.teamId);
+				this.logger.info({
+					message: `DLQ item ${item.id} retried successfully, removed`,
+					service: SERVICE_NAME,
+					method: "processRetries",
+				});
+			} catch (error: unknown) {
+				const newRetryCount = item.retryCount + 1;
+				const errorMessage = error instanceof Error ? error.message : "Unknown error";
+
+				if (newRetryCount >= item.maxRetries) {
+					await this.dlqRepository.updateById(item.id, {
+						status: "failed",
+						retryCount: newRetryCount,
+						lastError: errorMessage,
+					});
+					this.logger.warn({
+						message: `DLQ item ${item.id} permanently failed after ${newRetryCount} retries`,
+						service: SERVICE_NAME,
+						method: "processRetries",
+					});
+				} else {
+					const delay = Math.min(BASE_DELAY_MS * Math.pow(2, newRetryCount), MAX_DELAY_MS);
+					const nextRetryAt = new Date(Date.now() + delay).toISOString();
+					await this.dlqRepository.updateById(item.id, {
+						status: "retrying",
+						retryCount: newRetryCount,
+						lastError: errorMessage,
+						nextRetryAt,
+					});
+					this.logger.debug({
+						message: `DLQ item ${item.id} retry ${newRetryCount}/${item.maxRetries} failed, next retry at ${nextRetryAt}`,
+						service: SERVICE_NAME,
+						method: "processRetries",
+					});
+				}
+			}
+		}
+	};
+
+	retryItem = async (id: string): Promise<DLQItem | null> => {
+		const item = await this.dlqRepository.findById(id);
+		if (!item) {
+			return null;
+		}
+		try {
+			await this.executeRetry(item);
+			await this.dlqRepository.deleteById(item.id, item.teamId);
+			this.logger.info({
+				message: `DLQ item ${id} manually retried successfully, removed`,
+				service: SERVICE_NAME,
+				method: "retryItem",
+			});
+			return item;
+		} catch (error: unknown) {
+			const newRetryCount = item.retryCount + 1;
+			const errorMessage = error instanceof Error ? error.message : "Unknown error";
+			const status = newRetryCount >= item.maxRetries ? "failed" : "retrying";
+			const updated = await this.dlqRepository.updateById(id, {
+				status,
+				retryCount: newRetryCount,
+				lastError: errorMessage,
+			});
+			this.logger.warn({
+				message: `DLQ item ${id} manual retry failed: ${errorMessage}`,
+				service: SERVICE_NAME,
+				method: "retryItem",
+			});
+			return updated;
+		}
+	};
+
+	getItems = async (teamId: string, filters: DLQQueryFilters): Promise<{ items: DLQItem[]; count: number }> => {
+		const [items, count] = await Promise.all([
+			this.dlqRepository.findByTeamId(teamId, filters),
+			this.dlqRepository.countByTeamId(teamId),
+		]);
+		return { items, count };
+	};
+
+	getSummary = async (teamId: string): Promise<DLQStatusCount[]> => {
+		return this.dlqRepository.countByTeamIdGrouped(teamId);
+	};
+
+	purge = async (id: string, teamId: string): Promise<number> => {
+		return this.dlqRepository.deleteById(id, teamId);
+	};
+
+	cleanup = async (ttlDays: number): Promise<number> => {
+		const cutoff = new Date(Date.now() - ttlDays * 24 * 60 * 60 * 1000);
+		const deleted = await this.dlqRepository.deleteOlderThan(cutoff);
+		if (deleted > 0) {
+			this.logger.info({
+				message: `DLQ cleanup: deleted ${deleted} items older than ${ttlDays} days`,
+				service: SERVICE_NAME,
+				method: "cleanup",
+			});
+		}
+		return deleted;
+	};
+
+	private executeRetry = async (item: DLQItem): Promise<void> => {
+		const payload = item.payload;
+
+		switch (item.type) {
+			case "notification": {
+				const monitor = payload.monitor as Parameters<INotificationsService["handleNotifications"]>[0];
+				const monitorStatusResponse = payload.monitorStatusResponse as Parameters<INotificationsService["handleNotifications"]>[1];
+				const decision = payload.decision as Parameters<INotificationsService["handleNotifications"]>[2];
+
+				// Staleness check: skip "down" notifications if monitor has recovered
+				const itemAge = Date.now() - new Date(item.createdAt).getTime();
+				if (itemAge > STALENESS_THRESHOLD_MS) {
+					try {
+						const currentMonitor = await this.monitorsRepository.findById(monitor.id, monitor.teamId);
+						if (currentMonitor.status === "up" && decision.notificationReason === "status_change") {
+							this.logger.info({
+								message: `DLQ item ${item.id} skipped: monitor ${monitor.id} has recovered`,
+								service: SERVICE_NAME,
+								method: "executeRetry",
+							});
+							return;
+						}
+					} catch {
+						// Monitor may have been deleted — skip the notification
+						this.logger.warn({
+							message: `DLQ item ${item.id} skipped: monitor ${monitor.id} not found`,
+							service: SERVICE_NAME,
+							method: "executeRetry",
+						});
+						return;
+					}
+				}
+
+				await this.notificationsService.handleNotifications(monitor, monitorStatusResponse, decision);
+				break;
+			}
+			case "incident_create":
+			case "incident_resolve": {
+				const monitor = payload.monitor as Parameters<IIncidentService["handleIncident"]>[0];
+				const code = payload.code as number;
+				const decision = payload.decision as Parameters<IIncidentService["handleIncident"]>[2];
+				const monitorStatusResponse = payload.monitorStatusResponse as Parameters<IIncidentService["handleIncident"]>[3];
+
+				await this.incidentService.handleIncident(monitor, code, decision, monitorStatusResponse);
+				break;
+			}
+		}
+	};
+}


### PR DESCRIPTION
## Describe your changes

- Adds DLQService with enqueue, exponential backoff retry (30s base, 1h cap, 5 max attempts), and staleness checks that skip "down" notifications if the monitor has since recovered
- Replaces fire-and-forget .catch(log) patterns in the heartbeat job with .catch(enqueue to DLQ) for both notification and incident failures
- Registers two new scheduler jobs: DLQ retry (every 30s) and DLQ cleanup (daily, 7-day TTL)
- Wires DLQ repository and service into the dependency injection chain

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

