### PR TITLE
changes

### DIFF
--- a/client/src/Pages/CreateMonitor/MonitorEscalation.tsx
+++ b/client/src/Pages/CreateMonitor/MonitorEscalation.tsx
@@ -1,0 +1,120 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { useTheme } from "@mui/material";
+import Stack from "@mui/material/Stack";
+import FormControl from "@mui/material/FormControl";
+import Divider from "@mui/material/Divider";
+import IconButton from "@mui/material/IconButton";
+import Typography from "@mui/material/Typography";
+import { Trash2 } from "lucide-react";
+import { Autocomplete, TextField } from "@/Components/inputs";
+import { LAYOUT } from "@/Utils/Theme/constants";
+
+type EscalationStep = {
+	notificationIds?: string[];
+	delayMinutes?: number;
+};
+
+type NotificationItem = {
+	id: string;
+	notificationName?: string;
+};
+
+type Props = {
+	notifications: NotificationItem[];
+	value: EscalationStep;
+	onChange: (step: EscalationStep) => void;
+};
+
+export default function MonitorEscalation({ notifications, value, onChange }: Props) {
+	const theme = useTheme();
+	const { t } = useTranslation();
+	const options = useMemo(
+		() =>
+			notifications.map((notification) => ({
+				id: notification.id,
+				name: notification.notificationName ?? notification.id,
+			})),
+		[notifications]
+	);
+	const selectedOptions = options.filter((option) =>
+		(value.notificationIds ?? []).includes(option.id)
+	);
+
+	return (
+		<Stack spacing={theme.spacing(LAYOUT.MD)}>
+			<TextField
+				type="number"
+				fieldLabel={t("pages.createMonitor.form.notifications.escalation.delayLabel")}
+				value={value.delayMinutes ?? 1}
+				onChange={(event) => {
+					const parsedValue = Number(event.target.value);
+					onChange({
+						...value,
+						delayMinutes: Number.isFinite(parsedValue)
+							? Math.max(1, Math.floor(parsedValue))
+							: 1,
+					});
+				}}
+				inputProps={{ min: 1 }}
+				fullWidth
+			/>
+			<FormControl>
+				<Typography
+					component="label"
+					variant="body2"
+					sx={{ mb: theme.spacing(0.5), color: "text.secondary" }}
+				>
+					{t("pages.createMonitor.form.notifications.escalation.channelsLabel")}
+				</Typography>
+			<Autocomplete
+				multiple
+				options={options}
+				value={selectedOptions}
+				getOptionLabel={(option) => option.name}
+				onChange={(_: unknown, selected: typeof options) =>
+					onChange({
+						...value,
+						notificationIds: selected.map((item) => item.id),
+					})
+				}
+				isOptionEqualToValue={(option, selected) => option.id === selected.id}
+			/>
+			</FormControl>
+			{selectedOptions.length > 0 && (
+				<Stack
+					flex={1}
+					width="100%"
+				>
+					{selectedOptions.map((notification, index) => (
+						<Stack
+							direction="row"
+							alignItems="center"
+							key={notification.id}
+							width="100%"
+						>
+							<Typography flexGrow={1}>{notification.name}</Typography>
+							<IconButton
+								size="small"
+								onClick={() => {
+									onChange({
+										...value,
+										notificationIds: (value.notificationIds ?? []).filter(
+											(id) => id !== notification.id
+										),
+									});
+								}}
+								aria-label={t(
+									"pages.createMonitor.form.notifications.escalation.removeLabel"
+								)}
+							>
+								<Trash2 size={16} />
+							</IconButton>
+							{index < selectedOptions.length - 1 && <Divider />}
+						</Stack>
+					))}
+				</Stack>
+			)}
+		</Stack>
+	);
+}

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -40,6 +40,16 @@ import {
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
 import type { MonitorFormData } from "@/Validation/monitor";
+import MonitorEscalation from "./MonitorEscalation";
+
+type EscalationStep = {
+	notificationIds?: string[];
+	delayMinutes?: number;
+};
+
+type MonitorPayload = MonitorFormData & {
+	escalation?: EscalationStep;
+};
 
 interface GeneralSettingsConfig {
 	urlLabel: string;
@@ -222,8 +232,8 @@ const CreateMonitorPage = () => {
 		[watchedType, t]
 	);
 
-	const { post, loading: isCreating } = usePost<MonitorFormData, Monitor>();
-	const { patch, loading: isUpdating } = usePatch<MonitorFormData, Monitor>();
+	const { post, loading: isCreating } = usePost<MonitorPayload, Monitor>();
+	const { patch, loading: isUpdating } = usePatch<MonitorPayload, Monitor>();
 	const isSubmitting = isCreating || isUpdating;
 	// Delete functionality
 	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
@@ -252,11 +262,22 @@ const CreateMonitorPage = () => {
 	};
 
 	const onSubmit = async (data: MonitorFormData) => {
+		const normalizedEscalation: EscalationStep = {
+			notificationIds: escalation.notificationIds ?? [],
+			delayMinutes: escalation.delayMinutes ?? 1,
+		};
+		const payload: MonitorPayload = {
+			...data,
+			escalation: (normalizedEscalation.notificationIds ?? []).length
+				? normalizedEscalation
+				: undefined,
+		};
+
 		let result;
 		if (isEditMode && monitorId) {
-			result = await patch(`/monitors/${monitorId}`, data);
+			result = await patch(`/monitors/${monitorId}`, payload);
 		} else {
-			result = await post("/monitors", data);
+			result = await post("/monitors", payload);
 		}
 
 		if (result?.success) {
@@ -273,6 +294,20 @@ const CreateMonitorPage = () => {
 	const onError = (errors: unknown) => {
 		logger.debug("Monitor creation validation errors", errors);
 	};
+
+	const [escalation, setEscalation] = useState<EscalationStep>({
+		notificationIds: [],
+		delayMinutes: 1,
+	});
+
+	useEffect(() => {
+		const monitorEscalation = (existingMonitor as MonitorPayload | undefined)
+			?.escalation;
+		setEscalation({
+			notificationIds: monitorEscalation?.notificationIds ?? [],
+			delayMinutes: monitorEscalation?.delayMinutes ?? 1,
+		});
+	}, [existingMonitor]);
 
 	return (
 		<BasePage
@@ -764,6 +799,17 @@ const CreateMonitorPage = () => {
 					/>
 				}
 			/>
+			<ConfigBox
+				title={t("pages.createMonitor.form.notifications.escalation.title")}
+				subtitle={t("pages.createMonitor.form.notifications.escalation.description")}
+				rightContent={
+					<MonitorEscalation
+						notifications={notifications ?? []}
+						value={escalation}
+						onChange={setEscalation}
+					/>
+				}
+			/>
 
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
@@ -871,7 +917,7 @@ const CreateMonitorPage = () => {
 									/>
 									<Controller
 										name="jsonPath"
-										control={control}
+									 control={control}
 										render={({ field, fieldState }) => (
 											<TextField
 												{...field}

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,12 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface MonitorEscalation {
+	notificationIds: string[];
+	delayMinutes: number;
+	lastNotifiedAt?: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +66,8 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalation?: MonitorEscalation;
+	lastStatusChangeAt?: string;
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -541,7 +541,14 @@
 				},
 				"notifications": {
 					"description": "Select the notification channels you want to use",
-					"title": "Notifications"
+					"title": "Notifications",
+					"escalation": {
+						"title": "Escalation rules",
+						"description": "If the monitor stays down for the specified time, notify additional channels.",
+						"delayLabel": "Escalate after (minutes)",
+						"channelsLabel": "Escalation notification channels",
+						"removeLabel": "Remove escalated notification"
+					}
 				},
 				"type": {
 					"description": "Select the type of check to perform",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -855,7 +855,6 @@
 			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
 				"@babel/generator": "^7.28.6",
@@ -1485,7 +1484,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -1530,7 +1528,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4322,7 +4319,6 @@
 			"integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -4483,7 +4479,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
 			"integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -4733,7 +4728,6 @@
 			"integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.56.1",
 				"@typescript-eslint/types": "8.56.1",
@@ -5347,7 +5341,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5926,7 +5919,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.19",
 				"caniuse-lite": "^1.0.30001751",
@@ -6869,7 +6861,6 @@
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.1.tgz",
 			"integrity": "sha512-fm4D8ti0dQmFPeF8DXSAA//btEmqCOgAc/9Oa3C1LW94h5usNrJEfrON7b4FkPZgnDEn6OUs5NdxiJZmAtGOpQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssnano-preset-default": "^7.0.9",
 				"lilconfig": "^3.1.3"
@@ -7637,7 +7628,6 @@
 			"integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7999,7 +7989,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
 			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -9668,7 +9657,6 @@
 			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.2.0",
 				"@jest/types": "30.2.0",
@@ -12409,7 +12397,6 @@
 			"resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
 			"integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"pg-connection-string": "^2.12.0",
 				"pg-pool": "^3.13.0",
@@ -12645,7 +12632,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -14754,7 +14740,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14923,7 +14908,6 @@
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -15086,7 +15070,6 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/server/src/db/migration/timescaledb/index.ts
+++ b/server/src/db/migration/timescaledb/index.ts
@@ -21,6 +21,7 @@ import { createStatusPages, dropStatusPages } from "./0018_create_status_pages.j
 import { createAppSettings, dropAppSettings } from "./0019_create_app_settings.js";
 import { createContinuousAggregates, dropContinuousAggregates } from "./0020_create_continuous_aggregates.js";
 import { createRetentionCompression, dropRetentionCompression } from "./0021_create_retention_compression.js";
+import { addMonitorEscalation, dropMonitorEscalation } from "./0022_add_monitor_escalation.js";
 
 const SERVICE_NAME = "TimescaleDB Migrations";
 
@@ -52,6 +53,7 @@ const migrations: MigrationEntry[] = [
 	{ name: "0019_create_app_settings", up: createAppSettings, down: dropAppSettings },
 	{ name: "0020_create_continuous_aggregates", up: createContinuousAggregates, down: dropContinuousAggregates },
 	{ name: "0021_create_retention_compression", up: createRetentionCompression, down: dropRetentionCompression },
+	{ name: "0022_add_monitor_escalation", up: addMonitorEscalation, down: dropMonitorEscalation },
 ];
 
 const ensureMigrationsTable = async (pool: Pool) => {

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -284,6 +284,22 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalation: {
+			notificationIds: {
+				type: [String],
+				default: [],
+			},
+			delayMinutes: {
+				type: Number,
+				default: 1,
+			},
+			lastNotifiedAt: {
+				type: Date,
+			},
+		},
+		lastStatusChangeAt: {
+			type: Date,
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -374,6 +374,18 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation: doc.escalation
+				? {
+						notificationIds: doc.escalation.notificationIds ?? [],
+						delayMinutes: doc.escalation.delayMinutes ?? 1,
+						lastNotifiedAt: doc.escalation.lastNotifiedAt
+							? toDateString(doc.escalation.lastNotifiedAt)
+							: undefined,
+					}
+				: undefined,
+			lastStatusChangeAt: doc.lastStatusChangeAt
+				? toDateString(doc.lastStatusChangeAt)
+				: undefined,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -433,6 +445,18 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalation: doc.escalation
+				? {
+						notificationIds: doc.escalation.notificationIds ?? [],
+						delayMinutes: doc.escalation.delayMinutes ?? 1,
+						lastNotifiedAt: doc.escalation.lastNotifiedAt
+							? toDateString(doc.escalation.lastNotifiedAt)
+							: undefined,
+					}
+				: undefined,
+			lastStatusChangeAt: doc.lastStatusChangeAt
+				? toDateString(doc.lastStatusChangeAt)
+				: undefined,
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/repositories/monitors/TimescaleMonitorsRepository.ts
+++ b/server/src/repositories/monitors/TimescaleMonitorsRepository.ts
@@ -40,6 +40,8 @@ interface MonitorRow {
 	geo_check_enabled: boolean;
 	geo_check_locations: GeoContinent[] | null;
 	geo_check_interval_ms: number;
+	escalation: { notificationIds?: string[]; delayMinutes?: number; lastNotifiedAt?: string } | null;
+	last_status_change_at: Date | null;
 	created_at: Date;
 	updated_at: Date;
 }
@@ -50,6 +52,7 @@ const MONITOR_COLUMNS = `id, user_id, team_id, name, description, type, status, 
 	cpu_alert_threshold, cpu_alert_counter, memory_alert_threshold, memory_alert_counter,
 	disk_alert_threshold, disk_alert_counter, temp_alert_threshold, temp_alert_counter, selected_disks,
 	game_id, grpc_service_name, monitor_group, geo_check_enabled, geo_check_locations, geo_check_interval_ms,
+	escalation, last_status_change_at,
 	created_at, updated_at`;
 
 export class TimescaleMonitorsRepository implements IMonitorsRepository {
@@ -62,8 +65,8 @@ export class TimescaleMonitorsRepository implements IMonitorsRepository {
 				interval_ms, is_active, status_window, status_window_size, status_window_threshold,
 				cpu_alert_threshold, cpu_alert_counter, memory_alert_threshold, memory_alert_counter,
 				disk_alert_threshold, disk_alert_counter, temp_alert_threshold, temp_alert_counter, selected_disks,
-				game_id, grpc_service_name, monitor_group, geo_check_enabled, geo_check_locations, geo_check_interval_ms)
-			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34)
+				game_id, grpc_service_name, monitor_group, geo_check_enabled, geo_check_locations, geo_check_interval_ms, escalation, last_status_change_at)
+			 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36)
 			 RETURNING ${MONITOR_COLUMNS}`,
 			[
 				userId,
@@ -100,6 +103,8 @@ export class TimescaleMonitorsRepository implements IMonitorsRepository {
 				monitor.geoCheckEnabled ?? false,
 				monitor.geoCheckLocations ?? [],
 				monitor.geoCheckInterval ?? 300000,
+				monitor.escalation ?? null,
+				monitor.lastStatusChangeAt ? new Date(monitor.lastStatusChangeAt) : null,
 			]
 		);
 		const row = result.rows[0];
@@ -598,6 +603,8 @@ export class TimescaleMonitorsRepository implements IMonitorsRepository {
 			["geoCheckEnabled", "geo_check_enabled"],
 			["geoCheckLocations", "geo_check_locations"],
 			["geoCheckInterval", "geo_check_interval_ms"],
+			["escalation", "escalation"],
+			["lastStatusChangeAt", "last_status_change_at"],
 		];
 
 		for (const [key, column] of fieldMap) {
@@ -1037,6 +1044,14 @@ export class TimescaleMonitorsRepository implements IMonitorsRepository {
 		geoCheckEnabled: row.geo_check_enabled,
 		geoCheckLocations: row.geo_check_locations ?? [],
 		geoCheckInterval: row.geo_check_interval_ms,
+		escalation: row.escalation
+			? {
+					notificationIds: row.escalation.notificationIds ?? [],
+					delayMinutes: row.escalation.delayMinutes ?? 1,
+					lastNotifiedAt: row.escalation.lastNotifiedAt ?? undefined,
+				}
+			: undefined,
+		lastStatusChangeAt: row.last_status_change_at?.toISOString(),
 		recentChecks: [],
 		createdAt: row.created_at.toISOString(),
 		updatedAt: row.updated_at.toISOString(),

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -157,16 +157,14 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				const decision = this.evaluateMonitorAction(statusChangeResult);
 
 				// Step 6. Handle notifications (best effort, continue even in event of failure, don't wait)
-				if (decision.shouldSendNotification) {
-					this.notificationsService.handleNotifications(statusChangeResult.monitor, status, decision).catch((error: unknown) => {
-						this.logger.error({
-							message: `Error sending notifications for job ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
-							service: SERVICE_NAME,
-							method: "getMonitorJob",
-							stack: error instanceof Error ? error.stack : undefined,
-						});
+				this.notificationsService.handleNotifications(statusChangeResult.monitor, status, decision).catch((error: unknown) => {
+					this.logger.error({
+						message: `Error sending notifications for job ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "getMonitorJob",
+						stack: error instanceof Error ? error.stack : undefined,
 					});
-				}
+				});
 
 				// Step 7. Handle incidents (best effort, don't wait)
 				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -78,17 +78,21 @@ export class EmailProvider implements INotificationProvider {
 	}
 
 	private buildSubject(message: NotificationMessage): string {
+		const escalationPrefix = message.metadata.isEscalation
+			? "[Escalated] "
+			: "";
+
 		switch (message.type) {
 			case "monitor_down":
-				return `Monitor ${message.monitor.name} is down`;
+				return `${escalationPrefix}Monitor ${message.monitor.name} is down`;
 			case "monitor_up":
-				return `Monitor ${message.monitor.name} is back up`;
+				return `${escalationPrefix}Monitor ${message.monitor.name} is back up`;
 			case "threshold_breach":
-				return `Monitor ${message.monitor.name} threshold exceeded`;
+				return `${escalationPrefix}Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
-				return `Monitor ${message.monitor.name} thresholds resolved`;
+				return `${escalationPrefix}Monitor ${message.monitor.name} thresholds resolved`;
 			default:
-				return `Alert: ${message.monitor.name}`;
+				return `${escalationPrefix}Alert: ${message.monitor.name}`;
 		}
 	}
 

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -112,14 +112,40 @@ export class NotificationsService implements INotificationsService {
 		}
 	};
 
-	private sendNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
+	private sendNotifications = async (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision,
+		isEscalation: boolean = false
+	) => {
 		const notificationIds = monitor.notifications ?? [];
+		return this.sendNotificationsByIds(
+			monitor,
+			monitorStatusResponse,
+			decision,
+			notificationIds,
+			isEscalation
+		);
+	};
+
+	private sendNotificationsByIds = async (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		decision: MonitorActionDecision,
+		notificationIds: string[],
+		isEscalation: boolean = false
+	) => {
+		if (!notificationIds.length) {
+			return true;
+		}
+
 		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
 
 		// Build notification message once for all notifications
 		const settings = this.settingsService.getSettings();
 		const clientHost = settings.clientHost || "Host not defined";
 		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+		notificationMessage.metadata.isEscalation = isEscalation;
 
 		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage));
 
@@ -138,12 +164,78 @@ export class NotificationsService implements INotificationsService {
 	};
 
 	handleNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {
-		if (!decision.shouldSendNotification) {
-			return false;
+		let sentAnyNotification = false;
+
+		if (decision.shouldSendNotification) {
+			const immediateSent = await this.sendNotifications(monitor, monitorStatusResponse, decision);
+			sentAnyNotification = sentAnyNotification || immediateSent;
 		}
 
-		// Send notifications based on decision
-		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+		const escalation = monitor.escalation;
+		const shouldEvaluateEscalation =
+			monitor.status === "down" &&
+			Boolean(escalation) &&
+			(escalation?.notificationIds?.length ?? 0) > 0 &&
+			(escalation?.delayMinutes ?? 0) > 0;
+
+		if (!shouldEvaluateEscalation) {
+			return sentAnyNotification;
+		}
+
+		// Backfill baseline for older monitors that are already down and don't have this field yet.
+		// Start the escalation timer from first observed down state.
+		if (!monitor.lastStatusChangeAt) {
+			await this.monitorsRepository.updateById(monitor.id, monitor.teamId, {
+				lastStatusChangeAt: new Date().toISOString(),
+			});
+			return sentAnyNotification;
+		}
+
+		const downSince = monitor.lastStatusChangeAt
+			? new Date(monitor.lastStatusChangeAt).getTime()
+			: Number.NaN;
+		const now = Date.now();
+		const delayMs = (escalation?.delayMinutes ?? 0) * 60 * 1000;
+
+		if (!Number.isFinite(downSince) || now - downSince < delayMs) {
+			return sentAnyNotification;
+		}
+
+		const lastEscalationAt = escalation?.lastNotifiedAt
+			? new Date(escalation.lastNotifiedAt).getTime()
+			: Number.NaN;
+		const alreadyNotifiedForCurrentOutage =
+			Number.isFinite(lastEscalationAt) && lastEscalationAt >= downSince;
+
+		if (alreadyNotifiedForCurrentOutage) {
+			return sentAnyNotification;
+		}
+
+		const escalationDecision: MonitorActionDecision = {
+			...decision,
+			shouldSendNotification: true,
+			notificationReason: "status_change",
+		};
+
+		const escalationSent = await this.sendNotificationsByIds(
+			monitor,
+			monitorStatusResponse,
+			escalationDecision,
+			escalation?.notificationIds ?? [],
+			true
+		);
+
+		if (escalationSent) {
+			await this.monitorsRepository.updateById(monitor.id, monitor.teamId, {
+				escalation: {
+					notificationIds: escalation?.notificationIds ?? [],
+					delayMinutes: escalation?.delayMinutes ?? 1,
+					lastNotifiedAt: new Date(now).toISOString(),
+				},
+			});
+		}
+
+		return sentAnyNotification || escalationSent;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/service/infrastructure/statusService.ts
+++ b/server/src/service/infrastructure/statusService.ts
@@ -347,6 +347,14 @@ export class StatusService implements IStatusService {
 
 			// Apply the final status
 			monitor.status = newStatus;
+			if (statusChanged) {
+				const nowIso = new Date().toISOString();
+				monitor.lastStatusChangeAt = nowIso;
+				if (monitor.escalation) {
+					// Reset escalation state whenever status transitions.
+					monitor.escalation.lastNotifiedAt = undefined;
+				}
+			}
 
 			const updated = await this.monitorsRepository.updateById(monitor.id, monitor.teamId, monitor);
 

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,12 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface MonitorEscalation {
+	notificationIds: string[];
+	delayMinutes: number;
+	lastNotifiedAt?: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +43,8 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalation?: MonitorEscalation;
+	lastStatusChangeAt?: string;
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -49,5 +49,6 @@ export interface NotificationMessage {
 	metadata: {
 		teamId: string;
 		notificationReason: string;
+		isEscalation?: boolean;
 	};
 }

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -49,6 +49,12 @@ export const getCertificateParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
 
+const monitorEscalationValidation = z.object({
+	notificationIds: z.array(z.string()).default([]),
+	delayMinutes: z.number().int().min(1).default(1),
+	lastNotifiedAt: z.string().optional(),
+});
+
 export const createMonitorBodyValidation = z.object({
 	_id: z.string().optional(),
 	name: z.string().min(1, "Name is required"),
@@ -67,6 +73,8 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: monitorEscalationValidation.optional(),
+	lastStatusChangeAt: z.string().optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +97,8 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalation: monitorEscalationValidation.optional(),
+	lastStatusChangeAt: z.string().optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +154,8 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalation: monitorEscalationValidation.optional(),
+	lastStatusChangeAt: z.string().optional(),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
Describe your changes
Added escalation notifications for monitor downtime, with both UI and backend support.

Frontend
Added a dedicated Escalation Rules section under Configure > Notifications (separate block from regular notifications).
Reused the same notification-channel picker behavior as regular notifications.
Added Escalate after (minutes) input for delay configuration.
Added i18n strings for new escalation labels/descriptions.
Included escalation fields in Create/Edit monitor payloads.
Backend
Added monitor escalation data model support:
escalation.notificationIds
escalation.delayMinutes
i
- [ ] (Do not skip this or your PR will be closed) I deployed the application locally.
- [ ] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
- [ ] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [ ] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [ ] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [ ] My PR is granular and targeted to one specific feature.
- [ ] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

all checked