### PR TITLE
feat: add escalated notifications for monitors

### DIFF
--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -12,6 +12,7 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	description: data?.description || "",
 	interval: data?.interval || 60000,
 	notifications: data?.notifications || [],
+	escalations: data?.escalations || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -765,6 +765,114 @@ const CreateMonitorPage = () => {
 				}
 			/>
 
+			<ConfigBox
+				title="Escalated notifications"
+				subtitle="Send additional alerts after a monitor has been down for a specified amount of time. Escalations reset when the monitor recovers."
+				rightContent={
+					<Controller
+						name="escalations"
+						control={control}
+						render={({ field, fieldState }) => {
+							const value = (field.value ?? []) as {
+								delayMinutes: number;
+								notificationId: string;
+							}[];
+							const notificationOptions = notifications ?? [];
+							const updateAt = (
+								idx: number,
+								patch: Partial<{ delayMinutes: number; notificationId: string }>
+							) => {
+								const next = value.map((row, i) =>
+									i === idx ? { ...row, ...patch } : row
+								);
+								field.onChange(next);
+							};
+							const removeAt = (idx: number) => {
+								field.onChange(value.filter((_, i) => i !== idx));
+							};
+							const addRow = () => {
+								field.onChange([
+									...value,
+									{ delayMinutes: 5, notificationId: "" },
+								]);
+							};
+							return (
+								<Stack spacing={theme.spacing(LAYOUT.MD)}>
+									{value.length === 0 && (
+										<Typography color="text.secondary">
+											No escalations configured. Add one to be alerted again if an
+											incident persists.
+										</Typography>
+									)}
+									{value.map((row, idx) => (
+										<Stack
+											key={idx}
+											direction="row"
+											spacing={theme.spacing(SPACING.LG)}
+											alignItems="center"
+										>
+											<TextField
+												type="number"
+												fieldLabel="Delay (minutes)"
+												value={row.delayMinutes}
+												onChange={(e) =>
+													updateAt(idx, {
+														delayMinutes: Number(e.target.value) || 0,
+													})
+												}
+												sx={{ width: 160 }}
+											/>
+											<Select
+												value={row.notificationId || ""}
+												fieldLabel="Notification channel"
+												onChange={(e) =>
+													updateAt(idx, {
+														notificationId: String(e.target.value ?? ""),
+													})
+												}
+												sx={{ flexGrow: 1 }}
+											>
+												<MenuItem value="">
+													<em>Select a notification</em>
+												</MenuItem>
+												{notificationOptions.map((n) => (
+													<MenuItem
+														key={n.id}
+														value={n.id}
+													>
+														{n.notificationName} ({n.type})
+													</MenuItem>
+												))}
+											</Select>
+											<IconButton
+												size="small"
+												onClick={() => removeAt(idx)}
+												aria-label="Remove escalation"
+											>
+												<Trash2 size={16} />
+											</IconButton>
+										</Stack>
+									))}
+									{fieldState.error && (
+										<Typography color="error">
+											Please fill in delay and notification channel for each
+											escalation.
+										</Typography>
+									)}
+									<Button
+										variant="outlined"
+										onClick={addRow}
+										sx={{ alignSelf: "flex-start" }}
+									>
+										Add escalation
+									</Button>
+								</Stack>
+							);
+						}}
+					/>
+				}
+			/>
+
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||
 				watchedType === "websocket") && (

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -38,6 +38,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 
 export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
 
+export interface EscalationConfig {
+	delayMinutes: number;
+	notificationId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -60,6 +65,7 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations?: EscalationConfig[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -13,6 +13,18 @@ const baseSchema = z.object({
 	description: z.string().optional(),
 	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
 	notifications: z.array(z.string()),
+	escalations: z
+		.array(
+			z.object({
+				delayMinutes: z
+					.number({ message: "Delay is required" })
+					.min(0, "Delay must be at least 0 minutes")
+					.max(10080, "Delay must be at most 10080 minutes (7 days)"),
+				notificationId: z.string().min(1, "Notification channel is required"),
+			})
+		)
+		.optional()
+		.default([]),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -18,11 +18,14 @@ type CheckSnapshotDocument = Omit<CheckSnapshot, "createdAt"> & { createdAt: Dat
 
 type MonitorDocumentBase = Omit<
 	Monitor,
-	"id" | "userId" | "teamId" | "notifications" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
+	"id" | "userId" | "teamId" | "notifications" | "escalations" | "downSince" | "selectedDisks" | "statusWindow" | "recentChecks" | "createdAt" | "updatedAt"
 > & {
 	statusWindow: boolean[];
 	recentChecks: CheckSnapshotDocument[];
 	notifications: Types.ObjectId[];
+	escalations: { delayMinutes: number; notificationId: Types.ObjectId }[];
+	downSince: Date | null;
+	escalationsSent: number[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
 };
@@ -284,6 +287,26 @@ const MonitorSchema = new Schema<MonitorDocument>(
 				ref: "Notification",
 			},
 		],
+		escalations: {
+			type: [
+				new Schema(
+					{
+						delayMinutes: { type: Number, required: true, min: 0 },
+						notificationId: { type: Schema.Types.ObjectId, ref: "Notification", required: true },
+					},
+					{ _id: false }
+				),
+			],
+			default: [],
+		},
+		downSince: {
+			type: Date,
+			default: null,
+		},
+		escalationsSent: {
+			type: [Number],
+			default: [],
+		},
 		secret: {
 			type: String,
 		},

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -351,6 +351,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification) => toStringId(notification));
+		const escalations = (doc.escalations ?? []).map((e: { delayMinutes: number; notificationId: unknown }) => ({
+			delayMinutes: e.delayMinutes,
+			notificationId: toStringId(e.notificationId),
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -374,6 +378,9 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations,
+			downSince: doc.downSince ? (doc.downSince instanceof Date ? doc.downSince.toISOString() : String(doc.downSince)) : null,
+			escalationsSent: doc.escalationsSent ?? [],
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,
@@ -410,6 +417,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 
 		const notificationIds = (doc.notifications ?? []).map((notification: unknown) => toStringId(notification));
+		const escalations = (doc.escalations ?? []).map((e: { delayMinutes: number; notificationId: unknown }) => ({
+			delayMinutes: e.delayMinutes,
+			notificationId: toStringId(e.notificationId),
+		}));
 
 		return {
 			id: toStringId(doc._id),
@@ -433,6 +444,9 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			interval: doc.interval,
 			uptimePercentage: doc.uptimePercentage ?? undefined,
 			notifications: notificationIds,
+			escalations,
+			downSince: doc.downSince ? (doc.downSince instanceof Date ? doc.downSince.toISOString() : String(doc.downSince)) : null,
+			escalationsSent: doc.escalationsSent ?? [],
 			secret: doc.secret ?? undefined,
 			cpuAlertThreshold: doc.cpuAlertThreshold,
 			cpuAlertCounter: doc.cpuAlertCounter,

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -1,5 +1,6 @@
 const SERVICE_NAME = "JobQueueHelper";
 import type { Monitor } from "@/types/monitor.js";
+import type { MonitorStatusResponse } from "@/types/index.js";
 import { supportsGeoCheck } from "@/types/monitor.js";
 import { AppError } from "@/utils/AppError.js";
 import {
@@ -165,6 +166,16 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 							method: "getMonitorJob",
 							stack: error instanceof Error ? error.stack : undefined,
 						});
+					});
+				}
+
+				try {
+					await this.handleEscalations(statusChangeResult.monitor, status);
+				} catch (error: unknown) {
+					this.logger.warn({
+						message: `Error handling escalations for monitor ${statusChangeResult.monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "getMonitorJob",
 					});
 				}
 
@@ -417,6 +428,72 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 			}
 		};
 	};
+
+	private async handleEscalations(monitor: Monitor, status: MonitorStatusResponse): Promise<void> {
+		const monitorId = monitor.id;
+		const teamId = monitor.teamId;
+		const escalations = monitor.escalations ?? [];
+
+		if (monitor.status !== "down") {
+			if (monitor.downSince || (monitor.escalationsSent && monitor.escalationsSent.length > 0)) {
+				await this.monitorsRepository.updateById(monitorId, teamId, {
+					downSince: null,
+					escalationsSent: [],
+				});
+			}
+			return;
+		}
+
+		let downSinceMs: number;
+		const alreadySent = monitor.escalationsSent ?? [];
+		if (!monitor.downSince) {
+			downSinceMs = Date.now();
+			await this.monitorsRepository.updateById(monitorId, teamId, {
+				downSince: new Date(downSinceMs).toISOString(),
+				escalationsSent: [],
+			});
+		} else {
+			downSinceMs = new Date(monitor.downSince).getTime();
+		}
+
+		if (escalations.length === 0) {
+			return;
+		}
+
+		const elapsedMinutes = (Date.now() - downSinceMs) / 60000;
+		const dueEscalations = escalations.filter((e) => e.delayMinutes <= elapsedMinutes && !alreadySent.includes(e.delayMinutes));
+
+		if (dueEscalations.length === 0) {
+			return;
+		}
+
+		const byDelay = new Map<number, string[]>();
+		for (const esc of dueEscalations) {
+			const list = byDelay.get(esc.delayMinutes) ?? [];
+			list.push(esc.notificationId);
+			byDelay.set(esc.delayMinutes, list);
+		}
+
+		const newlySent: number[] = [];
+		for (const [delay, notificationIds] of byDelay) {
+			try {
+				await this.notificationsService.sendEscalationNotifications(monitor, status, notificationIds, delay);
+				newlySent.push(delay);
+			} catch (error: unknown) {
+				this.logger.warn({
+					message: `Failed to send escalation (delay=${delay}) for monitor ${monitorId}: ${error instanceof Error ? error.message : "Unknown error"}`,
+					service: SERVICE_NAME,
+					method: "handleEscalations",
+				});
+			}
+		}
+
+		if (newlySent.length > 0) {
+			await this.monitorsRepository.updateById(monitorId, teamId, {
+				escalationsSent: [...alreadySent, ...newlySent],
+			});
+		}
+	}
 
 	private evaluateMonitorAction(statusChangeResult: StatusChangeResult): MonitorActionDecision {
 		const { monitor, statusChanged, prevStatus } = statusChangeResult;

--- a/server/src/service/infrastructure/notificationProviders/email.ts
+++ b/server/src/service/infrastructure/notificationProviders/email.ts
@@ -87,6 +87,8 @@ export class EmailProvider implements INotificationProvider {
 				return `Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
+			case "escalation":
+				return `Escalation: Monitor ${message.monitor.name} is still down`;
 			default:
 				return `Alert: ${message.monitor.name}`;
 		}

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -173,10 +173,12 @@ export class NotificationsService implements INotificationsService {
 
 		const escalationMessage: NotificationMessage = {
 			...baseMessage,
+			type: "escalation",
+			severity: "warning",
 			content: {
 				...baseMessage.content,
-				title: `[Escalation +${delayMinutes}m] ${baseMessage.content.title}`,
-				summary: `Monitor "${monitor.name}" has been down for at least ${delayMinutes} minute(s). ${baseMessage.content.summary}`,
+				title: `Escalation: Monitor ${monitor.name} is still down`,
+				summary: `Monitor "${monitor.name}" has been down for at least ${delayMinutes} minute(s). This is an escalated notification.`,
 			},
 		};
 

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -14,6 +14,12 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+	sendEscalationNotifications: (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		notificationIds: string[],
+		delayMinutes: number
+	) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -135,6 +141,48 @@ export class NotificationsService implements INotificationsService {
 		}
 		// Return true if all notifications succeeded
 		return succeeded === notifications.length;
+	};
+
+	sendEscalationNotifications = async (
+		monitor: Monitor,
+		monitorStatusResponse: MonitorStatusResponse,
+		notificationIds: string[],
+		delayMinutes: number
+	): Promise<boolean> => {
+		if (!notificationIds || notificationIds.length === 0) {
+			return false;
+		}
+
+		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
+		if (!notifications.length) {
+			return false;
+		}
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+
+		const decision: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "status_change",
+		};
+
+		const baseMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
+
+		const escalationMessage: NotificationMessage = {
+			...baseMessage,
+			content: {
+				...baseMessage.content,
+				title: `[Escalation +${delayMinutes}m] ${baseMessage.content.title}`,
+				summary: `Monitor "${monitor.name}" has been down for at least ${delayMinutes} minute(s). ${baseMessage.content.summary}`,
+			},
+		};
+
+		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, escalationMessage));
+		const outcomes = await Promise.all(tasks);
+		return outcomes.every(Boolean);
 	};
 
 	handleNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -15,6 +15,11 @@ export type MonitorStatus = (typeof MonitorStatuses)[number];
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";
 
+export interface EscalationConfig {
+	delayMinutes: number;
+	notificationId: string;
+}
+
 export interface Monitor {
 	id: string;
 	userId: string;
@@ -37,6 +42,9 @@ export interface Monitor {
 	interval: number;
 	uptimePercentage?: number;
 	notifications: string[];
+	escalations?: EscalationConfig[];
+	downSince?: string | null;
+	escalationsSent?: number[];
 	secret?: string;
 	cpuAlertThreshold: number;
 	cpuAlertCounter: number;

--- a/server/src/types/notificationMessage.ts
+++ b/server/src/types/notificationMessage.ts
@@ -3,7 +3,7 @@
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "escalation" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -45,6 +45,11 @@ export const getMonitorsWithChecksQueryValidation = z.object({
 	explain: booleanCoercion.optional(),
 });
 
+const escalationSchema = z.object({
+	delayMinutes: z.number().min(0).max(10080),
+	notificationId: z.string().min(1),
+});
+
 export const getCertificateParamValidation = z.object({
 	monitorId: z.string().min(1, "Monitor ID is required"),
 });
@@ -67,6 +72,7 @@ export const createMonitorBodyValidation = z.object({
 	diskAlertThreshold: z.number().optional(),
 	tempAlertThreshold: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.array(escalationSchema).optional(),
 	secret: z.string().optional(),
 	jsonPath: z.union([z.string(), z.literal("")]).optional(),
 	expectedValue: z.union([z.string(), z.literal("")]).optional(),
@@ -89,6 +95,7 @@ export const editMonitorBodyValidation = z.object({
 	description: z.union([z.string(), z.literal("")]).optional(),
 	interval: z.number().optional(),
 	notifications: z.array(z.string()).optional(),
+	escalations: z.array(escalationSchema).optional(),
 	secret: z.string().optional(),
 	ignoreTlsErrors: z.boolean().optional(),
 	useAdvancedMatching: z.boolean().optional(),
@@ -144,6 +151,7 @@ const importedMonitorSchema = z.object({
 	interval: z.number().default(60000),
 	uptimePercentage: z.number().optional(),
 	notifications: z.array(z.string()).default([]),
+	escalations: z.array(escalationSchema).default([]),
 	secret: z.string().optional(),
 	cpuAlertThreshold: z.number().default(100),
 	cpuAlertCounter: z.number().default(5),


### PR DESCRIPTION
## Summary

Adds escalated notifications: per-monitor list of additional alerts that fire after a monitor has been down for a configurable delay (in minutes). Each escalation targets one of the user's existing notification channels. Tracking resets automatically when the monitor recovers.

## Changes

**Backend**
- Extended the Monitor model with \`escalations\`, \`downSince\`, and \`escalationsSent\` fields.
- Added validation for escalations on create / edit / import.
- Repository now persists and returns the new fields.
- New \`sendEscalationNotifications\` method on \`NotificationsService\` reuses the existing message builder and provider routing, prefixing the title with \`[Escalation +Nm]\`.
- Heartbeat job stamps \`downSince\` on first DOWN observation, fires due escalations grouped by delay, persists \`escalationsSent\`, and clears tracking on recovery.

**Frontend**
- New "Escalated notifications" config box on the create/edit monitor page with add/remove rows (delay in minutes + notification channel dropdown).
- Form defaults, schema, and \`Monitor\` type updated so values persist across reload and reset cleanly on cancel.

## Test plan
- Create a monitor with two escalations (e.g. 1 min and 2 min) pointing at an email notification channel.
- Reload the edit page and confirm the escalations persist.
- Cancel an in-progress edit and confirm changes are discarded.
- Take the monitored target offline and confirm the initial down alert and each escalation email arrive after their respective delays.
- Bring the target back online and confirm escalation tracking resets (no further escalation emails on the next downtime until delays elapse again).