### PR TITLE
Fix matrix notifications

### DIFF
--- a/server/src/service/infrastructure/notificationProviders/matrix.ts
+++ b/server/src/service/infrastructure/notificationProviders/matrix.ts
@@ -5,6 +5,7 @@ import type { AlertMatrixPayload, Notification } from "@/types/index.js";
 import type { NotificationMessage } from "@/types/notificationMessage.js";
 import { getTestMessage } from "@/service/infrastructure/notificationProviders/utils.js";
 import { ILogger } from "@/utils/logger.js";
+import { randomUUID } from "crypto";
 
 export class MatrixProvider implements INotificationProvider {
 	private logger: ILogger;
@@ -18,60 +19,48 @@ export class MatrixProvider implements INotificationProvider {
 		if (!homeserverUrl || !accessToken || !roomId) {
 			return false;
 		}
-		const url = `${homeserverUrl}/_matrix/client/v3/rooms/${roomId}/send/m.room.message?access_token=${accessToken}`;
+
 		const body = {
 			msgtype: "m.text",
 			body: getTestMessage(),
 		};
-		try {
-			await got.post(url, {
-				json: body,
-				headers: {
-					"Content-Type": "application/json",
-				},
-			});
-			return true;
-		} catch (error) {
-			const err = error as Error;
-			this.logger.warn({
-				message: "Matrix test alert failed",
-				service: SERVICE_NAME,
-				method: "sendTestAlert",
-				stack: err?.stack,
-			});
-			return false;
-		}
+		return await this.sendMessageWithBody(notification, body);
 	};
 
 	sendMessage = async (notification: Notification, message: NotificationMessage): Promise<boolean> => {
 		const { homeserverUrl, accessToken, roomId } = notification;
-
 		if (!homeserverUrl || !accessToken || !roomId) {
 			return false;
 		}
 
 		const { plainText, htmlText } = this.buildMatrixMessage(message);
-
-		const url = `${homeserverUrl}/_matrix/client/v3/rooms/${roomId}/send/m.room.message?access_token=${accessToken}`;
 		const body = {
 			msgtype: "m.text",
 			body: plainText,
 			format: "org.matrix.custom.html",
 			formatted_body: htmlText,
 		};
+		return this.sendMessageWithBody(notification, body);
+	};
+
+	private sendMessageWithBody = async (notification: Partial<Notification>, body: unknown): Promise<boolean> => {
+		const { homeserverUrl, accessToken, roomId } = notification;
+		const txnId = randomUUID();
+		const url = `${homeserverUrl}/_matrix/client/v3/rooms/${roomId}/send/m.room.message/${txnId}`;
 
 		try {
-			await got.post(url, {
+			await got.put(url, {
 				json: body,
 				headers: {
 					"Content-Type": "application/json",
+					Authorization: `Bearer ${accessToken}`,
 				},
 			});
 			return true;
 		} catch (error) {
 			const err = error as Error;
 			this.logger.warn({
-				message: "Matrix notification failed",
+				message: `Matrix notification failed : ${err.message}`,
 				service: SERVICE_NAME,
 				method: "sendMessage",
 				stack: err?.stack,


### PR DESCRIPTION

## Summary

I tried to set up a matrix notification but the test message wasn't going through : #3478  This PR fixes it.

## What changed

- use `put` instead of `post` : [Matrix spec : send API](https://spec.matrix.org/v1.18/client-server-api/#put_matrixclientv3roomsroomidsendeventtypetxnid)
- Add transaction id : [Matrix spec : transaction ID](https://spec.matrix.org/v1.18/client-server-api/#transaction-identifiers)
- use access_token in header like it's recommended here : [access token](https://spec.matrix.org/v1.18/client-server-api/#using-access-tokens)
- factorize api call
- add the response message in the warning log

## Tests

- ✅ cd server && `npm run test` (thanks to #3460 ❤️)
- ✅ `npm run lint` `npm run format` 
- ✅ tested with a local [Synapse](https://github.com/element-hq/synapse) / [element](https://github.com/element-hq/element-web)
- ✅ also tested with a distant [Conduit](https://github.com/timokoesters/conduit) server


## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

