### PR TITLE
feat: escalation notifications added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+> [!NOTE]
+> ## 🎓 CEN3031 — Spring 2026 Mini Project
+>
+> This is the **central repository** for the CEN3031 Spring 2026 mini project.
+>
+> - 🍴 **Fork this repo** to begin your work
+> - 🔀 **All pull requests** should be submitted here
+> - 📖 **Read the rest of this README** for details about the project itself
+
+---
+
+
 <p align=center> <a href="https://trendshift.io/repositories/12443" target="_blank"><img src="https://trendshift.io/api/badge/repositories/12443" alt="bluewave-labs%2Fcheckmate | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a></p>
   
 ![](https://img.shields.io/github/license/bluewave-labs/checkmate)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Checkmate has been stress-tested with 1000+ active monitors without any particul
 
 ## Demo
 
-You can see the latest build of [Checkmate](https://checkmate-demo.bluewavelabs.ca/) in action. The username is demouser@demo.com and the password is Demouser1! (just a note that we update the demo server from time to time, so if it doesn't work for you, please ping us on the Discussions channel).
+You can see the latest build of [Checkmate](https://checkmate-demo.bluewavelabs.ca/) in action. Upon initial launch of the application, please register and fill out the appropriate fields. You can put whatever you would like for all of them just make sure to remember your username and password. The email that you use needs to be a real email you have access to as it will be the recipent of some of the notification emails.
 
 ## User's guide
 

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -17,6 +17,8 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
 	geoCheckLocations: data?.geoCheckLocations || [],
 	geoCheckInterval: data?.geoCheckInterval || 300000,
+	escalationNotificationId: data?.escalationNotificationId || null,
+	escalationDelayMinutes: data?.escalationDelayMinutes || null,
 });
 
 export const useMonitorForm = ({

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -202,7 +202,8 @@ const CreateMonitorPage = () => {
 		resolver: zodResolver(schema),
 		defaultValues: defaults,
 	});
-	const { control, watch, handleSubmit, clearErrors } = form;
+	const { control, watch, handleSubmit, clearErrors, formState } = form;
+	const { errors } = formState;
 
 	useEffect(() => {
 		form.reset(defaults);
@@ -212,6 +213,8 @@ const CreateMonitorPage = () => {
 
 	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
 	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
+	const watchedEscalationNotificationId = watch("escalationNotificationId") as string | null;
+	const watchedInterval = watch("interval") as number;
 
 	useEffect(() => {
 		clearErrors();
@@ -764,6 +767,208 @@ const CreateMonitorPage = () => {
 					/>
 				}
 			/>
+
+			<ConfigBox
+				title={t("pages.createMonitor.form.escalation.title")}
+				subtitle={t("pages.createMonitor.form.escalation.description")}
+				rightContent={
+					<Stack spacing={theme.spacing(LAYOUT.MD)}>
+						<Controller
+							name="escalationNotificationId"
+							control={control}
+							render={({ field }) => {
+								const notificationOptions = (notifications ?? []).map((n) => ({
+									...n,
+									name: n.notificationName,
+								}));
+								const selectedNotification = notificationOptions.find(
+									(n) => n.id === field.value
+								);
+								return (
+									<Stack spacing={theme.spacing(SPACING.MD)}>
+										<Typography variant="subtitle2">
+											{t("pages.createMonitor.form.escalation.notificationLabel")}
+										</Typography>
+										<Autocomplete
+											options={notificationOptions}
+											value={selectedNotification || null}
+											getOptionLabel={(option) => option.name}
+											onChange={(_: unknown, newValue: typeof notificationOptions[0] | null) => {
+												field.onChange(newValue?.id || null);
+											}}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+											noOptionsText={t("pages.createMonitor.form.escalation.noNotifications")}
+										/>
+										{selectedNotification && (
+											<Stack
+												sx={{
+													p: theme.spacing(SPACING.MD),
+													bgcolor: "background.default",
+													borderRadius: 1,
+													border: `1px solid ${theme.palette.divider}`,
+												}}
+												spacing={theme.spacing(SPACING.SM)}
+											>
+												<Stack
+													direction="row"
+													alignItems="center"
+													justifyContent="space-between"
+												>
+													<Stack flex={1} spacing={0.5}>
+														<Typography variant="body2" sx={{ fontWeight: 600 }}>
+															{selectedNotification.notificationName}
+														</Typography>
+														<Typography variant="caption" sx={{ color: "text.secondary" }}>
+															{selectedNotification.address || selectedNotification.phone || "—"}
+														</Typography>
+													</Stack>
+													<IconButton
+														size="small"
+														onClick={() => field.onChange(null)}
+														aria-label="Remove escalation notification"
+													>
+														<Trash2 size={16} />
+													</IconButton>
+												</Stack>
+											</Stack>
+										)}
+									</Stack>
+								);
+							}}
+						/>
+						<Controller
+							name="escalationDelayMinutes"
+							control={control}
+							render={({ field }) => (
+								<Stack spacing={theme.spacing(SPACING.MD)}>
+									<Typography variant="subtitle2">
+										{t("pages.createMonitor.form.escalation.delayLabel")}
+									</Typography>
+									<TextField
+										type="number"
+										inputProps={{
+											min: 1,
+											max: 10080,
+											step: 1,
+										}}
+										placeholder={t("pages.createMonitor.form.escalation.delayPlaceholder")}
+										value={field.value === null ? "" : field.value}
+										onChange={(e) => {
+											const value = e.target.value ? parseInt(e.target.value, 10) : null;
+											field.onChange(value);
+										}}
+										error={Boolean(errors.escalationDelayMinutes)}
+										helperText={
+											errors.escalationDelayMinutes?.message ||
+											t("pages.createMonitor.form.escalation.delayHint")
+										}
+									/>
+									{field.value !== null && field.value !== undefined && field.value > 0 && (
+										<Stack
+											sx={{
+												p: theme.spacing(SPACING.MD),
+												bgcolor: "background.default",
+												borderRadius: 1,
+												border: `1px solid ${theme.palette.divider}`,
+											}}
+											direction="row"
+											alignItems="center"
+											justifyContent="space-between"
+										>
+											<Stack flex={1}>
+												<Typography variant="body2" sx={{ fontWeight: 600 }}>
+													{t("pages.createMonitor.form.escalation.savedDelayLabel")}
+												</Typography>
+												<Typography variant="caption" sx={{ color: "text.secondary" }}>
+													{field.value} {t("pages.createMonitor.form.escalation.minutes")}
+												</Typography>
+											</Stack>
+											<IconButton
+												size="small"
+												onClick={() => field.onChange(null)}
+												aria-label="Clear escalation delay"
+											>
+												<Trash2 size={16} />
+											</IconButton>
+										</Stack>
+									)}
+								</Stack>
+							)}
+						/>
+					</Stack>
+				}
+			/>
+
+			{watchedEscalationNotificationId && watchedInterval && (
+				<ConfigBox
+					title={t("pages.createMonitor.form.escalationSummary.title")}
+					subtitle={t("pages.createMonitor.form.escalationSummary.description")}
+					rightContent={
+						<Stack
+							direction="row"
+							alignItems="center"
+							spacing={theme.spacing(SPACING.MD)}
+							width="100%"
+						>
+							<Stack
+								spacing={theme.spacing(SPACING.SM)}
+								flex={1}
+							>
+								<Typography
+									variant="subtitle2"
+									sx={{ color: "text.secondary" }}
+								>
+									{t("pages.createMonitor.form.escalationSummary.notificationLabel")}
+								</Typography>
+								<Typography variant="body2">
+									{notifications
+										?.find((n) => n.id === watchedEscalationNotificationId)
+										?.notificationName || "—"}
+								</Typography>
+							</Stack>
+							<Stack
+								spacing={theme.spacing(SPACING.SM)}
+								flex={1}
+							>
+								<Typography
+									variant="subtitle2"
+									sx={{ color: "text.secondary" }}
+								>
+									{t("pages.createMonitor.form.escalationSummary.delayLabel")}
+								</Typography>
+								<Typography variant="body2">
+									{(watch("escalationDelayMinutes") ?? null) || "—"} {t("pages.createMonitor.form.escalationSummary.minutes")}
+								</Typography>
+							</Stack>
+							<Stack
+								spacing={theme.spacing(SPACING.SM)}
+								flex={1}
+							>
+								<Typography
+									variant="subtitle2"
+									sx={{ color: "text.secondary" }}
+								>
+									{t("pages.createMonitor.form.escalationSummary.checkIntervalLabel")}
+								</Typography>
+								<Typography variant="body2">
+									{Math.round(watchedInterval / 1000 / 60)} {t("pages.createMonitor.form.escalationSummary.minutes")}
+								</Typography>
+							</Stack>
+							<IconButton
+								size="small"
+								onClick={() => {
+									form.setValue("escalationNotificationId", null);
+									form.setValue("escalationDelayMinutes", null);
+								}}
+								aria-label="Clear escalation settings"
+								sx={{ alignSelf: "flex-start", mt: theme.spacing(SPACING.MD) }}
+							>
+								<Trash2 size={16} />
+							</IconButton>
+						</Stack>
+					}
+				/>
+			)}
 
 			{(watchedType === "http" ||
 				watchedType === "grpc" ||

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -76,6 +76,8 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalationNotificationId?: string | null;
+	escalationDelayMinutes?: number | null;
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -27,6 +27,13 @@ const baseSchema = z.object({
 		.number()
 		.min(300000, "Interval must be at least 5 minutes")
 		.optional(),
+	escalationNotificationId: z.string().nullable().optional(),
+	escalationDelayMinutes: z
+		.number()
+		.min(1, "Escalation delay must be at least 1 minute")
+		.max(10080, "Escalation delay must be at most 7 days (10080 minutes)")
+		.nullable()
+		.optional(),
 });
 
 // HTTP monitor schema

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -543,6 +543,25 @@
 					"description": "Select the notification channels you want to use",
 					"title": "Notifications"
 				},
+				"escalation": {
+					"description": "Configure an escalation notification to send after the monitor has been down for a specified duration",
+					"title": "Escalation Notification",
+					"notificationLabel": "Escalation notification channel",
+					"delayLabel": "Escalation delay (minutes)",
+					"delayPlaceholder": "Enter delay in minutes",
+					"delayHint": "Number of minutes before sending escalation (1-10080)",
+					"noNotifications": "No notifications available",
+					"savedDelayLabel": "Escalation delay saved",
+					"minutes": "minutes"
+				},
+				"escalationSummary": {
+					"description": "Summary of your escalation configuration",
+					"title": "Escalation Configuration Summary",
+					"notificationLabel": "Escalation Notification",
+					"delayLabel": "Escalation Delay",
+					"checkIntervalLabel": "Check Interval",
+					"minutes": "minutes"
+				},
 				"type": {
 					"description": "Select the type of check to perform",
 					"optionDockerDescription": "Use Docker to monitor if a container is running.",

--- a/server/src/db/models/Incident.ts
+++ b/server/src/db/models/Incident.ts
@@ -72,6 +72,10 @@ const IncidentSchema = new Schema<IncidentDocument>(
 			type: String,
 			default: null,
 		},
+		escalationSent: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	{ timestamps: true }
 );

--- a/server/src/db/models/Monitor.ts
+++ b/server/src/db/models/Monitor.ts
@@ -25,7 +25,10 @@ type MonitorDocumentBase = Omit<
 	notifications: Types.ObjectId[];
 	selectedDisks: string[];
 	matchMethod?: MonitorMatchMethod;
+	escalationNotificationId?: Types.ObjectId | null;
+	escalationDelayMinutes?: number | null;
 };
+
 
 interface MonitorDocument extends MonitorDocumentBase {
 	_id: Types.ObjectId;
@@ -350,6 +353,15 @@ const MonitorSchema = new Schema<MonitorDocument>(
 		geoCheckInterval: {
 			type: Number,
 			default: 300000,
+		},
+		escalationNotificationId: {
+			type: Schema.Types.ObjectId,
+			ref: "Notification",
+			default: null,
+		},
+		escalationDelayMinutes: {
+			type: Number,
+			default: null,
 		},
 		recentChecks: {
 			type: [checkSnapshotSchema],

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -391,6 +391,8 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationNotificationId: doc.escalationNotificationId ? toStringId(doc.escalationNotificationId) : undefined,
+			escalationDelayMinutes: doc.escalationDelayMinutes ?? undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -450,6 +452,8 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 			geoCheckEnabled: doc.geoCheckEnabled ?? false,
 			geoCheckLocations: doc.geoCheckLocations ?? [],
 			geoCheckInterval: doc.geoCheckInterval ?? 300000,
+			escalationNotificationId: doc.escalationNotificationId ? toStringId(doc.escalationNotificationId) : undefined,
+			escalationDelayMinutes: doc.escalationDelayMinutes ?? undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/service/business/incidentService.ts
+++ b/server/src/service/business/incidentService.ts
@@ -102,6 +102,7 @@ export class IncidentService implements IIncidentService {
 			activeIncident.status = false;
 			activeIncident.endTime = Date.now().toString();
 			activeIncident.resolutionType = "automatic";
+			activeIncident.escalationSent = false;
 			return await this.incidentsRepository.updateById(activeIncident.id, activeIncident.teamId, activeIncident);
 		}
 

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts
@@ -11,7 +11,7 @@ import {
 	IncidentService,
 	type IGeoChecksService,
 } from "@/service/index.js";
-import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult } from "@/types/index.js";
+import { CHECK_TTL_SENTINEL, type MaintenanceWindow, type StatusChangeResult, type Incident } from "@/types/index.js";
 import {
 	IMaintenanceWindowsRepository,
 	IMonitorsRepository,
@@ -172,6 +172,16 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 				this.incidentService.handleIncident(statusChangeResult.monitor, statusChangeResult.code, decision, status).catch((error: unknown) => {
 					this.logger.warn({
 						message: `Error handling incident for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						service: SERVICE_NAME,
+						method: "getMonitorJob",
+						stack: error instanceof Error ? error.stack : undefined,
+					});
+				});
+
+				// Step 8. Handle escalation (best effort, don't wait)
+				this.handleEscalation(statusChangeResult.monitor).catch((error: unknown) => {
+					this.logger.warn({
+						message: `Error handling escalation for job ${monitor.id}: ${error instanceof Error ? error.message : "Unknown error"}`,
 						service: SERVICE_NAME,
 						method: "getMonitorJob",
 						stack: error instanceof Error ? error.stack : undefined,
@@ -455,4 +465,147 @@ export class SuperSimpleQueueHelper implements ISuperSimpleQueueHelper {
 
 		return decision;
 	}
+
+	private handleEscalation = async (monitor: Monitor): Promise<void> => {
+		// Check if escalation is configured
+		this.logger.debug({
+			message: `Escalation check: escalationNotificationId=${monitor.escalationNotificationId}, escalationDelayMinutes=${monitor.escalationDelayMinutes}`,
+			service: SERVICE_NAME,
+			method: "handleEscalation",
+		});
+
+		if (!monitor.escalationNotificationId || !monitor.escalationDelayMinutes) {
+			return;
+		}
+
+		// Only escalate if monitor is still down
+		if (monitor.status !== "down" && monitor.status !== "breached") {
+			this.logger.debug({
+				message: `Monitor ${monitor.id} not down/breached (status: ${monitor.status})`,
+				service: SERVICE_NAME,
+				method: "handleEscalation",
+			});
+			return;
+		}
+
+		// Get active incident
+		const activeIncident = await this.incidentsRepository.findActiveByMonitorId(monitor.id, monitor.teamId);
+		if (!activeIncident) {
+			this.logger.debug({
+				message: `No active incident for monitor ${monitor.id}`,
+				service: SERVICE_NAME,
+				method: "handleEscalation",
+			});
+			return;
+		}
+
+		if (activeIncident.escalationSent) {
+			this.logger.debug({
+				message: `Escalation already sent for incident ${activeIncident.id}`,
+				service: SERVICE_NAME,
+				method: "handleEscalation",
+			});
+			return;
+		}
+
+		// Calculate elapsed time since incident started
+		const startTime = new Date(activeIncident.startTime).getTime();
+		const currentTime = Date.now();
+		const elapsedMinutes = (currentTime - startTime) / (1000 * 60);
+
+		this.logger.debug({
+			message: `Escalation timing: elapsed=${elapsedMinutes.toFixed(2)}min, required=${monitor.escalationDelayMinutes}min`,
+			service: SERVICE_NAME,
+			method: "handleEscalation",
+		});
+
+		// Check if escalation delay has elapsed
+		if (elapsedMinutes < monitor.escalationDelayMinutes) {
+			return;
+		}
+
+		// Send escalation notification
+		this.logger.info({
+			message: `Sending escalation for monitor ${monitor.id} (incident elapsed: ${elapsedMinutes.toFixed(2)} minutes)`,
+			service: SERVICE_NAME,
+			method: "handleEscalation",
+		});
+
+		// Get the escalation notification - convert to string in case it's an ObjectId
+		const notificationId = typeof monitor.escalationNotificationId === 'string' 
+			? monitor.escalationNotificationId 
+			: String(monitor.escalationNotificationId);
+
+		const escalationNotification = await this.notificationsService.findById(
+			notificationId,
+			monitor.teamId
+		);
+
+		if (!escalationNotification) {
+			this.logger.warn({
+				message: `Escalation notification ${notificationId} not found for monitor ${monitor.id}`,
+				service: SERVICE_NAME,
+				method: "handleEscalation",
+			});
+			return;
+		}
+
+		this.logger.debug({
+			message: `Found escalation notification: ${escalationNotification.notificationName} (type: ${escalationNotification.type})`,
+			service: SERVICE_NAME,
+			method: "handleEscalation",
+		});
+
+		// Build escalation message with context that it's an escalation
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+
+		// Create a decision object for escalation notification
+		const escalationDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "status_change" as const,
+		};
+
+		// Get current monitor status to build the message
+		const currentMonitor = await this.monitorsRepository.findById(monitor.id, monitor.teamId);
+		if (!currentMonitor) {
+			return;
+		}
+
+		// Build notification message
+		const notificationMessage = this.notificationsService.buildEscalationMessage(
+			currentMonitor,
+			escalationNotification,
+			clientHost,
+			activeIncident
+		);
+
+		this.logger.debug({
+			message: `Built escalation message: type=${notificationMessage.type}, severity=${notificationMessage.severity}`,
+			service: SERVICE_NAME,
+			method: "handleEscalation",
+		});
+
+		// Send the escalation
+		const sent = await this.notificationsService.sendEscalation(escalationNotification, notificationMessage);
+
+		this.logger.info({
+			message: `Escalation send result: ${sent ? "SUCCESS" : "FAILED"} for monitor ${monitor.id}`,
+			service: SERVICE_NAME,
+			method: "handleEscalation",
+		});
+
+		if (sent) {
+			// Mark escalation as sent
+			await this.incidentsRepository.updateById(activeIncident.id, monitor.teamId, { escalationSent: true });
+			this.logger.info({
+				message: `Marked escalation as sent for incident ${activeIncident.id}`,
+				service: SERVICE_NAME,
+				method: "handleEscalation",
+			});
+		}
+	};
 }

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -17,6 +17,8 @@ export interface INotificationsService {
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
+	buildEscalationMessage: (monitor: Monitor, notification: Notification, clientHost: string, incident: any) => NotificationMessage;
+	sendEscalation: (notification: Notification, message: NotificationMessage) => Promise<boolean>;
 }
 
 const SERVICE_NAME = "NotificationsService";
@@ -196,5 +198,66 @@ export class NotificationsService implements INotificationsService {
 		const deleted = await this.notificationsRepository.deleteById(id, teamId);
 		await this.monitorsRepository.removeNotificationFromMonitors(id);
 		return deleted;
+	};
+
+	buildEscalationMessage = (
+		monitor: Monitor,
+		notification: Notification,
+		clientHost: string,
+		incident: any
+	): NotificationMessage => {
+		// Reuse the existing message builder but with escalation context
+		const startTime = new Date(incident.startTime);
+		const elapsedMinutes = Math.round((Date.now() - startTime.getTime()) / (1000 * 60));
+
+		return {
+			type: "monitor_down",
+			severity: "critical",
+			monitor: {
+				id: monitor.id,
+				name: monitor.name,
+				url: monitor.url,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title: `⚠️ Escalation: ${monitor.name} has been down for ${elapsedMinutes} minutes`,
+				summary: `Monitor down since: ${startTime.toISOString()}`,
+				details: [`The monitor "${monitor.name}" has remained down for ${elapsedMinutes} minutes. This is an escalation notification.`],
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "escalation",
+			},
+		};
+	};
+
+	sendEscalation = async (notification: Notification, message: NotificationMessage): Promise<boolean> => {
+		// Route to provider based on notification type
+		switch (notification.type) {
+			case "email":
+				return await this.emailProvider.sendMessage!(notification, message);
+			case "slack":
+				return await this.slackProvider.sendMessage!(notification, message);
+			case "discord":
+				return await this.discordProvider.sendMessage!(notification, message);
+			case "webhook":
+				return await this.webhookProvider.sendMessage!(notification, message);
+			case "pager_duty":
+				return await this.pagerDutyProvider.sendMessage!(notification, message);
+			case "matrix":
+				return await this.matrixProvider.sendMessage!(notification, message);
+			case "teams":
+				return await this.teamsProvider.sendMessage!(notification, message);
+			default:
+				this.logger.warn({
+					message: `Unknown notification type for escalation: ${notification.type}`,
+					service: SERVICE_NAME,
+					method: "sendEscalation",
+				});
+				return false;
+		}
 	};
 }

--- a/server/src/types/incident.ts
+++ b/server/src/types/incident.ts
@@ -16,6 +16,7 @@ export interface Incident {
 	resolvedBy?: string | null;
 	resolvedByEmail?: string | null;
 	comment?: string | null;
+	escalationSent?: boolean;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/types/monitor.ts
+++ b/server/src/types/monitor.ts
@@ -53,6 +53,8 @@ export interface Monitor {
 	geoCheckEnabled?: boolean;
 	geoCheckLocations?: GeoContinent[];
 	geoCheckInterval?: number;
+	escalationNotificationId?: string | null;
+	escalationDelayMinutes?: number | null;
 	recentChecks: CheckSnapshot[];
 	createdAt: string;
 	updatedAt: string;

--- a/server/src/validation/monitorValidation.ts
+++ b/server/src/validation/monitorValidation.ts
@@ -78,6 +78,8 @@ export const createMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationNotificationId: z.string().nullable().optional(),
+	escalationDelayMinutes: z.number().min(1).max(10080).nullable().optional(),
 });
 
 export const editMonitorBodyValidation = z.object({
@@ -107,6 +109,8 @@ export const editMonitorBodyValidation = z.object({
 	geoCheckEnabled: z.boolean().optional(),
 	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
 	geoCheckInterval: z.number().min(300000).optional(),
+	escalationNotificationId: z.string().nullable().optional(),
+	escalationDelayMinutes: z.number().min(1).max(10080).nullable().optional(),
 });
 
 export const pauseMonitorParamValidation = z.object({


### PR DESCRIPTION
 ## Describe your changes
 
 Implemented escalated notifications feature allowing monitors to automatically send a second email after a configured 
delay if the monitor remains down. This prevents missed alerts when downtime persists unnoticed.
 
 **Backend changes:**
 - Added `escalationNotificationId` and `escalationDelayMinutes` fields to Monitor model
 - Added `escalationSent` flag to Incident model to prevent duplicate emails
 - Implemented escalation logic in `handleEscalation()` that evaluates on each monitor check and sends email when delay
 is reached
 - Fixed critical bug in monitor repository where escalation fields weren't being loaded from database during entity 
mapping
 - Added escalation validation to API schemas
 
 **Frontend changes:**
 - Added escalation notification configuration section to monitor create/edit form with notification selector and delay
 input
 - Display selected notification with email address and current delay setting with delete buttons
 - Added i18n translations for all UI strings
 
 **Technical highlights:**
 - Reuses existing email notification system and patterns
 - Escalation resets when monitor recovers to prevent stale state
 - Comprehensive debug logging for troubleshooting
 - Settings persist across page reloads
 
 ## Write your issue number after "Fixes "
 
 Fixes #3491
 
 ## Please ensure all items are checked off before requesting a review.
 
 - [x] (Do not skip this or your PR will be closed) I deployed the application locally.
 - [x] (Do not skip this or your PR will be closed) I have performed a self-review and testing of my code.
 - [x] I have included the issue # in the PR.
 - [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
 ```Javascript
 const { t } = useTranslation();
 <div>{t('add')}</div>

 - [X]  I have not included any files that are not related to my pull request, including package-lock and package-json 
if dependencies have not changed
 - [X]  I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain 
consistency across the application).
 - [X]  I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded 
dimensions.
 - [X]  My PR is granular and targeted to one specific feature.
 - [X]  I ran npm run format in server and client directories, which automatically formats your code.
 - [X]  I took a screenshot or a video and attached to this PR if there is a UI change.

Files Changed

Backend:

 - server/src/db/models/Monitor.ts - Added escalation fields
 - server/src/db/models/Incident.ts - Added escalationSent tracking
 - server/src/types/monitor.ts & incident.ts - Type definitions
 - server/src/validation/monitorValidation.ts - Validation schema fix (CRITICAL)
 - server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueueHelper.ts - Escalation logic
 - server/src/service/business/incidentService.ts - Reset escalation on recovery
 - server/src/service/infrastructure/notificationsService.ts - Email building & sending
 - server/src/repositories/monitors/MongoMonitorsRepository.ts - Entity mapping fix (CRITICAL)

Frontend:

 - client/src/Pages/CreateMonitor/index.tsx - Escalation form UI
 - client/src/Hooks/useMonitorForm.ts - Form defaults
 - client/src/Types/Monitor.ts - Type definitions
 - client/src/Validation/monitor.ts - Validation
 - client/src/locales/en.json - Translations

Testing Performed

✅ Set escalation to 1 minute delay on test monitor
✅ Took monitor down and verified escalation email sends after configured delay
✅ Verified settings persist after page reload
✅ Verified no duplicate escalation emails for same incident
✅ Verified escalation resets when monitor recovers
✅ Tested delete buttons clear both notification and delay
✅ All TypeScript types compile without errors
✅ Both client and server builds succeed ```
