### PR TITLE
fix: demo user

### DIFF
--- a/client/src/Pages/Account/components/AddTeamMemberDialog.tsx
+++ b/client/src/Pages/Account/components/AddTeamMemberDialog.tsx
@@ -43,6 +43,7 @@ export const AddTeamMemberDialog = ({
 	const roleOptions: { value: UserRole; label: string }[] = [
 		{ value: "admin", label: t("common.auth.roles.admin") },
 		{ value: "user", label: t("common.auth.roles.user") },
+		{ value: "demo", label: t("common.auth.roles.demo") },
 	];
 
 	const handleClose = () => {

--- a/client/src/Pages/Account/components/InviteTeamMemberDialog.tsx
+++ b/client/src/Pages/Account/components/InviteTeamMemberDialog.tsx
@@ -48,6 +48,7 @@ export const InviteTeamMemberDialog = ({
 	const roleOptions: { value: UserRole; label: string }[] = [
 		{ value: "admin", label: t("common.auth.roles.admin") },
 		{ value: "user", label: t("common.auth.roles.user") },
+		{ value: "demo", label: t("common.auth.roles.demo") },
 	];
 
 	const handleGenerateToken = async (data: InviteFormData) => {

--- a/server/src/routes/authRoute.ts
+++ b/server/src/routes/authRoute.ts
@@ -32,8 +32,8 @@ class AuthRoutes {
 		this.router.patch("/users/:userId/password", verifyJWT, isAllowed(["superadmin"]), this.authController.editUserPasswordById);
 		this.router.delete("/users/:userId", verifyJWT, isAllowed(["admin", "superadmin"]), this.authController.deleteUserById);
 
-		this.router.patch("/user", verifyJWT, upload.single("profileImage"), this.authController.editUser);
-		this.router.delete("/user", verifyJWT, this.authController.deleteUser);
+		this.router.patch("/user", verifyJWT, upload.single("profileImage"), isAllowed(["admin", "superadmin", "user"]), this.authController.editUser);
+		this.router.delete("/user", verifyJWT, isAllowed(["admin", "superadmin", "user"]), this.authController.deleteUser);
 	}
 
 	getRouter() {


### PR DESCRIPTION
This PR allows adding demo user accounts and disallows demo users from changing their account details

- Add `isAllowed` middleware to the edit user route
- Add demo role to the array of acceptable roles in the Team management page