### PR TITLE
feat: add notification escalation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+> [!NOTE]
+> ## 🎓 CEN3031 — Spring 2026 Mini Project
+>
+> This is the **central repository** for the CEN3031 Spring 2026 mini project.
+>
+> - 🍴 **Fork this repo** to begin your work
+> - 🔀 **All pull requests** should be submitted here
+> - 📖 **Read the rest of this README** for details about the project itself
+
+---
+
+
 <p align=center> <a href="https://trendshift.io/repositories/12443" target="_blank"><img src="https://trendshift.io/api/badge/repositories/12443" alt="bluewave-labs%2Fcheckmate | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a></p>
   
 ![](https://img.shields.io/github/license/bluewave-labs/checkmate)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Checkmate has been stress-tested with 1000+ active monitors without any particul
 
 ## Demo
 
-You can see the latest build of [Checkmate](https://checkmate-demo.bluewavelabs.ca/) in action. The username is demouser@demo.com and the password is Demouser1! (just a note that we update the demo server from time to time, so if it doesn't work for you, please ping us on the Discussions channel).
+You can see the latest build of [Checkmate](https://checkmate-demo.bluewavelabs.ca/) in action. Upon initial launch of the application, please register and fill out the appropriate fields. You can put whatever you would like for all of them just make sure to remember your username and password. The email that you use needs to be a real email you have access to as it will be the recipent of some of the notification emails.
 
 ## User's guide
 

--- a/client/src/Components/inputs/AutoComplete.tsx
+++ b/client/src/Components/inputs/AutoComplete.tsx
@@ -24,6 +24,7 @@ export const AutoCompleteInput = ({
 }: AutoCompleteInputProps) => {
 	const theme = useTheme();
 	const multiple = props.multiple;
+	const optionLabelGetter = props.getOptionLabel;
 
 	const defaultRenderInput = (params: any) => (
 		<TextField
@@ -48,6 +49,7 @@ export const AutoCompleteInput = ({
 			renderTags={() => null}
 			renderOption={(props, option, { selected }) => {
 				const { key, ...optionProps } = props;
+				const label = optionLabelGetter?.(option as any) ?? option.name ?? (option as any).notificationName;
 				return (
 					<ListItem
 						key={key}
@@ -59,7 +61,7 @@ export const AutoCompleteInput = ({
 							gap={theme.spacing(2)}
 						>
 							{multiple && <Checkbox checked={selected} />}
-							{option.name}
+							{label ?? option.name ?? (option as any).notificationName}
 						</Stack>
 					</ListItem>
 				);

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalation: data?.escalation,
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,77 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title="Escalation Rules"
+				subtitle="If the monitor stays down for the specified time, notify additional channels."
+				rightContent={
+					<Controller
+						name="escalation"
+						control={control}
+						render={({ field }) => {
+							const fieldValue = field.value ?? { delayMinutes: 3, channelId: "" };
+							const selectedEscalationNotification = (notifications ?? []).find(
+								(n) => n.id === fieldValue.channelId
+							) ?? null;
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									<TextField
+										fieldLabel="Escalate after (minutes)"
+										type="number"
+										value={fieldValue.delayMinutes}
+										onChange={(e) => {
+											field.onChange({
+												...fieldValue,
+												delayMinutes: parseInt(e.target.value, 10) || 1,
+											});
+										}}
+										inputProps={{ min: 1 }}
+									/>
+									<Autocomplete
+										options={notifications ?? []}
+										getOptionLabel={(option) => option.notificationName}
+										value={selectedEscalationNotification}
+										onChange={(_, newValue) => {
+											field.onChange({
+												...fieldValue,
+												channelId: newValue?.id || "",
+											});
+										}}
+										renderInput={(params) => (
+											<TextField
+												{...params}
+												fieldLabel="Escalation notification channels"
+											/>
+										)}
+										isOptionEqualToValue={(option, value) => option.id === value.id}
+									/>
+									{selectedEscalationNotification && (
+										<Stack direction="row" alignItems="center" spacing={theme.spacing(LAYOUT.SM)}>
+											<Typography>Escalation email:</Typography>
+											<Typography flex={1} fontWeight={600}>
+												{selectedEscalationNotification.notificationName}
+											</Typography>
+											<IconButton
+												size="small"
+												onClick={() => {
+												field.onChange({
+													...fieldValue,
+													channelId: "",
+												});
+											}}
+												aria-label="Remove escalation email"
+											>
+												<Trash2 size={16} />
+											</IconButton>
+										</Stack>
+									)}
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -774,9 +774,13 @@ const CreateMonitorPage = () => {
 						control={control}
 						render={({ field }) => {
 							const fieldValue = field.value ?? { delayMinutes: 3, channelId: "" };
-							const selectedEscalationNotification = (notifications ?? []).find(
-								(n) => n.id === fieldValue.channelId
-							) ?? null;
+                            const escalationOptions = (notifications ?? []).map((n) => ({
+                                ...n,
+                                name: n.notificationName,
+                            }));
+                            const selectedEscalationNotification = escalationOptions.find(
+                                (n) => n.id === fieldValue.channelId
+                            ) ?? null;
 							return (
 								<Stack spacing={theme.spacing(LAYOUT.MD)}>
 									<TextField
@@ -792,8 +796,8 @@ const CreateMonitorPage = () => {
 										inputProps={{ min: 1 }}
 									/>
 									<Autocomplete
-										options={notifications ?? []}
-										getOptionLabel={(option) => option.notificationName}
+										options={escalationOptions}
+										getOptionLabel={(option) => option.name}
 										value={selectedEscalationNotification}
 										onChange={(_, newValue) => {
 											field.onChange({

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -60,6 +60,10 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalation?: {
+		delayMinutes: number;
+		channelId: string;
+	};
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,12 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalation: z
+		.object({
+			delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+			channelId: z.string().min(1, "Escalation channel is required"),
+		})
+		.optional(),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -202,7 +202,6 @@ export const initializeServices = async ({
 		webSocketProvider,
 	]);
 	const emailService = new EmailService(settingsService, fs, path, compile, mjml2html, nodemailer, logger);
-
 	const notificationMessageBuilder = new NotificationMessageBuilder();
 
 	const incidentService = new IncidentService(logger, incidentsRepository, monitorsRepository, usersRepository, notificationMessageBuilder);
@@ -261,11 +260,15 @@ export const initializeServices = async ({
 		monitorStatsRepository,
 		checksRepository,
 		incidentsRepository,
+		notificationsRepository,
+		notificationMessageBuilder,
 		geoChecksService,
 		geoChecksRepository
 	);
 
 	const superSimpleQueue = await SuperSimpleQueue.create(logger, superSimpleQueueHelper, monitorsRepository);
+
+	incidentService.setJobQueue(superSimpleQueue);
 
 	// Business services
 	const userService = new UserService({

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -1,12 +1,14 @@
 import { Schema, model, type Types } from "mongoose";
 import { IncidentResolutionTypes, type Incident } from "@/types/incident.js";
 
-type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "resolvedBy" | "startTime" | "endTime" | "createdAt" | "updatedAt"> & {
+type IncidentDocumentBase = Omit<Incident, "id" | "monitorId" | "teamId" | "resolvedBy" | "acknowledgedBy" | "startTime" | "endTime" | "acknowledgedAt" | "createdAt" | "updatedAt"> & {
 	monitorId: Types.ObjectId;
 	teamId: Types.ObjectId;
 	resolvedBy?: Types.ObjectId | null;
+	acknowledgedBy?: Types.ObjectId | null;
 	startTime: Date;
 	endTime: Date | null;
+	acknowledgedAt: Date | null;
 	createdAt: Date;
 	updatedAt: Date;
 };
@@ -70,6 +72,20 @@ const IncidentSchema = new Schema<IncidentDocument>(
 		},
 		comment: {
 			type: String,
+			default: null,
+		},
+		acknowledged: {
+			type: Boolean,
+			default: false,
+			index: true,
+		},
+		acknowledgedAt: {
+			type: Date,
+			default: null,
+		},
+		acknowledgedBy: {
+			type: Schema.Types.ObjectId,
+			ref: "User",
 			default: null,
 		},
 	},

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -355,6 +355,16 @@ const MonitorSchema = new Schema<MonitorDocument>(
 			type: [checkSnapshotSchema],
 			default: [],
 		},
+		escalation: {
+			delayMinutes: {
+				type: Number,
+				min: 1,
+			},
+			channelId: {
+				type: Schema.Types.ObjectId,
+				ref: "Notification",
+			},
+		},
 	},
 	{
 		timestamps: true,

--- a/server/src/repositories/incidents/MongoIncidentRepository.ts
+++ b/server/src/repositories/incidents/MongoIncidentRepository.ts
@@ -60,6 +60,9 @@ class MongoIncidentRepository implements IIncidentsRepository {
 			resolvedBy: doc.resolvedBy ? this.toStringId(doc.resolvedBy) : null,
 			resolvedByEmail: doc.resolvedByEmail ?? null,
 			comment: doc.comment ?? null,
+			acknowledged: doc.acknowledged ?? false,
+			acknowledgedAt: doc.acknowledgedAt ? this.toDateString(doc.acknowledgedAt) : null,
+			acknowledgedBy: doc.acknowledgedBy ? this.toStringId(doc.acknowledgedBy) : null,
 			createdAt: this.toDateString(doc.createdAt),
 			updatedAt: this.toDateString(doc.updatedAt),
 		};

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -374,6 +374,12 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation: doc.escalation
+				? {
+					delayMinutes: doc.escalation.delayMinutes,
+					channelId: toStringId(doc.escalation.channelId),
+				}
+				: undefined,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -433,6 +439,12 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation: doc.escalation
+				? {
+					delayMinutes: doc.escalation.delayMinutes,
+					channelId: toStringId(doc.escalation.channelId),
+				}
+				: undefined,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/business/incidentService.ts
+++ b/server/src/service/business/incidentService.ts
@@ -8,6 +8,7 @@ import type { Incident, IncidentSummary, User } from "@/types/index.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type { INotificationMessageBuilder } from "@/service/infrastructure/notificationMessageBuilder.js";
 import type { ILogger } from "@/utils/logger.js";
+import type { ISuperSimpleQueue } from "@/service/index.js";
 
 export interface IIncidentService {
 	handleIncident(
@@ -17,6 +18,8 @@ export interface IIncidentService {
 		monitorStatusResponse?: MonitorStatusResponse
 	): Promise<Incident | null>;
 	resolveIncident(incidentId: string, userId: string, teamId: string, comment?: string, userEmail?: string): Promise<Incident>;
+	acknowledgeIncident(incidentId: string, userId: string, teamId: string): Promise<Incident>;
+	setJobQueue(jobQueue: ISuperSimpleQueue): void;
 	getIncidentsByTeam(
 		teamId: string,
 		sortOrder: string,
@@ -39,19 +42,26 @@ export class IncidentService implements IIncidentService {
 	private monitorsRepository: IMonitorsRepository;
 	private usersRepository: IUsersRepository;
 	private notificationMessageBuilder: INotificationMessageBuilder;
+	private jobQueue?: ISuperSimpleQueue;
 
 	constructor(
 		logger: ILogger,
 		incidentsRepository: IIncidentsRepository,
 		monitorsRepository: IMonitorsRepository,
 		usersRepository: IUsersRepository,
-		notificationMessageBuilder: INotificationMessageBuilder
+		notificationMessageBuilder: INotificationMessageBuilder,
+		jobQueue?: ISuperSimpleQueue
 	) {
 		this.logger = logger;
 		this.incidentsRepository = incidentsRepository;
 		this.monitorsRepository = monitorsRepository;
 		this.usersRepository = usersRepository;
 		this.notificationMessageBuilder = notificationMessageBuilder;
+		this.jobQueue = jobQueue;
+	}
+
+	setJobQueue(jobQueue: ISuperSimpleQueue): void {
+		this.jobQueue = jobQueue;
 	}
 
 	get serviceName() {
@@ -83,7 +93,7 @@ export class IncidentService implements IIncidentService {
 					message = this.buildThresholdBreachMessage(monitor, monitorStatusResponse);
 				}
 
-				const incident = {
+				const incidentData = {
 					monitorId: monitor.id,
 					teamId: monitor.teamId,
 					startTime: Date.now().toString(),
@@ -91,7 +101,35 @@ export class IncidentService implements IIncidentService {
 					statusCode,
 					message,
 				};
-				return await this.incidentsRepository.create(incident);
+				const incident = await this.incidentsRepository.create(incidentData);
+
+				// Schedule escalation job if configured
+				if (monitor.escalation && this.jobQueue) {
+					try {
+						await this.jobQueue.addCustomJob({
+							id: `${monitor.id}-escalation-${incident.id}`,
+							template: "escalation-job",
+							repeat: 0, // One-time job
+							active: true,
+							data: { incidentId: incident.id, monitor },
+							runAt: Date.now() + (monitor.escalation.delayMinutes * 60 * 1000), // Delay in milliseconds
+						});
+						this.logger.debug({
+							message: `Scheduled escalation job for incident ${incident.id} on monitor ${monitor.id}`,
+							service: SERVICE_NAME,
+							method: "handleIncident",
+						});
+					} catch (error: unknown) {
+						this.logger.error({
+							message: `Failed to schedule escalation job for incident ${incident.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+							service: SERVICE_NAME,
+							method: "handleIncident",
+							stack: error instanceof Error ? error.stack : undefined,
+						});
+					}
+				}
+
+				return incident;
 			}
 		}
 
@@ -167,6 +205,60 @@ export class IncidentService implements IIncidentService {
 			this.logger.error({
 				service: SERVICE_NAME,
 				method: "resolveIncident",
+				message: error instanceof Error ? error.message : "Unknown error",
+				details: { id: incidentId },
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			throw error;
+		}
+	};
+
+	acknowledgeIncident = async (incidentId: string, userId: string, teamId: string) => {
+		try {
+			if (!incidentId) {
+				throw new AppError({ message: "No incident ID in request", service: SERVICE_NAME, method: "acknowledgeIncident" });
+			}
+
+			if (!userId) {
+				throw new AppError({ message: "No user ID in request", service: SERVICE_NAME, method: "acknowledgeIncident" });
+			}
+
+			if (!teamId) {
+				throw new AppError({ message: "No team ID in request", service: SERVICE_NAME, method: "acknowledgeIncident" });
+			}
+
+			const incident = await this.incidentsRepository.findActiveByIncidentId(incidentId, teamId);
+
+			if (!incident) {
+				throw new AppError({ message: "Incident not found", service: SERVICE_NAME, method: "acknowledgeIncident" });
+			}
+
+			if (incident.status === false) {
+				throw new AppError({ message: "Incident is already resolved", service: SERVICE_NAME, method: "acknowledgeIncident" });
+			}
+
+			if (incident.acknowledged) {
+				throw new AppError({ message: "Incident is already acknowledged", service: SERVICE_NAME, method: "acknowledgeIncident" });
+			}
+
+			incident.acknowledged = true;
+			incident.acknowledgedAt = new Date().toISOString();
+			incident.acknowledgedBy = userId;
+
+			const acknowledgedIncident = await this.incidentsRepository.updateById(incident.id, teamId, incident);
+
+			this.logger.debug({
+				service: SERVICE_NAME,
+				method: "acknowledgeIncident",
+				message: `Incident acknowledged by user`,
+				details: { incidentId: acknowledgedIncident.id, userId },
+			});
+
+			return acknowledgedIncident;
+		} catch (error: unknown) {
+			this.logger.error({
+				service: SERVICE_NAME,
+				method: "acknowledgeIncident",
 				message: error instanceof Error ? error.message : "Unknown error",
 				details: { id: incidentId },
 				stack: error instanceof Error ? error.stack : undefined,

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
@@ -43,6 +43,7 @@ export interface ISuperSimpleQueue {
 	readonly serviceName: string;
 	init(): Promise<boolean>;
 	addJob(monitorId: string, monitor: Monitor): Promise<void>;
+	addCustomJob(job: { id: string; template: string; repeat?: number; active?: boolean; data?: any; runAt?: number }): Promise<void>;
 	deleteJob(monitor: Monitor): Promise<void>;
 	pauseJob(monitor: Monitor): Promise<void>;
 	resumeJob(monitor: Monitor): Promise<void>;
@@ -91,6 +92,7 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 
 			this.scheduler.addTemplate("monitor-job", this.helper.getHeartbeatJob());
 			this.scheduler.addTemplate("geo-check-job", this.helper.getHeartbeatGeoJob());
+			this.scheduler.addTemplate("escalation-job", this.helper.getEscalationJob());
 			this.scheduler.addTemplate("cleanup-orphaned", this.helper.getCleanupOrphanedJob());
 			this.scheduler.addTemplate("cleanup-retention-job", this.helper.getCleanupRetentionJob());
 			const monitors = await this.monitorsRepository.findAll();
@@ -202,6 +204,10 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 			// Remove geo job if disabled or monitor type changed
 			this.scheduler.removeJob(geoJobId);
 		}
+	};
+
+	addCustomJob = async (job: { id: string; template: string; repeat?: number; active?: boolean; data?: any; runAt?: number }) => {
+		this.scheduler.addJob(job);
 	};
 
 	shutdown = async () => {

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -10,8 +10,9 @@ import {
 	IStatusService,
 	IncidentService,
 	type IGeoChecksService,
+	type INotificationMessageBuilder,
 } from "@/service/index.js";
-import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
+import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type MonitorStatusResponse, type StatusChangeResult } from "@/types/index.js";
 import {
 	IMaintenanceWindowsRepository,
 	IMonitorsRepository,
@@ -19,6 +20,7 @@ import {
 	IMonitorStatsRepository,
 	IChecksRepository,
 	IIncidentsRepository,
+	INotificationsRepository,
 	IGeoChecksRepository,
 } from "@/repositories/index.js";
 import { ILogger } from "@/utils/logger.js";
@@ -30,6 +32,7 @@ export interface ISuperSimpleQueueHelper {
 	getHeartbeatGeoJob(): (monitor: Monitor) => Promise<void>;
 	getCleanupOrphanedJob(): () => Promise<void>;
 	getCleanupRetentionJob(): () => Promise<void>;
+	getEscalationJob(): (data?: { incidentId: string; monitor: Monitor }) => Promise<void>;
 	isInMaintenanceWindow(monitorId: string, teamId: string): Promise<boolean>;
 }
 
@@ -64,6 +67,8 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 	private monitorStatsRepository: IMonitorStatsRepository;
 	private checksRepository: IChecksRepository;
 	private incidentsRepository: IIncidentsRepository;
+	private notificationsRepository: INotificationsRepository;
+	private notificationMessageBuilder: INotificationMessageBuilder;
 	private geoChecksService: IGeoChecksService;
 	private geoChecksRepository: IGeoChecksRepository;
 
@@ -82,6 +87,8 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		monitorStatsRepository: IMonitorStatsRepository,
 		checksRepository: IChecksRepository,
 		incidentsRepository: IIncidentsRepository,
+		notificationsRepository: INotificationsRepository,
+		notificationMessageBuilder: INotificationMessageBuilder,
 		geoChecksService: IGeoChecksService,
 		geoChecksRepository: IGeoChecksRepository
 	) {
@@ -96,6 +103,13 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 		this.maintenanceWindowsRepository = maintenanceWindowsRepository;
 		this.monitorsRepository = monitorsRepository;
 		this.teamsRepository = teamsRepository;
+		this.monitorStatsRepository = monitorStatsRepository;
+		this.checksRepository = checksRepository;
+		this.incidentsRepository = incidentsRepository;
+		this.notificationsRepository = notificationsRepository;
+		this.notificationMessageBuilder = notificationMessageBuilder;
+		this.geoChecksService = geoChecksService;
+		this.geoChecksRepository = geoChecksRepository;
 		this.monitorStatsRepository = monitorStatsRepository;
 		this.checksRepository = checksRepository;
 		this.incidentsRepository = incidentsRepository;
@@ -455,4 +469,93 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 
 		return decision;
 	}
+
+	getEscalationJob = () => {
+		return async (data?: { incidentId: string; monitor: Monitor }) => {
+			const incidentId = data?.incidentId;
+			const monitor = data?.monitor;
+			if (!incidentId || !monitor) {
+				this.logger.warn({
+					message: "Escalation job data is missing incidentId or monitor",
+					service: SERVICE_NAME,
+					method: "getEscalationJob",
+				});
+				return;
+			}
+			try {
+				this.logger.debug({
+					message: `Processing escalation for incident ${incidentId} on monitor ${monitor.id}`,
+					service: SERVICE_NAME,
+					method: "getEscalationJob",
+				});
+
+				// Check if incident is still active and not acknowledged
+				const activeIncident = await this.incidentsRepository.findActiveByIncidentId(incidentId, monitor.teamId);
+				if (!activeIncident || activeIncident.acknowledged) {
+					this.logger.debug({
+						message: `Incident ${incidentId} is no longer active or already acknowledged, skipping escalation`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+					return;
+				}
+
+				// Check if escalation is configured
+				if (!monitor.escalation) {
+					this.logger.debug({
+						message: `No escalation configured for monitor ${monitor.id}`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+					return;
+				}
+
+				// Send escalation notification
+				const escalationNotification = await this.notificationsRepository.findById(monitor.escalation.channelId, monitor.teamId);
+				if (!escalationNotification) {
+					this.logger.warn({
+						message: `Escalation notification ${monitor.escalation.channelId} not found for monitor ${monitor.id}`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+					return;
+				}
+
+				// Build escalation message
+				const settings = this.settingsService.getSettings();
+				const clientHost = settings.clientHost || "Host not defined";
+				const escalationMessage = this.notificationMessageBuilder.buildEscalationMessage(monitor, activeIncident, clientHost);
+
+				// Send the escalation notification
+				const success = await this.notificationsService.send(escalationNotification, monitor, {} as MonitorStatusResponse, {
+					shouldCreateIncident: false,
+					shouldResolveIncident: false,
+					shouldSendNotification: true,
+					incidentReason: null,
+					notificationReason: "status_change",
+				}, escalationMessage);
+
+				if (success) {
+					this.logger.info({
+						message: `Escalation notification sent for incident ${incidentId} on monitor ${monitor.id}`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+				} else {
+					this.logger.warn({
+						message: `Failed to send escalation notification for incident ${incidentId} on monitor ${monitor.id}`,
+						service: SERVICE_NAME,
+						method: "getEscalationJob",
+					});
+				}
+			} catch (error: unknown) {
+				this.logger.error({
+					message: error instanceof Error ? error.message : "Unknown error",
+					service: SERVICE_NAME,
+					method: "getEscalationJob",
+					stack: error instanceof Error ? error.stack : undefined,
+				});
+			}
+		};
+	};
 }

--- a/server/src/service/infrastructure/notificationMessageBuilder.ts
+++ b/server/src/service/infrastructure/notificationMessageBuilder.ts
@@ -1,4 +1,4 @@
-import type { HardwareStatusPayload, Monitor, MonitorStatusResponse } from "@/types/index.js";
+import type { HardwareStatusPayload, Monitor, MonitorStatusResponse, Incident } from "@/types/index.js";
 import type { MonitorActionDecision } from "@/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.js";
 import type {
 	NotificationMessage,
@@ -13,6 +13,11 @@ export interface INotificationMessageBuilder {
 		monitor: Monitor,
 		monitorStatusResponse: MonitorStatusResponse,
 		decision: MonitorActionDecision,
+		clientHost: string
+	): NotificationMessage;
+	buildEscalationMessage(
+		monitor: Monitor,
+		incident: Incident,
 		clientHost: string
 	): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
@@ -52,6 +57,35 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 		};
 	}
 
+	buildEscalationMessage(
+		monitor: Monitor,
+		incident: Incident,
+		clientHost: string
+	): NotificationMessage {
+		const type: NotificationType = "escalation";
+		const severity: NotificationSeverity = "critical";
+		const content = this.buildEscalationContent(monitor, incident);
+
+		return {
+			type,
+			severity,
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content,
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+				incidentId: incident.id,
+			},
+		};
+	}
+
 	private determineNotificationType(decision: MonitorActionDecision, monitor: Monitor): NotificationType {
 		// Down status has highest priority (critical)
 		if (monitor.status === "down") {
@@ -80,6 +114,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 	private determineSeverity(type: NotificationType): NotificationSeverity {
 		switch (type) {
 			case "monitor_down":
+			case "escalation":
 				return "critical";
 			case "threshold_breach":
 				return "warning";
@@ -178,6 +213,29 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 			title: `Monitor: ${monitor.name}`,
 			summary: `Status update for monitor "${monitor.name}".`,
 			details: [`URL: ${monitor.url}`, `Status: ${monitor.status}`, `Type: ${monitor.type}`],
+			timestamp: new Date(),
+		};
+	}
+
+	private buildEscalationContent(monitor: Monitor, incident: Incident): NotificationContent {
+		const title = `ESCALATION: ${monitor.name} - Unacknowledged Incident`;
+		const summary = `Monitor "${monitor.name}" has an unacknowledged incident that requires immediate attention.`;
+		const details = [
+			`URL: ${monitor.url}`,
+			`Status: ${monitor.status}`,
+			`Type: ${monitor.type}`,
+			`Incident ID: ${incident.id}`,
+			`Started: ${new Date(incident.startTime).toLocaleString()}`,
+		];
+
+		if (incident.message) {
+			details.push(`Message: ${incident.message}`);
+		}
+
+		return {
+			title,
+			summary,
+			details,
 			timestamp: new Date(),
 		};
 	}

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -87,6 +87,10 @@ export class EmailProvider implements INotificationProvider {
 				return `Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
+			case "escalation":
+				return `ESCALATION: Monitor ${message.monitor.name} - Unacknowledged Incident`;
+			case "test":
+				return `Test notification from Checkmate`;
 			default:
 				return `Alert: ${message.monitor.name}`;
 		}

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,7 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	send: (notification: Notification, monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision, notificationMessage: NotificationMessage | undefined) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -65,7 +66,7 @@ export class NotificationsService implements INotificationsService {
 		this.notificationMessageBuilder = notificationMessageBuilder;
 	}
 
-	private send = async (
+	send = async (
 		notification: Notification,
 		monitor: Monitor,
 		monitorStatusResponse: MonitorStatusResponse,

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,9 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	acknowledged?: boolean;
+	acknowledgedAt?: string | null;
+	acknowledgedBy?: string | null;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -37,6 +37,10 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalation?: {
+		delayMinutes: number;
+		channelId: string;
+	};
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "escalation" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 
@@ -49,5 +49,6 @@ export interface NotificationMessage {
 	metadata: {
 		teamId: string;
 		notificationReason: string;
+		incidentId?: string;
 	};
 }

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -67,6 +67,12 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: z
+		.object({
+			delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+			channelId: z.string().min(1, "Escalation channel is required"),
+		})
+		.optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,12 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: z
+		.object({
+			delayMinutes: z.number().min(1, "Delay must be at least 1 minute"),
+			channelId: z.string().min(1, "Escalation channel is required"),
+		})
+		.optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),


### PR DESCRIPTION
## Added escalation notification options.
In the configuration menu for every monitor, there will be a menu for escalation notifications. Users can choose their method of notification for escalations as well the the duration of time (in minutes) a monitor must be down for in order for an escalation notification to be sent.

Fixes #1

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [X] (Do not skip this or your PR will be closed) I deployed the application locally.
- [X] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [X] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [X] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [X] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [X] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [X] My PR is granular and targeted to one specific feature.
- [ ] I ran `npm run format` in server and client directories, which automatically formats your code.
- [X] I took a screenshot or a video and attached to this PR if there is a UI change.

