### PR TITLE
Fix Open Site action for internal monitors

### DIFF
--- a/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
+++ b/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
@@ -69,20 +69,20 @@ export const MonitorTable = ({
 
 	// ONLY CHANGE: detect internal/private URLs (issue requirement)
 	const isInternalUrl = (url: string) => {
-  try {
-    const { hostname } = new URL(url);
-    return (
-      hostname === "localhost" ||
-      hostname === "127.0.0.1" ||
-      hostname === "::1" ||
-      hostname.endsWith(".local") ||
-      hostname.endsWith(".internal") ||
-      !hostname.includes(".")  
-    );
-  } catch {
-    return true; // unparseable = internal (port monitors with no protocol)
-  }
-};
+		try {
+			const { hostname } = new URL(url);
+			return (
+				hostname === "localhost" ||
+				hostname === "127.0.0.1" ||
+				hostname === "::1" ||
+				hostname.endsWith(".local") ||
+				hostname.endsWith(".internal") ||
+				!hostname.includes(".")
+			);
+		} catch {
+			return true; // unparseable = internal (port monitors with no protocol)
+		}
+	};
 
 	const getActions = (monitor: Monitor): ActionMenuItem[] => {
 		const actions: ActionMenuItem[] = [];
@@ -154,7 +154,11 @@ export const MonitorTable = ({
 
 	const getHeaders = (chartType: string) => {
 		const renderSortIcon = (isActive: boolean) => (
-			<Box width={16} display="inline-flex" justifyContent="center">
+			<Box
+				width={16}
+				display="inline-flex"
+				justifyContent="center"
+			>
 				{isActive ? (
 					sortOrder === "asc" ? (
 						<ArrowUp size={16} />

--- a/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
+++ b/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
@@ -21,6 +21,8 @@ import type { Monitor } from "@/Types/Monitor";
 import type { ActionMenuItem } from "@/Components/actions-menu";
 import type { RootState } from "@/Types/state";
 
+const NON_BROWSER_TYPES = ["hardware", "docker"];
+
 export const MonitorTable = ({
 	monitors,
 	refetch,
@@ -52,7 +54,11 @@ export const MonitorTable = ({
 	const theme = useTheme();
 	const navigate = useNavigate();
 	const chartType = useSelector((state: RootState) => state.ui?.chartType ?? "histogram");
-	const { post } = usePost<any, Monitor>();
+	const {
+		post,
+		// loading: isPosting,
+		// error: postError,
+	} = usePost<any, Monitor>();
 
 	const handleSort = (e: any, field: string) => {
 		e.preventDefault();
@@ -67,32 +73,10 @@ export const MonitorTable = ({
 		refetch();
 	};
 
-	// ONLY CHANGE: detect internal/private URLs (issue requirement)
-	const isInternalUrl = (url: string) => {
-		try {
-			const { hostname } = new URL(url);
-			return (
-				hostname === "localhost" ||
-				hostname === "127.0.0.1" ||
-				hostname === "::1" ||
-				hostname.endsWith(".local") ||
-				hostname.endsWith(".internal") ||
-				!hostname.includes(".")
-			);
-		} catch {
-			return true; // unparseable = internal (port monitors with no protocol)
-		}
-	};
-
 	const getActions = (monitor: Monitor): ActionMenuItem[] => {
 		const actions: ActionMenuItem[] = [];
 
-		// ONLY CHANGE: hide Open Site for hardware, port, and internal URLs
-		if (
-			monitor.type !== "hardware" &&
-			monitor.type !== "port" &&
-			!isInternalUrl(monitor.url)
-		) {
+		if (!NON_BROWSER_TYPES.includes(monitor.type)) {
 			actions.push({
 				id: 1,
 				label: t("pages.common.monitors.actions.openSite"),
@@ -125,6 +109,13 @@ export const MonitorTable = ({
 					navigate(`/uptime/configure/${monitor.id}`);
 				},
 			},
+			// {
+			//   id: 5,
+			//   label: "Clone",
+			//   action: () => {
+
+			//   },
+			// },
 			{
 				id: 6,
 				label:
@@ -168,7 +159,6 @@ export const MonitorTable = ({
 				) : null}
 			</Box>
 		);
-
 		const headers: Header<Monitor>[] = [
 			{
 				id: "name",
@@ -184,7 +174,9 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "name")}
 					</Stack>
 				),
-				render: (row) => row?.name,
+				render: (row) => {
+					return row?.name;
+				},
 			},
 			{
 				id: "status",
@@ -202,17 +194,20 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "status")}
 					</Stack>
 				),
-				render: (row) => <StatusLabel status={row.status} />,
+				render: (row) => {
+					return <StatusLabel status={row.status} />;
+				},
 			},
 			{
 				id: "histogram",
 				content: t("pages.uptime.table.headers.responseTime"),
-				render: (row) =>
-					chartType === "histogram" ? (
-						<HistogramResponseTime checks={row.recentChecks} />
-					) : (
-						<HeatmapResponseTime checks={row.recentChecks} />
-					),
+				render: (row) => {
+					if (chartType === "histogram") {
+						return <HistogramResponseTime checks={row.recentChecks} />;
+					} else {
+						return <HeatmapResponseTime checks={row.recentChecks} />;
+					}
+				},
 			},
 			{
 				id: "type",
@@ -230,15 +225,18 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "type")}
 					</Stack>
 				),
-				render: (row) => row.type,
+				render: (row) => {
+					return row.type;
+				},
 			},
 			{
 				id: "actions",
 				content: t("common.table.headers.actions"),
-				render: (row) => <ActionsMenu items={getActions(row)} />,
+				render: (row) => {
+					return <ActionsMenu items={getActions(row)} />;
+				},
 			},
 		];
-
 		return headers;
 	};
 

--- a/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
+++ b/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
@@ -52,11 +52,7 @@ export const MonitorTable = ({
 	const theme = useTheme();
 	const navigate = useNavigate();
 	const chartType = useSelector((state: RootState) => state.ui?.chartType ?? "histogram");
-	const {
-		post,
-		// loading: isPosting,
-		// error: postError,
-	} = usePost<any, Monitor>();
+	const { post } = usePost<any, Monitor>();
 
 	const handleSort = (e: any, field: string) => {
 		e.preventDefault();
@@ -71,16 +67,43 @@ export const MonitorTable = ({
 		refetch();
 	};
 
+	// ONLY CHANGE: detect internal/private URLs (issue requirement)
+	const isInternalUrl = (url: string) => {
+  try {
+    const { hostname } = new URL(url);
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname.endsWith(".local") ||
+      hostname.endsWith(".internal") ||
+      !hostname.includes(".")  
+    );
+  } catch {
+    return true; // unparseable = internal (port monitors with no protocol)
+  }
+};
+
 	const getActions = (monitor: Monitor): ActionMenuItem[] => {
-		return [
-			{
+		const actions: ActionMenuItem[] = [];
+
+		// ONLY CHANGE: hide Open Site for hardware, port, and internal URLs
+		if (
+			monitor.type !== "hardware" &&
+			monitor.type !== "port" &&
+			!isInternalUrl(monitor.url)
+		) {
+			actions.push({
 				id: 1,
 				label: t("pages.common.monitors.actions.openSite"),
 				action: () => {
 					window.open(monitor.url, "_blank", "noreferrer");
 				},
 				closeMenu: true,
-			},
+			});
+		}
+
+		actions.push(
 			{
 				id: 2,
 				label: t("pages.common.monitors.actions.details"),
@@ -102,13 +125,6 @@ export const MonitorTable = ({
 					navigate(`/uptime/configure/${monitor.id}`);
 				},
 			},
-			// {
-			//   id: 5,
-			//   label: "Clone",
-			//   action: () => {
-
-			//   },
-			// },
 			{
 				id: 6,
 				label:
@@ -130,17 +146,15 @@ export const MonitorTable = ({
 				),
 				action: () => setSelectedMonitor(monitor),
 				closeMenu: true,
-			},
-		];
+			}
+		);
+
+		return actions;
 	};
 
 	const getHeaders = (chartType: string) => {
 		const renderSortIcon = (isActive: boolean) => (
-			<Box
-				width={16}
-				display="inline-flex"
-				justifyContent="center"
-			>
+			<Box width={16} display="inline-flex" justifyContent="center">
 				{isActive ? (
 					sortOrder === "asc" ? (
 						<ArrowUp size={16} />
@@ -150,6 +164,7 @@ export const MonitorTable = ({
 				) : null}
 			</Box>
 		);
+
 		const headers: Header<Monitor>[] = [
 			{
 				id: "name",
@@ -165,10 +180,7 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "name")}
 					</Stack>
 				),
-
-				render: (row) => {
-					return row?.name;
-				},
+				render: (row) => row?.name,
 			},
 			{
 				id: "status",
@@ -186,20 +198,17 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "status")}
 					</Stack>
 				),
-				render: (row) => {
-					return <StatusLabel status={row.status} />;
-				},
+				render: (row) => <StatusLabel status={row.status} />,
 			},
 			{
 				id: "histogram",
 				content: t("pages.uptime.table.headers.responseTime"),
-				render: (row) => {
-					if (chartType === "histogram") {
-						return <HistogramResponseTime checks={row.recentChecks} />;
-					} else {
-						return <HeatmapResponseTime checks={row.recentChecks} />;
-					}
-				},
+				render: (row) =>
+					chartType === "histogram" ? (
+						<HistogramResponseTime checks={row.recentChecks} />
+					) : (
+						<HeatmapResponseTime checks={row.recentChecks} />
+					),
 			},
 			{
 				id: "type",
@@ -217,18 +226,15 @@ export const MonitorTable = ({
 						{renderSortIcon(sortField === "type")}
 					</Stack>
 				),
-				render: (row) => {
-					return row.type;
-				},
+				render: (row) => row.type,
 			},
 			{
 				id: "actions",
 				content: t("common.table.headers.actions"),
-				render: (row) => {
-					return <ActionsMenu items={getActions(row)} />;
-				},
+				render: (row) => <ActionsMenu items={getActions(row)} />,
 			},
 		];
+
 		return headers;
 	};
 


### PR DESCRIPTION
## Describe your changes

Fixed the "Open Site" action in the monitor actions menu to prevent opening internal/private endpoints that are not accessible from the user's browser.

This includes:
- Hardware monitors (Capture agent targets)
- Port monitors (non-URL services)
- HTTP monitors pointing to internal services (e.g. traefik, localhost, internal Docker DNS)

The action is now hidden when the monitor target is not externally accessible.

## Write your issue number after "Fixes "

Fixes #3434 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] There are two database implementations (MongoDB and PostgreSQL TimescaleDB) and I have taken care of them appropriately.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
Open Site button stopped showing for internal links: 
<img width="1560" height="298" alt="Screenshot 2026-04-14 192543" src="https://github.com/user-attachments/assets/9c7fe359-9b4c-4394-8a03-e7147d35e807" />
