### PR TITLE
Fix: added "down" display on down monitors instead of "Active for:..."

### DIFF
--- a/client/src/Components/monitors/MonitorStatBoxes.tsx
+++ b/client/src/Components/monitors/MonitorStatBoxes.tsx
@@ -42,6 +42,11 @@ export const MonitorStatBoxes = ({
 	const streakTime = prettyMilliseconds(timeSinceLastFailure, options);
 
 	const lastCheckTime = prettyMilliseconds(timeSinceLastCheck, options);
+	const isActive =
+		monitor?.status === "up" ||
+		monitor?.status === "paused" ||
+		monitor?.status === "initializing" ||
+		monitor?.status === "breached";
 	const palette = getStatusPalette(monitor?.status);
 
 	return (
@@ -52,11 +57,11 @@ export const MonitorStatBoxes = ({
 			<StatBox
 				palette={palette}
 				title={
-					monitor?.status === "down"
-						? t("pages.common.monitors.statBoxes.serviceIsDown")
-						: t("pages.common.monitors.statBoxes.activeFor")
+					isActive
+						? t("pages.common.monitors.statBoxes.activeFor")
+						: t("pages.common.monitors.statBoxes.serviceIsDown")
 				}
-				subtitle={monitor?.status === "down" ? "" : streakTime}
+				subtitle={isActive ? streakTime : ""}
 			/>
 			<StatBox
 				title={t("pages.common.monitors.statBoxes.lastCheck")}

--- a/client/src/Components/monitors/MonitorStatBoxes.tsx
+++ b/client/src/Components/monitors/MonitorStatBoxes.tsx
@@ -53,7 +53,7 @@ export const MonitorStatBoxes = ({
 				palette={palette}
 				title={
 					monitor?.status === "down"
-						? t("pages.common.monitors.status.down")
+						? t("pages.common.monitors.statBoxes.serviceIsDown")
 						: t("pages.common.monitors.statBoxes.activeFor")
 				}
 				subtitle={monitor?.status === "down" ? "" : streakTime}

--- a/client/src/Components/monitors/MonitorStatBoxes.tsx
+++ b/client/src/Components/monitors/MonitorStatBoxes.tsx
@@ -51,8 +51,12 @@ export const MonitorStatBoxes = ({
 		>
 			<StatBox
 				palette={palette}
-				title={t("pages.common.monitors.statBoxes.activeFor")}
-				subtitle={streakTime}
+				title={
+					monitor?.status === "down"
+						? t("pages.common.monitors.status.down")
+						: t("pages.common.monitors.statBoxes.activeFor")
+				}
+				subtitle={monitor?.status === "down" ? "" : streakTime}
 			/>
 			<StatBox
 				title={t("pages.common.monitors.statBoxes.lastCheck")}

--- a/client/src/Components/monitors/MonitorStatBoxes.tsx
+++ b/client/src/Components/monitors/MonitorStatBoxes.tsx
@@ -45,6 +45,7 @@ export const MonitorStatBoxes = ({
 	const isActive =
 		monitor?.status === "up" ||
 		monitor?.status === "paused" ||
+		monitor?.status === "maintenance" ||
 		monitor?.status === "initializing" ||
 		monitor?.status === "breached";
 	const palette = getStatusPalette(monitor?.status);

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -397,7 +397,8 @@
 					"activeFor": "Active for",
 					"certificateExpiry": "Certificate expiry",
 					"lastCheck": "Last check",
-					"lastResponseTime": "Last response time"
+					"lastResponseTime": "Last response time",
+					"serviceIsDown": "Service is down"
 				},
 				"status": {
 					"down": "down",


### PR DESCRIPTION
## Describe your changes

This fixes an incorrect UI state in the monitor details page where the "Active for" stat box was still showing a duration even when the monitor status is "down".

Now, when a monitor is down, the stat box correctly displays "Down" instead of showing an invalid uptime duration.

This improves clarity and prevents misleading uptime information.

## Fixes #3509

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] There are two database implementations (MongoDB and PostgreSQL TimescaleDB) and I have taken care of them appropriately.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
Here is the new UI for monitors that are down: 

<img width="1597" height="336" alt="Screenshot 2026-04-15 144018" src="https://github.com/user-attachments/assets/06c91ca9-f269-4fd5-a6b4-983f1c83ac11" />
