### PR TITLE
fix(3459-response-time): Replaced avgResponseTime with avgOriginalRes…

### DIFF
--- a/client/src/Components/monitors/charts/HistogramDetails.tsx
+++ b/client/src/Components/monitors/charts/HistogramDetails.tsx
@@ -20,6 +20,8 @@ import {
 import { useTheme } from "@mui/material/styles";
 import type { GroupedCheck } from "@/Types/Check";
 import type { RootState } from "@/Types/state";
+import type { TooltipProps } from "recharts";
+import type { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
 
 type XTickProps = {
 	x: number;
@@ -46,9 +48,7 @@ export const XTick = ({ x, y, payload, range }: XTickProps) => {
 	);
 };
 
-type ResponseTimeToolTipProps = {
-	active?: boolean | undefined;
-	payload?: any[];
+type ResponseTimeToolTipProps = TooltipProps<ValueType, NameType> & {
 	label?: string | number;
 	range: string;
 	theme: any;

--- a/client/src/Components/monitors/charts/HistogramDetails.tsx
+++ b/client/src/Components/monitors/charts/HistogramDetails.tsx
@@ -152,7 +152,7 @@ export const HistogramDetails = ({
 					/>
 					<Area
 						type="monotone"
-						dataKey="originalAvgResponseTime"
+						dataKey="avgResponseTime"
 						stroke={theme.palette.primary.main}
 						fill="url(#colorUv)"
 					/>

--- a/client/src/Components/monitors/charts/HistogramDetails.tsx
+++ b/client/src/Components/monitors/charts/HistogramDetails.tsx
@@ -68,7 +68,7 @@ const ResponseTimeToolTip = ({
 	if (!active) return null;
 
 	const format = tooltipDateFormatLookup(range);
-	const responseTime = Math.floor(payload?.[0]?.payload?.avgResponseTime || 0);
+	const responseTime = Math.floor(payload?.[0]?.payload?.originalAvgResponseTime || 0);
 	return (
 		<BaseBox sx={{ py: theme.spacing(2), px: theme.spacing(4) }}>
 			<Typography>{formatDateWithTz(String(label), format, uiTimezone)}</Typography>
@@ -152,7 +152,7 @@ export const HistogramDetails = ({
 					/>
 					<Area
 						type="monotone"
-						dataKey="avgResponseTime"
+						dataKey="originalAvgResponseTime"
 						stroke={theme.palette.primary.main}
 						fill="url(#colorUv)"
 					/>

--- a/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
+++ b/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
@@ -13,6 +13,7 @@ import { XTick } from "@/Components/monitors";
 import { Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { HardwareCheckStats } from "@/Types/Monitor";
+import { SPACING } from "@/Utils/Theme/constants";
 
 const AREA_COLORS = [
 	// Blues
@@ -141,7 +142,7 @@ const ResponseTimeToolTip = ({
 		.replace(" at ", ", ");
 
 	return (
-		<BaseBox sx={{ py: theme.spacing(2), px: theme.spacing(4) }}>
+		<BaseBox sx={{ py: theme.spacing(SPACING.LG), px: theme.spacing(SPACING.XS) }}>
 			<Typography>{formattedDate}</Typography>
 			<Typography>{displayLabel}: {formattedValue}</Typography>
 		</BaseBox>

--- a/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
+++ b/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
@@ -98,6 +98,7 @@ type ResponseTimeToolTipProps = {
 	payload?: any[];
 	label?: string | number;
 	theme: any;
+	labelFormatter?: (value: number) => string;
 };
 
 const ResponseTimeToolTip = ({
@@ -106,6 +107,7 @@ const ResponseTimeToolTip = ({
 	label,
 	theme,
 	type,
+	labelFormatter
 }: ResponseTimeToolTipProps & { type: string }) => {
 	if (!active || !payload || !payload.length || label === undefined || label === null) {
 		return null;
@@ -121,10 +123,10 @@ const ResponseTimeToolTip = ({
 	const rawValue = payload[0].payload[targetKey];
 
 	const value = typeof rawValue === "number" ? rawValue : 0;
+	const formattedValue = labelFormatter ? labelFormatter(value) : value;
 
 	const displayLabel =
 		type === "temp" ? "Temperature" : type.charAt(0).toUpperCase() + type.slice(1);
-	const unit = type === "temp" ? "°C" : "%";
 
 	const formattedDate = new Date(label)
 		.toLocaleString("en-US", {
@@ -139,25 +141,9 @@ const ResponseTimeToolTip = ({
 		.replace(" at ", ", ");
 
 	return (
-		<BaseBox
-			sx={{
-				py: theme.spacing(1.5),
-				px: theme.spacing(2.5),
-				backgroundColor: "rgba(28, 28, 30, 0.95)",
-				borderRadius: "8px",
-				border: "1px solid rgba(255, 255, 255, 0.1)",
-				boxShadow: "0 4px 12px rgba(0,0,0,0.5)",
-			}}
-		>
-			<Typography
-				sx={{ color: "rgba(255, 255, 255, 0.6)", fontSize: "0.75rem", mb: 0.5 }}
-			>
-				{formattedDate}
-			</Typography>
-			<Typography sx={{ color: "#fff", fontWeight: 600, fontSize: "0.9rem" }}>
-				{displayLabel}: {value.toFixed(1)}
-				{unit}
-			</Typography>
+		<BaseBox sx={{ py: theme.spacing(2), px: theme.spacing(4) }}>
+			<Typography>{formattedDate}</Typography>
+			<Typography>{displayLabel}: {formattedValue}</Typography>
 		</BaseBox>
 	);
 };
@@ -272,9 +258,10 @@ export const HistogramInfrastructure = ({
 					<Tooltip
 						content={(props) => (
 							<ResponseTimeToolTip
-								{...props} // This is the missing piece
+								{...props}
 								type={type}
 								theme={theme}
+								labelFormatter={yAxisFormatter}
 							/>
 						)}
 					/>

--- a/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
+++ b/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
@@ -17,6 +17,9 @@ import { SPACING } from "@/Utils/Theme/constants";
 import { useTranslation } from "react-i18next";
 import type { TooltipProps } from "recharts";
 import type { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
+import { formatDateWithTz, tooltipDateFormatLookup } from "@/Utils/TimeUtils";
+import type { RootState } from "@/Types/state";
+import { useSelector } from "react-redux";
 
 const AREA_COLORS = [
 	// Blues
@@ -97,22 +100,25 @@ const createGradient = ({
 	</defs>
 );
 
-type HistogramInfrastructureToolTipProps = TooltipProps<ValueType, NameType> & {
-	label?: string | number;
+type HistogramInfrastructureTooltipProps = TooltipProps<ValueType, NameType> & {
+	range: string;
 	theme: Theme;
+	uiTimezone: string;
 	labelFormatter?: (value: number) => string;
 };
 
-const HistogramInfrastructureToolTip = ({
+const HistogramInfrastructureTooltip = ({
 	active,
 	payload,
-	label,
+	range,
 	theme,
+	label,
 	type,
+	uiTimezone,
 	labelFormatter,
-}: HistogramInfrastructureToolTipProps & { type: string }) => {
+}: HistogramInfrastructureTooltipProps & { type: string }) => {
 	const { t } = useTranslation();
-	if (!active || !payload || !payload.length || label === undefined || label === null) {
+	if (!active || !payload || !payload.length || range === undefined || range === null) {
 		return null;
 	}
 
@@ -123,27 +129,17 @@ const HistogramInfrastructureToolTip = ({
 	};
 	const targetKey = dataKeys[type] ?? payload[0].dataKey;
 	if (!targetKey) return null;
-	const rawValue = payload[0].payload[targetKey as keyof HardwareCheckStats];
+	const rawValue = payload[0].payload[targetKey];
 
 	const value = typeof rawValue === "number" ? rawValue : 0;
 	const formattedValue = labelFormatter ? labelFormatter(value) : value;
 
 	const displayLabel = t(`pages.infrastructure.charts.labels.${type}`);
-	const formattedDate = new Date(label)
-		.toLocaleString("en-US", {
-			weekday: "short",
-			month: "long",
-			day: "numeric",
-			year: "numeric",
-			hour: "2-digit",
-			minute: "2-digit",
-			hour12: true,
-		})
-		.replace(" at ", ", ");
+	const formattedDate = tooltipDateFormatLookup(range);
 
 	return (
 		<BaseBox sx={{ py: theme.spacing(SPACING.LG), px: theme.spacing(SPACING.XS) }}>
-			<Typography>{formattedDate}</Typography>
+			<Typography>{formatDateWithTz(String(label), formattedDate, uiTimezone)}</Typography>
 			<Typography>
 				{displayLabel}: {formattedValue}
 			</Typography>
@@ -187,20 +183,21 @@ export const HistogramInfrastructure = ({
 	const theme = useTheme();
 	const uniqueId = useId();
 	const data = checks;
+	const uiTimezone = useSelector((state: RootState) => state.ui.timezone);
 
-	let avgTemps: { bucketDate: string; avgTemp: number | null }[] = [];
+	let avgTemps: { bucketDate: string; avg_temp: number | null }[] = [];
 	let tempYDomain: number[] = [];
 	if (type === "temp") {
 		avgTemps = data.map((check) => {
 			const temps = check.avgTemperature || [];
-			if (temps.length === 0) return { bucketDate: check.bucketDate, avgTemp: null };
+			if (temps.length === 0) return { bucketDate: check.bucketDate, avg_temp: null };
 			const totalTemp = temps.reduce((sum, temp) => sum + (temp || 0), 0);
 			const avgTemp = totalTemp / temps.length;
-			return { bucketDate: check.bucketDate, avgTemp: avgTemp };
+			return { bucketDate: check.bucketDate, avg_temp: avgTemp };
 		});
 
 		const maxTemp: number = avgTemps.reduce((max, item) => {
-			return item.avgTemp && item.avgTemp > max ? item.avgTemp : max;
+			return item.avg_temp && item.avg_temp > max ? item.avg_temp : max;
 		}, 0);
 
 		tempYDomain = [0, Math.ceil((maxTemp * 1.3) / 10) * 10];
@@ -260,11 +257,13 @@ export const HistogramInfrastructure = ({
 					})}
 					<Tooltip
 						content={(props) => (
-							<HistogramInfrastructureToolTip
+							<HistogramInfrastructureTooltip
 								{...props}
 								type={type}
 								theme={theme}
 								labelFormatter={yAxisFormatter}
+								range={dateRange}
+								uiTimezone={uiTimezone}
 							/>
 						)}
 					/>

--- a/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
+++ b/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
@@ -104,6 +104,7 @@ type HistogramInfrastructureTooltipProps = TooltipProps<ValueType, NameType> & {
 	range: string;
 	theme: Theme;
 	uiTimezone: string;
+	type: string;
 	labelFormatter?: (value: number) => string;
 };
 
@@ -116,37 +117,30 @@ const HistogramInfrastructureTooltip = ({
 	type,
 	uiTimezone,
 	labelFormatter,
-}: HistogramInfrastructureTooltipProps & { type: string }) => {
+}: HistogramInfrastructureTooltipProps) => {
 	const { t } = useTranslation();
-	if (!active || !payload || !payload.length || range === undefined || range === null) {
-		return null;
-	}
 
-	const dataKeys: Record<string, string> = {
-		cpu: "avgCpuUsage",
-		memory: "avgMemoryUsage",
-		temp: "avgTemperature",
-	};
-	const targetKey = dataKeys[type] ?? payload[0].dataKey;
-	if (!targetKey) return null;
-	const rawValue = payload[0].payload[targetKey];
+	if (!active || !payload?.length || range == null) return null;
 
-	const value = typeof rawValue === "number" ? rawValue : 0;
-	const formattedValue = labelFormatter ? labelFormatter(value) : value;
+	const formattedDate = tooltipDateFormatLookup(range);
 
 	const displayLabel = t(`pages.infrastructure.charts.labels.${type}`);
-	const formattedDate = tooltipDateFormatLookup(range);
 
 	return (
 		<BaseBox sx={{ py: theme.spacing(SPACING.LG), px: theme.spacing(SPACING.XS) }}>
-			<Typography>{formatDateWithTz(String(label), formattedDate, uiTimezone)}</Typography>
 			<Typography>
-				{displayLabel}: {formattedValue}
+				{formatDateWithTz(String(label), formattedDate, uiTimezone)}
 			</Typography>
+
+			{payload.map((entry) => (
+				<Typography key={entry.dataKey}>
+					{displayLabel}:{" "}
+					{labelFormatter ? labelFormatter(entry.value as number) : entry.value}
+				</Typography>
+			))}
 		</BaseBox>
 	);
 };
-
 export const HistogramInfrastructure = ({
 	dateRange,
 	title,

--- a/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
+++ b/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
@@ -1,4 +1,4 @@
-import { BaseChart } from "@/Components/design-elements";
+import { BaseChart, BaseBox } from "@/Components/design-elements";
 import {
 	AreaChart,
 	Area,
@@ -6,10 +6,11 @@ import {
 	YAxis,
 	CartesianGrid,
 	ResponsiveContainer,
+	Tooltip,
 } from "recharts";
 import { Fragment, useId } from "react";
 import { XTick } from "@/Components/monitors";
-
+import { Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import type { HardwareCheckStats } from "@/Types/Monitor";
 
@@ -91,6 +92,67 @@ const createGradient = ({
 		</linearGradient>
 	</defs>
 );
+
+type ResponseTimeToolTipProps = {
+	active?: boolean | undefined;
+	payload?: any[];
+	label?: string | number;
+	theme: any;
+};
+
+const ResponseTimeToolTip = ({
+	active,
+	payload,
+	label,
+	theme,
+	type,
+}: ResponseTimeToolTipProps & { type: string }) => {
+	if (!active || !payload || !payload.length || label === undefined || label === null) {
+		return null;
+	}
+
+	const dataKeys: Record<string, string> = {
+		cpu: 'avgCpuUsage',
+		memory: 'avgMemoryUsage',
+		temp: 'avg_temp'
+	};
+
+	const targetKey = dataKeys[type] || payload[0].dataKey;
+	const rawValue = payload[0].payload[targetKey];
+
+	const value = typeof rawValue === 'number' ? rawValue : 0;
+
+	const displayLabel = type === 'temp' ? 'Temperature' : type.charAt(0).toUpperCase() + type.slice(1);
+	const unit = type === 'temp' ? '°C' : '%';
+
+	const formattedDate = new Date(label).toLocaleString('en-US', {
+		weekday: 'short',
+		month: 'long',
+		day: 'numeric',
+		year: 'numeric',
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: true
+	}).replace(' at ', ', ');
+
+	return (
+		<BaseBox sx={{
+			py: theme.spacing(1.5),
+			px: theme.spacing(2.5),
+			backgroundColor: 'rgba(28, 28, 30, 0.95)',
+			borderRadius: '8px',
+			border: '1px solid rgba(255, 255, 255, 0.1)',
+			boxShadow: '0 4px 12px rgba(0,0,0,0.5)'
+		}}>
+			<Typography sx={{ color: 'rgba(255, 255, 255, 0.6)', fontSize: '0.75rem', mb: 0.5 }}>
+				{formattedDate}
+			</Typography>
+			<Typography sx={{ color: '#fff', fontWeight: 600, fontSize: '0.9rem' }}>
+				{displayLabel}: {value.toFixed(1)}{unit}
+			</Typography>
+		</BaseBox>
+	);
+};
 
 export const HistogramInfrastructure = ({
 	dateRange,
@@ -199,6 +261,15 @@ export const HistogramInfrastructure = ({
 							</Fragment>
 						);
 					})}
+					<Tooltip
+						content={(props) => (
+							<ResponseTimeToolTip
+								{...props} // This is the missing piece
+								type={type}
+								theme={theme}
+							/>
+						)}
+					/>
 				</AreaChart>
 			</ResponsiveContainer>
 		</BaseChart>

--- a/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
+++ b/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
@@ -112,43 +112,51 @@ const ResponseTimeToolTip = ({
 	}
 
 	const dataKeys: Record<string, string> = {
-		cpu: 'avgCpuUsage',
-		memory: 'avgMemoryUsage',
-		temp: 'avg_temp'
+		cpu: "avgCpuUsage",
+		memory: "avgMemoryUsage",
+		temp: "avg_temp",
 	};
 
 	const targetKey = dataKeys[type] || payload[0].dataKey;
 	const rawValue = payload[0].payload[targetKey];
 
-	const value = typeof rawValue === 'number' ? rawValue : 0;
+	const value = typeof rawValue === "number" ? rawValue : 0;
 
-	const displayLabel = type === 'temp' ? 'Temperature' : type.charAt(0).toUpperCase() + type.slice(1);
-	const unit = type === 'temp' ? '°C' : '%';
+	const displayLabel =
+		type === "temp" ? "Temperature" : type.charAt(0).toUpperCase() + type.slice(1);
+	const unit = type === "temp" ? "°C" : "%";
 
-	const formattedDate = new Date(label).toLocaleString('en-US', {
-		weekday: 'short',
-		month: 'long',
-		day: 'numeric',
-		year: 'numeric',
-		hour: '2-digit',
-		minute: '2-digit',
-		hour12: true
-	}).replace(' at ', ', ');
+	const formattedDate = new Date(label)
+		.toLocaleString("en-US", {
+			weekday: "short",
+			month: "long",
+			day: "numeric",
+			year: "numeric",
+			hour: "2-digit",
+			minute: "2-digit",
+			hour12: true,
+		})
+		.replace(" at ", ", ");
 
 	return (
-		<BaseBox sx={{
-			py: theme.spacing(1.5),
-			px: theme.spacing(2.5),
-			backgroundColor: 'rgba(28, 28, 30, 0.95)',
-			borderRadius: '8px',
-			border: '1px solid rgba(255, 255, 255, 0.1)',
-			boxShadow: '0 4px 12px rgba(0,0,0,0.5)'
-		}}>
-			<Typography sx={{ color: 'rgba(255, 255, 255, 0.6)', fontSize: '0.75rem', mb: 0.5 }}>
+		<BaseBox
+			sx={{
+				py: theme.spacing(1.5),
+				px: theme.spacing(2.5),
+				backgroundColor: "rgba(28, 28, 30, 0.95)",
+				borderRadius: "8px",
+				border: "1px solid rgba(255, 255, 255, 0.1)",
+				boxShadow: "0 4px 12px rgba(0,0,0,0.5)",
+			}}
+		>
+			<Typography
+				sx={{ color: "rgba(255, 255, 255, 0.6)", fontSize: "0.75rem", mb: 0.5 }}
+			>
 				{formattedDate}
 			</Typography>
-			<Typography sx={{ color: '#fff', fontWeight: 600, fontSize: '0.9rem' }}>
-				{displayLabel}: {value.toFixed(1)}{unit}
+			<Typography sx={{ color: "#fff", fontWeight: 600, fontSize: "0.9rem" }}>
+				{displayLabel}: {value.toFixed(1)}
+				{unit}
 			</Typography>
 		</BaseBox>
 	);

--- a/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
+++ b/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
@@ -14,7 +14,6 @@ import { Typography } from "@mui/material";
 import { useTheme, type Theme } from "@mui/material/styles";
 import type { HardwareCheckStats } from "@/Types/Monitor";
 import { SPACING } from "@/Utils/Theme/constants";
-import { useTranslation } from "react-i18next";
 import type { TooltipProps } from "recharts";
 import type { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
 import { formatDateWithTz, tooltipDateFormatLookup } from "@/Utils/TimeUtils";
@@ -104,7 +103,7 @@ type HistogramInfrastructureTooltipProps = TooltipProps<ValueType, NameType> & {
 	range: string;
 	theme: Theme;
 	uiTimezone: string;
-	type: string;
+	title?: string;
 	labelFormatter?: (value: number) => string;
 };
 
@@ -114,17 +113,13 @@ const HistogramInfrastructureTooltip = ({
 	range,
 	theme,
 	label,
-	type,
+	title,
 	uiTimezone,
 	labelFormatter,
 }: HistogramInfrastructureTooltipProps) => {
-	const { t } = useTranslation();
-
 	if (!active || !payload?.length || range == null) return null;
 
 	const formattedDate = tooltipDateFormatLookup(range);
-
-	const displayLabel = t(`pages.infrastructure.charts.labels.${type}`);
 
 	return (
 		<BaseBox sx={{ py: theme.spacing(SPACING.LG), px: theme.spacing(SPACING.XS) }}>
@@ -134,8 +129,7 @@ const HistogramInfrastructureTooltip = ({
 
 			{payload.map((entry) => (
 				<Typography key={entry.dataKey}>
-					{displayLabel}:{" "}
-					{labelFormatter ? labelFormatter(entry.value as number) : entry.value}
+					{title}: {labelFormatter ? labelFormatter(entry.value as number) : entry.value}
 				</Typography>
 			))}
 		</BaseBox>
@@ -253,8 +247,8 @@ export const HistogramInfrastructure = ({
 						content={(props) => (
 							<HistogramInfrastructureTooltip
 								{...props}
-								type={type}
 								theme={theme}
+								title={title}
 								labelFormatter={yAxisFormatter}
 								range={dateRange}
 								uiTimezone={uiTimezone}

--- a/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
+++ b/client/src/Components/monitors/charts/HistogramInfrastructure.tsx
@@ -11,9 +11,12 @@ import {
 import { Fragment, useId } from "react";
 import { XTick } from "@/Components/monitors";
 import { Typography } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
+import { useTheme, type Theme } from "@mui/material/styles";
 import type { HardwareCheckStats } from "@/Types/Monitor";
 import { SPACING } from "@/Utils/Theme/constants";
+import { useTranslation } from "react-i18next";
+import type { TooltipProps } from "recharts";
+import type { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
 
 const AREA_COLORS = [
 	// Blues
@@ -94,22 +97,21 @@ const createGradient = ({
 	</defs>
 );
 
-type ResponseTimeToolTipProps = {
-	active?: boolean | undefined;
-	payload?: any[];
+type HistogramInfrastructureToolTipProps = TooltipProps<ValueType, NameType> & {
 	label?: string | number;
-	theme: any;
+	theme: Theme;
 	labelFormatter?: (value: number) => string;
 };
 
-const ResponseTimeToolTip = ({
+const HistogramInfrastructureToolTip = ({
 	active,
 	payload,
 	label,
 	theme,
 	type,
-	labelFormatter
-}: ResponseTimeToolTipProps & { type: string }) => {
+	labelFormatter,
+}: HistogramInfrastructureToolTipProps & { type: string }) => {
+	const { t } = useTranslation();
 	if (!active || !payload || !payload.length || label === undefined || label === null) {
 		return null;
 	}
@@ -117,18 +119,16 @@ const ResponseTimeToolTip = ({
 	const dataKeys: Record<string, string> = {
 		cpu: "avgCpuUsage",
 		memory: "avgMemoryUsage",
-		temp: "avg_temp",
+		temp: "avgTemperature",
 	};
-
-	const targetKey = dataKeys[type] || payload[0].dataKey;
-	const rawValue = payload[0].payload[targetKey];
+	const targetKey = dataKeys[type] ?? payload[0].dataKey;
+	if (!targetKey) return null;
+	const rawValue = payload[0].payload[targetKey as keyof HardwareCheckStats];
 
 	const value = typeof rawValue === "number" ? rawValue : 0;
 	const formattedValue = labelFormatter ? labelFormatter(value) : value;
 
-	const displayLabel =
-		type === "temp" ? "Temperature" : type.charAt(0).toUpperCase() + type.slice(1);
-
+	const displayLabel = t(`pages.infrastructure.charts.labels.${type}`);
 	const formattedDate = new Date(label)
 		.toLocaleString("en-US", {
 			weekday: "short",
@@ -144,7 +144,9 @@ const ResponseTimeToolTip = ({
 	return (
 		<BaseBox sx={{ py: theme.spacing(SPACING.LG), px: theme.spacing(SPACING.XS) }}>
 			<Typography>{formattedDate}</Typography>
-			<Typography>{displayLabel}: {formattedValue}</Typography>
+			<Typography>
+				{displayLabel}: {formattedValue}
+			</Typography>
 		</BaseBox>
 	);
 };
@@ -186,19 +188,19 @@ export const HistogramInfrastructure = ({
 	const uniqueId = useId();
 	const data = checks;
 
-	let avgTemps: { bucketDate: string; avg_temp: number | null }[] = [];
+	let avgTemps: { bucketDate: string; avgTemp: number | null }[] = [];
 	let tempYDomain: number[] = [];
 	if (type === "temp") {
 		avgTemps = data.map((check) => {
 			const temps = check.avgTemperature || [];
-			if (temps.length === 0) return { bucketDate: check.bucketDate, avg_temp: null };
+			if (temps.length === 0) return { bucketDate: check.bucketDate, avgTemp: null };
 			const totalTemp = temps.reduce((sum, temp) => sum + (temp || 0), 0);
 			const avgTemp = totalTemp / temps.length;
-			return { bucketDate: check.bucketDate, avg_temp: avgTemp };
+			return { bucketDate: check.bucketDate, avgTemp: avgTemp };
 		});
 
 		const maxTemp: number = avgTemps.reduce((max, item) => {
-			return item.avg_temp && item.avg_temp > max ? item.avg_temp : max;
+			return item.avgTemp && item.avgTemp > max ? item.avgTemp : max;
 		}, 0);
 
 		tempYDomain = [0, Math.ceil((maxTemp * 1.3) / 10) * 10];
@@ -258,7 +260,7 @@ export const HistogramInfrastructure = ({
 					})}
 					<Tooltip
 						content={(props) => (
-							<ResponseTimeToolTip
+							<HistogramInfrastructureToolTip
 								{...props}
 								type={type}
 								theme={theme}


### PR DESCRIPTION
…ponseTime for uptime tooltip value and area. Additionally, added tooltip for infrastructure charts

## Describe your changes

I have replaced the value of responseTime with originalResponseTime in the uptime charts tooltips and area. Additionally, I added tooltips for infrastructure charts.

<img width="1584" height="819" alt="image" src="https://github.com/user-attachments/assets/cebc7ccb-a292-4293-981c-1f89182c37fd" />
<img width="1586" height="822" alt="image" src="https://github.com/user-attachments/assets/6d33ad93-e338-4510-a203-1534df6cc77c" />
<img width="1600" height="819" alt="image" src="https://github.com/user-attachments/assets/740e39e5-69ad-445c-819b-a040622f33c0" />
<img width="433" height="298" alt="image" src="https://github.com/user-attachments/assets/fe0d0252-7bcb-4944-8e5f-8495666d5379" />



## Write your issue number after "Fixes "
[This is the relevant issue.](https://github.com/bluewave-labs/Checkmate/issues/3459#issuecomment-4189387402)

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.