### PR TITLE
fix: copy email templates to dist during build

### DIFF
--- a/docker/dist-mono/server.Dockerfile
+++ b/docker/dist-mono/server.Dockerfile
@@ -19,10 +19,10 @@ WORKDIR /app/server
 
 COPY server ./
 
-
 RUN npm install
 
 RUN npm run build
+RUN cp -r src/templates dist/templates
 
 COPY --from=frontend-build /app/client/dist ./public
 


### PR DESCRIPTION

## Describe your changes
Briefly describe the changes you made and their purpose. 

Here's your filled-out PR description:

Describe your changes
Added a cp -r src/templates dist/templates step in docker/dist-mono/server.Dockerfile after the build step. The TypeScript compiler does not copy non-TS assets, so dist/templates/ was missing from the built image. This caused EmailService.init() to fail loading all email templates at startup, breaking test emails, notification emails, password resets, and all other email flows.

## Write your issue number after "Fixes "

Fixes #3514 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] There are two database implementations (MongoDB and PostgreSQL TimescaleDB) and I have taken care of them appropriately.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

