### PR TITLE
Fix/open site monitor action (I hid the button for certain monitor types)

### DIFF
--- a/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
+++ b/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
@@ -7,7 +7,10 @@ import {
 	Pagination,
 	StatusLabel,
 } from "@/Components/design-elements";
-import { HeatmapResponseTime, HistogramResponseTime } from "@/Components/common";
+import {
+	HeatmapResponseTime,
+	HistogramResponseTime,
+} from "@/Components/common";
 import { ActionsMenu } from "@/Components/actions-menu";
 import { ArrowDown, ArrowUp } from "lucide-react";
 
@@ -51,64 +54,99 @@ export const MonitorTable = ({
 	const { t } = useTranslation();
 	const theme = useTheme();
 	const navigate = useNavigate();
-	const chartType = useSelector((state: RootState) => state.ui?.chartType ?? "histogram");
-	const {
-		post,
-		// loading: isPosting,
-		// error: postError,
-	} = usePost<any, Monitor>();
+	const chartType =
+		useSelector((state: RootState) => state.ui?.chartType ?? "histogram");
 
+	const { post } = usePost<any, Monitor>();
+
+	/**
+	 * Handles sorting logic for table headers
+	 */
 	const handleSort = (e: any, field: string) => {
 		e.preventDefault();
 		e.stopPropagation();
+
 		if (sortField === field) {
-			const newOrder = sortOrder === "asc" ? "desc" : "asc";
-			setSortOrder(newOrder);
+			setSortOrder(sortOrder === "asc" ? "desc" : "asc");
 		} else {
 			setSortField(field);
 			setSortOrder("asc");
 		}
+
 		refetch();
 	};
 
+	/**
+	 * Builds actions menu per monitor row
+	 * Hides "Open Site" for:
+	 * - hardware monitors
+	 * - port monitors
+	 * - internal HTTP targets (localhost / private / loopback)
+	 */
 	const getActions = (monitor: Monitor): ActionMenuItem[] => {
+		const hostname = (() => {
+			try {
+				return new URL(monitor.url).hostname;
+			} catch {
+				return "";
+			}
+		})();
+
+		// loopback detection
+		const isLoopback =
+			hostname === "localhost" ||
+			hostname === "127.0.0.1" ||
+			hostname === "::1";
+
+		// private-style domains
+		const isPrivateLike =
+			hostname.endsWith(".local") ||
+			hostname.endsWith(".internal");
+
+		// internal HTTP targets (should not be opened in browser)
+		const isInternalHttpTarget =
+			monitor.type === "http" &&
+			(hostname === "" || isLoopback || isPrivateLike);
+
+		const showOpenSite =
+			monitor.type !== "hardware" &&
+			monitor.type !== "port" &&
+			!isInternalHttpTarget;
+
 		return [
-			{
-				id: 1,
-				label: t("pages.common.monitors.actions.openSite"),
-				action: () => {
-					window.open(monitor.url, "_blank", "noreferrer");
-				},
-				closeMenu: true,
-			},
+			...(showOpenSite
+				? [
+						{
+							id: 1,
+							label: t("pages.common.monitors.actions.openSite"),
+							action: () => {
+								window.open(monitor.url, "_blank", "noreferrer");
+							},
+							closeMenu: true,
+						},
+					]
+				: []),
+
 			{
 				id: 2,
 				label: t("pages.common.monitors.actions.details"),
-				action: () => {
-					navigate(`${monitor.id}`);
-				},
+				action: () => navigate(`${monitor.id}`),
 			},
+
 			{
 				id: 3,
 				label: t("pages.common.monitors.actions.incidents"),
-				action: () => {
-					navigate(`/incidents?monitorId=${monitor.id}`);
-				},
+				action: () =>
+					navigate(`/incidents?monitorId=${monitor.id}`),
 			},
+
 			{
 				id: 4,
 				label: t("pages.common.monitors.actions.configure"),
-				action: () => {
-					navigate(`/uptime/configure/${monitor.id}`);
-				},
+				action: () =>
+					navigate(`/uptime/configure/${monitor.id}`),
 			},
-			// {
-			//   id: 5,
-			//   label: "Clone",
-			//   action: () => {
 
-			//   },
-			// },
 			{
 				id: 6,
 				label:
@@ -121,6 +159,7 @@ export const MonitorTable = ({
 				},
 				closeMenu: true,
 			},
+
 			{
 				id: 7,
 				label: (
@@ -134,30 +173,28 @@ export const MonitorTable = ({
 		];
 	};
 
+	/**
+	 * Table headers configuration
+	 */
 	const getHeaders = (chartType: string) => {
 		const renderSortIcon = (isActive: boolean) => (
-			<Box
-				width={16}
-				display="inline-flex"
-				justifyContent="center"
-			>
-				{isActive ? (
-					sortOrder === "asc" ? (
-						<ArrowUp size={16} />
-					) : (
-						<ArrowDown size={16} />
-					)
-				) : null}
+			<Box width={16} display="inline-flex" justifyContent="center">
+				{isActive
+					? sortOrder === "asc"
+						? <ArrowUp size={16} />
+						: <ArrowDown size={16} />
+					: null}
 			</Box>
 		);
+
 		const headers: Header<Monitor>[] = [
 			{
 				id: "name",
 				content: (
 					<Stack
 						gap={theme.spacing(4)}
-						direction={"row"}
-						alignItems={"center"}
+						direction="row"
+						alignItems="center"
 						onClick={(e) => handleSort(e, "name")}
 						sx={{ cursor: "pointer" }}
 					>
@@ -165,19 +202,17 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "name")}
 					</Stack>
 				),
-
-				render: (row) => {
-					return row?.name;
-				},
+				render: (row) => row?.name,
 			},
+
 			{
 				id: "status",
 				content: (
 					<Stack
 						gap={theme.spacing(4)}
-						direction={"row"}
-						justifyContent={"center"}
-						alignItems={"center"}
+						direction="row"
+						justifyContent="center"
+						alignItems="center"
 						onClick={(e) => handleSort(e, "status")}
 						sx={{ cursor: "pointer" }}
 					>
@@ -186,29 +221,28 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "status")}
 					</Stack>
 				),
-				render: (row) => {
-					return <StatusLabel status={row.status} />;
-				},
+				render: (row) => <StatusLabel status={row.status} />,
 			},
+
 			{
 				id: "histogram",
 				content: t("pages.uptime.table.headers.responseTime"),
-				render: (row) => {
-					if (chartType === "histogram") {
-						return <HistogramResponseTime checks={row.recentChecks} />;
-					} else {
-						return <HeatmapResponseTime checks={row.recentChecks} />;
-					}
-				},
+				render: (row) =>
+					chartType === "histogram" ? (
+						<HistogramResponseTime checks={row.recentChecks} />
+					) : (
+						<HeatmapResponseTime checks={row.recentChecks} />
+					),
 			},
+
 			{
 				id: "type",
 				content: (
 					<Stack
 						gap={theme.spacing(4)}
-						direction={"row"}
-						justifyContent={"center"}
-						alignItems={"center"}
+						direction="row"
+						justifyContent="center"
+						alignItems="center"
 						onClick={(e) => handleSort(e, "type")}
 						sx={{ cursor: "pointer" }}
 					>
@@ -217,18 +251,16 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "type")}
 					</Stack>
 				),
-				render: (row) => {
-					return row.type;
-				},
+				render: (row) => row.type,
 			},
+
 			{
 				id: "actions",
 				content: t("common.table.headers.actions"),
-				render: (row) => {
-					return <ActionsMenu items={getActions(row)} />;
-				},
+				render: (row) => <ActionsMenu items={getActions(row)} />,
 			},
 		];
+
 		return headers;
 	};
 
@@ -239,17 +271,20 @@ export const MonitorTable = ({
 			<Table
 				headers={headers}
 				data={monitors}
-				onRowClick={(row) => {
-					navigate(`/uptime/${row.id}`);
-				}}
+				onRowClick={(row) =>
+					navigate(`/uptime/${row.id}`)
+				}
 			/>
+
 			<Pagination
 				component="div"
 				count={count}
 				page={page}
 				rowsPerPage={rowsPerPage}
 				onPageChange={(_e, newPage) => setPage(newPage)}
-				onRowsPerPageChange={(e) => setRowsPerPage(Number(e.target.value))}
+				onRowsPerPageChange={(e) =>
+					setRowsPerPage(Number(e.target.value))
+				}
 				itemsOnPage={monitors.length}
 			/>
 		</Box>

--- a/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
+++ b/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
@@ -7,10 +7,7 @@ import {
 	Pagination,
 	StatusLabel,
 } from "@/Components/design-elements";
-import {
-	HeatmapResponseTime,
-	HistogramResponseTime,
-} from "@/Components/common";
+import { HeatmapResponseTime, HistogramResponseTime } from "@/Components/common";
 import { ActionsMenu } from "@/Components/actions-menu";
 import { ArrowDown, ArrowUp } from "lucide-react";
 
@@ -54,8 +51,7 @@ export const MonitorTable = ({
 	const { t } = useTranslation();
 	const theme = useTheme();
 	const navigate = useNavigate();
-	const chartType =
-		useSelector((state: RootState) => state.ui?.chartType ?? "histogram");
+	const chartType = useSelector((state: RootState) => state.ui?.chartType ?? "histogram");
 
 	const { post } = usePost<any, Monitor>();
 
@@ -86,13 +82,12 @@ export const MonitorTable = ({
 		})();
 
 		const isLoopback =
-			hostname === "localhost" ||
-			hostname === "127.0.0.1" ||
-			hostname === "::1";
+			hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
 
-		const isPrivateIpv4 = /^(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3})$/.test(
-			hostname
-		);
+		const isPrivateIpv4 =
+			/^(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3})$/.test(
+				hostname
+			);
 		const isPrivateLike =
 			hostname.endsWith(".local") ||
 			hostname.endsWith(".internal") ||
@@ -103,9 +98,7 @@ export const MonitorTable = ({
 			(hostname === "" || isLoopback || isPrivateIpv4 || isPrivateLike);
 
 		const showOpenSite =
-			monitor.type !== "hardware" &&
-			monitor.type !== "port" &&
-			!isInternalHttpTarget;
+			monitor.type !== "hardware" && monitor.type !== "port" && !isInternalHttpTarget;
 
 		return [
 			...(showOpenSite
@@ -130,15 +123,13 @@ export const MonitorTable = ({
 			{
 				id: 3,
 				label: t("pages.common.monitors.actions.incidents"),
-				action: () =>
-					navigate(`/incidents?monitorId=${monitor.id}`),
+				action: () => navigate(`/incidents?monitorId=${monitor.id}`),
 			},
 
 			{
 				id: 4,
 				label: t("pages.common.monitors.actions.configure"),
-				action: () =>
-					navigate(`/uptime/configure/${monitor.id}`),
+				action: () => navigate(`/uptime/configure/${monitor.id}`),
 			},
 
 			{
@@ -172,12 +163,18 @@ export const MonitorTable = ({
 	 */
 	const getHeaders = (chartType: string) => {
 		const renderSortIcon = (isActive: boolean) => (
-			<Box width={16} display="inline-flex" justifyContent="center">
-				{isActive
-					? sortOrder === "asc"
-						? <ArrowUp size={16} />
-						: <ArrowDown size={16} />
-					: null}
+			<Box
+				width={16}
+				display="inline-flex"
+				justifyContent="center"
+			>
+				{isActive ? (
+					sortOrder === "asc" ? (
+						<ArrowUp size={16} />
+					) : (
+						<ArrowDown size={16} />
+					)
+				) : null}
 			</Box>
 		);
 
@@ -265,9 +262,7 @@ export const MonitorTable = ({
 			<Table
 				headers={headers}
 				data={monitors}
-				onRowClick={(row) =>
-					navigate(`/uptime/${row.id}`)
-				}
+				onRowClick={(row) => navigate(`/uptime/${row.id}`)}
 			/>
 
 			<Pagination
@@ -276,9 +271,7 @@ export const MonitorTable = ({
 				page={page}
 				rowsPerPage={rowsPerPage}
 				onPageChange={(_e, newPage) => setPage(newPage)}
-				onRowsPerPageChange={(e) =>
-					setRowsPerPage(Number(e.target.value))
-				}
+				onRowsPerPageChange={(e) => setRowsPerPage(Number(e.target.value))}
 				itemsOnPage={monitors.length}
 			/>
 		</Box>

--- a/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
+++ b/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
@@ -76,13 +76,6 @@ export const MonitorTable = ({
 		refetch();
 	};
 
-	/**
-	 * Builds actions menu per monitor row
-	 * Hides "Open Site" for:
-	 * - hardware monitors
-	 * - port monitors
-	 * - internal HTTP targets (localhost / private / loopback)
-	 */
 	const getActions = (monitor: Monitor): ActionMenuItem[] => {
 		const hostname = (() => {
 			try {
@@ -92,21 +85,22 @@ export const MonitorTable = ({
 			}
 		})();
 
-		// loopback detection
 		const isLoopback =
 			hostname === "localhost" ||
 			hostname === "127.0.0.1" ||
 			hostname === "::1";
 
-		// private-style domains
+		const isPrivateIpv4 = /^(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}|172\.(1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3})$/.test(
+			hostname
+		);
 		const isPrivateLike =
 			hostname.endsWith(".local") ||
-			hostname.endsWith(".internal");
+			hostname.endsWith(".internal") ||
+			(hostname !== "" && !hostname.includes("."));
 
-		// internal HTTP targets (should not be opened in browser)
 		const isInternalHttpTarget =
 			monitor.type === "http" &&
-			(hostname === "" || isLoopback || isPrivateLike);
+			(hostname === "" || isLoopback || isPrivateIpv4 || isPrivateLike);
 
 		const showOpenSite =
 			monitor.type !== "hardware" &&


### PR DESCRIPTION
## Describe your changes

Hide the "Open site" action in the monitor actions menu for monitor types where the target URL is not browser-accessible.

This applies to:
- `hardware` and `port` monitors (always internal agent-based targets)
- `http` monitors pointing to:
  - localhost / loopback (`localhost`, `127.0.0.1`, `::1`)
  - private/internal hostnames (`.local`, `.internal`)

A `try/catch` is used around URL parsing to safely handle invalid or bare hostnames (e.g. `postgres`) that would otherwise throw with `new URL()`.

### Known limitation
Bare internal hostnames on HTTP monitors (e.g. `http://traefik:8080`) are not yet detected and will be addressed in a follow-up PR.

## Fixes
Fixes #3434

## Please ensure all items are checked off before requesting a review.

- [x] I deployed the application locally.
- [x] I have performed a self-review and tested my code.
- [x] I have included the issue number in the PR.
- [x] I have added i18n support to visible strings
- [x] I have not included unrelated files (package-lock, etc.)
- [x] I didn't use hardcoded values
- [x] My PR is granular and targeted to one specific feature
- [x] I ran `npm run format` in server and client directories
- [x] I attached a screenshot/video if UI changed
<img width="1566" height="367" alt="Screenshot 2026-04-13 211424" src="https://github.com/user-attachments/assets/cf9f1432-51ec-4e71-b4af-5348792ce734" />
