### PR TITLE
fix: remove notifications from monitors before deleting notifications

### DIFF
--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -200,8 +200,8 @@ export class NotificationsService implements INotificationsService {
 	};
 
 	deleteById = async (id: string, teamId: string): Promise<Notification> => {
-		const deleted = await this.notificationsRepository.deleteById(id, teamId);
 		await this.monitorsRepository.removeNotificationFromMonitors(id);
+		const deleted = await this.notificationsRepository.deleteById(id, teamId);
 		return deleted;
 	};
 }


### PR DESCRIPTION
This PR changes the order of removing notifications when deleting a notification. 

- Strip notificaitions form monitors before deleting the notification

If stripping notifications fails, we fail early and don't delete the notification.

If we delete the notification first and _then_ strip notifications, we will be left with dangling references in the `monitor` object if stripping notifications fails.