### PR TITLE
Improve MonitorMatchMethod typing

### DIFF
--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -36,7 +36,7 @@ export const MonitorStatuses = [
 ] as const;
 export type MonitorStatus = (typeof MonitorStatuses)[number];
 
-export type MonitorMatchMethod = "equal" | "include" | "regex" | "";
+export type MonitorMatchMethod = "equal" | "include" | "regex" | undefined;
 
 export interface Monitor {
 	id: string;


### PR DESCRIPTION
 Changes

* Updated "MonitorMatchMethod"type to explicitly allow 'undefined' instead of an empty string.

Why

* Using an empty string (`""`) as a type is unclear and can lead to unintended values.
* 'undefined' better represents the absence of a match method and aligns with TypeScript best practices.

 Impact

* Improves type safety and readability.
* No functional change expected if `undefined` is already handled in the codebase.

**(Please remove this line only before submitting your PR. Ensure that all relevant items are checked before submission.)** 

## Describe your changes

Briefly describe the changes you made and their purpose. 

## Write your issue number after "Fixes "

Fixes #123 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [ ] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] There are two database implementations (MongoDB and PostgreSQL TimescaleDB) and I have taken care of them appropriately.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

