### PR TITLE
fix: monitor status atomicity

### DIFF
--- a/server/src/repositories/monitors/IMonitorsRepository.ts
+++ b/server/src/repositories/monitors/IMonitorsRepository.ts
@@ -35,7 +35,8 @@ export interface IMonitorsRepository {
 		status: boolean,
 		checkSnapshot: CheckSnapshot,
 		windowSize: number,
-		maxRecentChecks: number
+		maxRecentChecks: number,
+		statusPatch?: Partial<Monitor>
 	): Promise<Monitor>;
 	togglePauseById(monitorId: string, teamId: string): Promise<Monitor>;
 	// delete

--- a/server/src/repositories/monitors/IMonitorsRepository.ts
+++ b/server/src/repositories/monitors/IMonitorsRepository.ts
@@ -1,4 +1,4 @@
-import { type MonitorType, type Monitor, type MonitorsSummary } from "@/types/index.js";
+import { type MonitorType, type Monitor, type MonitorsSummary, CheckSnapshot } from "@/types/index.js";
 
 export interface TeamQueryConfig {
 	limit?: number;
@@ -29,6 +29,14 @@ export interface IMonitorsRepository {
 
 	// update
 	updateById(monitorId: string, teamId: string, updates: Partial<Monitor>): Promise<Monitor>;
+	updateStatusWindowAndChecks(
+		monitorId: string,
+		teamId: string,
+		status: boolean,
+		checkSnapshot: CheckSnapshot,
+		windowSize: number,
+		maxRecentChecks: number
+	): Promise<Monitor>;
 	togglePauseById(monitorId: string, teamId: string): Promise<Monitor>;
 	// delete
 	deleteById(monitorId: string, teamId: string): Promise<Monitor>;

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -182,6 +182,31 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		return this.toEntity(updatedMonitor);
 	};
 
+	updateStatusWindowAndChecks = async (
+		monitorId: string,
+		teamId: string,
+		status: boolean,
+		checkSnapshot: CheckSnapshot,
+		windowSize: number,
+		maxRecentChecks: number
+	): Promise<Monitor> => {
+		const updatedMonitor = await MonitorModel.findOneAndUpdate(
+			{ _id: monitorId, teamId },
+			{
+				$push: {
+					statusWindow: { $each: [status], $slice: -windowSize },
+					recentChecks: { $each: [checkSnapshot], $slice: -maxRecentChecks },
+				},
+			},
+			{ returnDocument: "after" }
+		);
+
+		if (!updatedMonitor) {
+			throw new AppError({ message: `Failed to update status and checks for monitor with id ${monitorId}`, status: 500 });
+		}
+		return this.toEntity(updatedMonitor);
+	};
+
 	togglePauseById = async (monitorId: string, teamId: string) => {
 		const monitor = await MonitorModel.findOneAndUpdate(
 			{ _id: monitorId, teamId },

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -188,7 +188,8 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		status: boolean,
 		checkSnapshot: CheckSnapshot,
 		windowSize: number,
-		maxRecentChecks: number
+		maxRecentChecks: number,
+		statusPatch?: Partial<Monitor>
 	): Promise<Monitor> => {
 		const updatedMonitor = await MonitorModel.findOneAndUpdate(
 			{ _id: monitorId, teamId },
@@ -197,6 +198,7 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 					statusWindow: { $each: [status], $slice: -windowSize },
 					recentChecks: { $each: [checkSnapshot], $slice: -maxRecentChecks },
 				},
+				...(statusPatch && { $set: statusPatch }),
 			},
 			{ returnDocument: "after" }
 		);

--- a/server/src/repositories/monitors/TimescaleMonitorsRepository.ts
+++ b/server/src/repositories/monitors/TimescaleMonitorsRepository.ts
@@ -1,5 +1,5 @@
 import type { Pool } from "pg";
-import type { Monitor, MonitorsSummary, MonitorStatus, MonitorType, MonitorMatchMethod, GeoContinent } from "@/types/monitor.js";
+import type { Monitor, MonitorsSummary, MonitorStatus, MonitorType, MonitorMatchMethod, GeoContinent, CheckSnapshot } from "@/types/monitor.js";
 import type { IMonitorsRepository, TeamQueryConfig, SummaryConfig } from "./IMonitorsRepository.js";
 import { AppError } from "@/utils/AppError.js";
 
@@ -638,6 +638,55 @@ export class TimescaleMonitorsRepository implements IMonitorsRepository {
 
 		const entity = this.toEntity(row);
 		entity.notifications = patch.notifications ?? (await this.fetchNotificationIds([monitorId]).then((m) => m.get(monitorId) ?? []));
+		return entity;
+	};
+
+	updateStatusWindowAndChecks = async (
+		monitorId: string,
+		teamId: string,
+		status: boolean,
+		_checkSnapshot: CheckSnapshot,
+		windowSize: number,
+		_maxRecentChecks: number,
+		statusPatch?: Partial<Monitor>
+	): Promise<Monitor> => {
+		// In TimescaleDB, recentChecks live in the checks table (inserted by the buffer service),
+		// so we only need to atomically update status_window and any statusPatch fields.
+		const sets: string[] = [
+			`status_window = (array_append(COALESCE(status_window, ARRAY[]::boolean[]), $1))[array_length(array_append(COALESCE(status_window, ARRAY[]::boolean[]), $1), 1) - $2 + 1:]`,
+			`updated_at = NOW()`,
+		];
+		const values: unknown[] = [status, windowSize];
+		let paramIndex = 3;
+
+		if (statusPatch) {
+			const patchFieldMap: [keyof Monitor, string][] = [
+				["status", "status"],
+				["cpuAlertCounter", "cpu_alert_counter"],
+				["memoryAlertCounter", "memory_alert_counter"],
+				["diskAlertCounter", "disk_alert_counter"],
+				["tempAlertCounter", "temp_alert_counter"],
+			];
+			for (const [key, column] of patchFieldMap) {
+				if (statusPatch[key] !== undefined) {
+					sets.push(`${column} = $${paramIndex++}`);
+					values.push(statusPatch[key]);
+				}
+			}
+		}
+
+		values.push(monitorId, teamId);
+		const result = await this.pool.query<MonitorRow>(
+			`UPDATE monitors SET ${sets.join(", ")} WHERE id = $${paramIndex++} AND team_id = $${paramIndex}
+			 RETURNING ${MONITOR_COLUMNS}`,
+			values
+		);
+		const row = result.rows[0];
+		if (!row) {
+			throw new AppError({ message: `Failed to update status and checks for monitor with id ${monitorId}`, status: 500 });
+		}
+		const entity = this.toEntity(row);
+		entity.notifications = await this.fetchNotificationIds([monitorId]).then((m) => m.get(monitorId) ?? []);
 		return entity;
 	};
 

--- a/server/src/service/infrastructure/statusService.ts
+++ b/server/src/service/infrastructure/statusService.ts
@@ -200,18 +200,6 @@ export class StatusService implements IStatusService {
 		return { nextStatus, transitioned, breaches, nextCounters };
 	};
 
-	private updateStatusWindowAndRecentChecks = async (monitor: Monitor, check: Check) => {
-		const checkSnapshot = this.toCheckSnapshot(check);
-		return await this.monitorsRepository.updateStatusWindowAndChecks(
-			monitor.id,
-			monitor.teamId,
-			check.status,
-			checkSnapshot,
-			monitor.statusWindowSize,
-			MAX_RECENT_CHECKS
-		);
-	};
-
 	updateMonitorStatus = async (
 		statusResponse: MonitorStatusResponse<
 			| PingStatusPayload
@@ -232,13 +220,32 @@ export class StatusService implements IStatusService {
 
 			// Update running stats
 			await this.tryUpdateRunningStats(monitor, statusResponse);
-			const updatedMonitor = await this.updateStatusWindowAndRecentChecks(monitor, check);
-			const prevStatus = updatedMonitor.status;
 
-			// Return early if not enough data points
-			if (updatedMonitor.statusWindow.length < updatedMonitor.statusWindowSize) {
-				updatedMonitor.status = status === true ? "up" : "down";
-				const updated = await this.monitorsRepository.updateById(updatedMonitor.id, updatedMonitor.teamId, { status: updatedMonitor.status });
+			const prevStatus = monitor.status;
+			const checkSnapshot = this.toCheckSnapshot(check);
+
+			// Project the window as it will look after updating DB
+			// This is done because we need the updated status window to compute new status, but we don't
+			// want an an extra DB write just to get the window.
+			const projectedWindow = [...(monitor.statusWindow || []), check.status].slice(-monitor.statusWindowSize);
+
+			// Build the status patch — computed against the projected window
+			const patch: Partial<Monitor> = {};
+
+			// Not enough data points yet
+			if (projectedWindow.length < monitor.statusWindowSize) {
+				patch.status = status === true ? "up" : "down";
+
+				const updated = await this.monitorsRepository.updateStatusWindowAndChecks(
+					monitor.id,
+					monitor.teamId,
+					check.status,
+					checkSnapshot,
+					monitor.statusWindowSize,
+					MAX_RECENT_CHECKS,
+					patch
+				);
+
 				return {
 					monitor: updated,
 					statusChanged: false,
@@ -248,18 +255,20 @@ export class StatusService implements IStatusService {
 				};
 			}
 
-			// With a full window, a single raw check must not change UNLESS we are initializing. Otherwise, only the sliding-window threshold can trigger a transition.
+			// With a full window, a single raw check must not change UNLESS we are initializing.
+			// Otherwise, only the sliding-window threshold can trigger a transition.
 			let newStatus: MonitorStatus;
-			if (updatedMonitor.status === "initializing") {
+			if (monitor.status === "initializing") {
 				newStatus = status === true ? "up" : "down";
 			} else {
-				newStatus = updatedMonitor.status;
+				newStatus = monitor.status;
 			}
 
 			let statusChanged = false;
 
-			// First evaluate reachability-based status changes, which apply to all monitor types and take precedence over hardware breaches.
-			const reachabilityResult = this.computeReachability(newStatus, updatedMonitor.statusWindow, updatedMonitor.statusWindowThreshold);
+			// First evaluate reachability-based status changes, which apply to all monitor types
+			// and take precedence over hardware breaches.
+			const reachabilityResult = this.computeReachability(newStatus, projectedWindow, monitor.statusWindowThreshold);
 			if (reachabilityResult.transitioned) {
 				newStatus = reachabilityResult.nextStatus;
 				statusChanged = true;
@@ -268,29 +277,29 @@ export class StatusService implements IStatusService {
 			// Evaluate hardware threshold breaches (only for hardware monitors with metrics payload)
 			let thresholdBreaches: HardwareBreaches | undefined;
 			const hardwarePayload = statusResponse.payload as HardwareStatusPayload | undefined;
-			if (updatedMonitor.type === "hardware" && hardwarePayload?.data) {
+			if (monitor.type === "hardware" && hardwarePayload?.data) {
 				const hardware = this.computeHardwareStatus({
 					currentStatus: newStatus,
 					reachabilityDown: newStatus === "down",
 					metrics: hardwarePayload.data,
 					thresholds: {
-						cpu: updatedMonitor.cpuAlertThreshold,
-						memory: updatedMonitor.memoryAlertThreshold,
-						disk: updatedMonitor.diskAlertThreshold,
-						temp: updatedMonitor.tempAlertThreshold,
+						cpu: monitor.cpuAlertThreshold,
+						memory: monitor.memoryAlertThreshold,
+						disk: monitor.diskAlertThreshold,
+						temp: monitor.tempAlertThreshold,
 					},
 					counters: {
-						cpu: updatedMonitor.cpuAlertCounter,
-						memory: updatedMonitor.memoryAlertCounter,
-						disk: updatedMonitor.diskAlertCounter,
-						temp: updatedMonitor.tempAlertCounter,
+						cpu: monitor.cpuAlertCounter,
+						memory: monitor.memoryAlertCounter,
+						disk: monitor.diskAlertCounter,
+						temp: monitor.tempAlertCounter,
 					},
 				});
 
-				updatedMonitor.cpuAlertCounter = hardware.nextCounters.cpu;
-				updatedMonitor.memoryAlertCounter = hardware.nextCounters.memory;
-				updatedMonitor.diskAlertCounter = hardware.nextCounters.disk;
-				updatedMonitor.tempAlertCounter = hardware.nextCounters.temp;
+				patch.cpuAlertCounter = hardware.nextCounters.cpu;
+				patch.memoryAlertCounter = hardware.nextCounters.memory;
+				patch.diskAlertCounter = hardware.nextCounters.disk;
+				patch.tempAlertCounter = hardware.nextCounters.temp;
 				thresholdBreaches = hardware.breaches;
 				if (hardware.transitioned) {
 					newStatus = hardware.nextStatus;
@@ -298,17 +307,18 @@ export class StatusService implements IStatusService {
 				}
 			}
 
-			// Apply the final status — only write fields computed by application logic,
-			// not statusWindow/recentChecks which are owned by the atomic push.
-			const patch: Partial<Monitor> = { status: newStatus };
-			if (updatedMonitor.type === "hardware" && hardwarePayload?.data) {
-				patch.cpuAlertCounter = updatedMonitor.cpuAlertCounter;
-				patch.memoryAlertCounter = updatedMonitor.memoryAlertCounter;
-				patch.diskAlertCounter = updatedMonitor.diskAlertCounter;
-				patch.tempAlertCounter = updatedMonitor.tempAlertCounter;
-			}
+			patch.status = newStatus;
 
-			const updated = await this.monitorsRepository.updateById(updatedMonitor.id, updatedMonitor.teamId, patch);
+			// Single atomic write: push arrays + set status/counters
+			const updated = await this.monitorsRepository.updateStatusWindowAndChecks(
+				monitor.id,
+				monitor.teamId,
+				check.status,
+				checkSnapshot,
+				monitor.statusWindowSize,
+				MAX_RECENT_CHECKS,
+				patch
+			);
 
 			return {
 				monitor: updated,

--- a/server/src/service/infrastructure/statusService.ts
+++ b/server/src/service/infrastructure/statusService.ts
@@ -217,6 +217,125 @@ export class StatusService implements IStatusService {
 		return { nextStatus, transitioned, breaches, nextCounters };
 	};
 
+	private updateStatusWindowAndRecentChecks = async (monitor: Monitor, check: Check) => {
+		const checkSnapshot = this.toCheckSnapshot(check);
+		return await this.monitorsRepository.updateStatusWindowAndChecks(
+			monitor.id,
+			monitor.teamId,
+			check.status,
+			checkSnapshot,
+			monitor.statusWindowSize,
+			MAX_RECENT_CHECKS
+		);
+	};
+
+	newUpdateMonitorStatus = async (
+		statusResponse: MonitorStatusResponse<
+			| PingStatusPayload
+			| HttpStatusPayload
+			| PageSpeedStatusPayload
+			| HardwareStatusPayload
+			| DockerStatusPayload
+			| PortStatusPayload
+			| GameStatusPayload
+			| GrpcStatusPayload
+			| undefined
+		>,
+		check: Check
+	): Promise<StatusChangeResult> => {
+		try {
+			const { monitorId, teamId, status, code } = statusResponse;
+			const monitor = await this.monitorsRepository.findById(monitorId, teamId);
+
+			// Update running stats
+			await this.tryUpdateRunningStats(monitor, statusResponse);
+			const updatedMonitor = await this.updateStatusWindowAndRecentChecks(monitor, check);
+			const prevStatus = updatedMonitor.status;
+
+			// Return early if not enough data points
+			if (updatedMonitor.statusWindow.length < updatedMonitor.statusWindowSize) {
+				updatedMonitor.status = status === true ? "up" : "down";
+				const updated = await this.monitorsRepository.updateById(updatedMonitor.id, updatedMonitor.teamId, { status: updatedMonitor.status });
+				return {
+					monitor: updated,
+					statusChanged: false,
+					prevStatus,
+					code,
+					timestamp: Date.now(),
+				};
+			}
+
+			// With a full window, a single raw check must not change UNLESS we are initializing. Otherwise, only the sliding-window threshold can trigger a transition.
+			let newStatus: MonitorStatus;
+			if (updatedMonitor.status === "initializing") {
+				newStatus = status === true ? "up" : "down";
+			} else {
+				newStatus = updatedMonitor.status;
+			}
+
+			let statusChanged = false;
+
+			// First evaluate reachability-based status changes, which apply to all monitor types and take precedence over hardware breaches.
+			const reachabilityResult = this.computeReachability(newStatus, updatedMonitor.statusWindow, updatedMonitor.statusWindowThreshold);
+			if (reachabilityResult.transitioned) {
+				newStatus = reachabilityResult.nextStatus;
+				statusChanged = true;
+			}
+
+			// Evaluate hardware threshold breaches (only for hardware monitors with metrics payload)
+			let thresholdBreaches: HardwareBreaches | undefined;
+			const hardwarePayload = statusResponse.payload as HardwareStatusPayload | undefined;
+			if (updatedMonitor.type === "hardware" && hardwarePayload?.data) {
+				const hardware = this.computeHardwareStatus({
+					currentStatus: newStatus,
+					reachabilityDown: newStatus === "down",
+					metrics: hardwarePayload.data,
+					thresholds: {
+						cpu: updatedMonitor.cpuAlertThreshold,
+						memory: updatedMonitor.memoryAlertThreshold,
+						disk: updatedMonitor.diskAlertThreshold,
+						temp: updatedMonitor.tempAlertThreshold,
+					},
+					counters: {
+						cpu: updatedMonitor.cpuAlertCounter,
+						memory: updatedMonitor.memoryAlertCounter,
+						disk: updatedMonitor.diskAlertCounter,
+						temp: updatedMonitor.tempAlertCounter,
+					},
+				});
+
+				updatedMonitor.cpuAlertCounter = hardware.nextCounters.cpu;
+				updatedMonitor.memoryAlertCounter = hardware.nextCounters.memory;
+				updatedMonitor.diskAlertCounter = hardware.nextCounters.disk;
+				updatedMonitor.tempAlertCounter = hardware.nextCounters.temp;
+				thresholdBreaches = hardware.breaches;
+				if (hardware.transitioned) {
+					newStatus = hardware.nextStatus;
+					statusChanged = true;
+				}
+			}
+
+			// Apply the final status
+			updatedMonitor.status = newStatus;
+
+			const updated = await this.monitorsRepository.updateById(updatedMonitor.id, updatedMonitor.teamId, updatedMonitor);
+
+			return {
+				monitor: updated,
+				statusChanged,
+				prevStatus,
+				code,
+				timestamp: new Date().getTime(),
+				thresholdBreaches,
+			};
+		} catch (error: unknown) {
+			throw new AppError({
+				message: `Failed to update monitor with id ${check.metadata.monitorId} with status: ${error instanceof Error ? error.message : "Unknown error"}`,
+				service: SERVICE_NAME,
+				method: "updateMonitorStatus",
+			});
+		}
+	};
 	updateMonitorStatus = async (
 		statusResponse: MonitorStatusResponse<
 			| PingStatusPayload

--- a/server/src/service/infrastructure/statusService.ts
+++ b/server/src/service/infrastructure/statusService.ts
@@ -102,14 +102,6 @@ export class StatusService implements IStatusService {
 		}
 	};
 
-	private appendToWindow = (monitor: Monitor, status: boolean) => {
-		monitor.statusWindow = monitor.statusWindow || [];
-		monitor.statusWindow.push(status);
-		while (monitor.statusWindow.length > monitor.statusWindowSize) {
-			monitor.statusWindow.shift();
-		}
-	};
-
 	private toCheckSnapshot = (check: Check): CheckSnapshot => {
 		return {
 			id: check.id,
@@ -132,15 +124,6 @@ export class StatusService implements IStatusService {
 			audits: check.audits,
 			createdAt: check.createdAt,
 		};
-	};
-
-	private appendToRecentChecks = (monitor: Monitor, check: Check) => {
-		monitor.recentChecks = monitor.recentChecks || [];
-		const checkSnapshot = this.toCheckSnapshot(check);
-		monitor.recentChecks.push(checkSnapshot);
-		while (monitor.recentChecks.length > MAX_RECENT_CHECKS) {
-			monitor.recentChecks.shift();
-		}
 	};
 
 	private computeReachability = (
@@ -229,7 +212,7 @@ export class StatusService implements IStatusService {
 		);
 	};
 
-	newUpdateMonitorStatus = async (
+	updateMonitorStatus = async (
 		statusResponse: MonitorStatusResponse<
 			| PingStatusPayload
 			| HttpStatusPayload
@@ -315,121 +298,17 @@ export class StatusService implements IStatusService {
 				}
 			}
 
-			// Apply the final status
-			updatedMonitor.status = newStatus;
-
-			const updated = await this.monitorsRepository.updateById(updatedMonitor.id, updatedMonitor.teamId, updatedMonitor);
-
-			return {
-				monitor: updated,
-				statusChanged,
-				prevStatus,
-				code,
-				timestamp: new Date().getTime(),
-				thresholdBreaches,
-			};
-		} catch (error: unknown) {
-			throw new AppError({
-				message: `Failed to update monitor with id ${check.metadata.monitorId} with status: ${error instanceof Error ? error.message : "Unknown error"}`,
-				service: SERVICE_NAME,
-				method: "updateMonitorStatus",
-			});
-		}
-	};
-	updateMonitorStatus = async (
-		statusResponse: MonitorStatusResponse<
-			| PingStatusPayload
-			| HttpStatusPayload
-			| PageSpeedStatusPayload
-			| HardwareStatusPayload
-			| DockerStatusPayload
-			| PortStatusPayload
-			| GameStatusPayload
-			| GrpcStatusPayload
-			| undefined
-		>,
-		check: Check
-	): Promise<StatusChangeResult> => {
-		try {
-			const { monitorId, teamId, status, code } = statusResponse;
-			const monitor = await this.monitorsRepository.findById(monitorId, teamId);
-
-			// Update running stats
-			await this.tryUpdateRunningStats(monitor, statusResponse);
-
-			// Update the sliding window and recent checks
-			this.appendToWindow(monitor, status);
-			this.appendToRecentChecks(monitor, check);
-
-			const prevStatus = monitor.status;
-
-			// Return early if not enough data points
-			if (monitor.statusWindow.length < monitor.statusWindowSize) {
-				monitor.status = status === true ? "up" : "down";
-				const updated = await this.monitorsRepository.updateById(monitor.id, monitor.teamId, monitor);
-				return {
-					monitor: updated,
-					statusChanged: false,
-					prevStatus,
-					code,
-					timestamp: Date.now(),
-				};
+			// Apply the final status — only write fields computed by application logic,
+			// not statusWindow/recentChecks which are owned by the atomic push.
+			const patch: Partial<Monitor> = { status: newStatus };
+			if (updatedMonitor.type === "hardware" && hardwarePayload?.data) {
+				patch.cpuAlertCounter = updatedMonitor.cpuAlertCounter;
+				patch.memoryAlertCounter = updatedMonitor.memoryAlertCounter;
+				patch.diskAlertCounter = updatedMonitor.diskAlertCounter;
+				patch.tempAlertCounter = updatedMonitor.tempAlertCounter;
 			}
 
-			// With a full window, a single raw check must not change UNLESS we are initializing. Otherwise, only the sliding-window threshold can trigger a transition.
-			let newStatus: MonitorStatus;
-			if (monitor.status === "initializing") {
-				newStatus = status === true ? "up" : "down";
-			} else {
-				newStatus = monitor.status;
-			}
-
-			let statusChanged = false;
-
-			// First evaluate reachability-based status changes, which apply to all monitor types and take precedence over hardware breaches.
-			const reachabilityResult = this.computeReachability(newStatus, monitor.statusWindow, monitor.statusWindowThreshold);
-			if (reachabilityResult.transitioned) {
-				newStatus = reachabilityResult.nextStatus;
-				statusChanged = true;
-			}
-
-			// Evaluate hardware threshold breaches (only for hardware monitors with metrics payload)
-			let thresholdBreaches: HardwareBreaches | undefined;
-			const hardwarePayload = statusResponse.payload as HardwareStatusPayload | undefined;
-			if (monitor.type === "hardware" && hardwarePayload?.data) {
-				const hardware = this.computeHardwareStatus({
-					currentStatus: newStatus,
-					reachabilityDown: newStatus === "down",
-					metrics: hardwarePayload.data,
-					thresholds: {
-						cpu: monitor.cpuAlertThreshold,
-						memory: monitor.memoryAlertThreshold,
-						disk: monitor.diskAlertThreshold,
-						temp: monitor.tempAlertThreshold,
-					},
-					counters: {
-						cpu: monitor.cpuAlertCounter,
-						memory: monitor.memoryAlertCounter,
-						disk: monitor.diskAlertCounter,
-						temp: monitor.tempAlertCounter,
-					},
-				});
-
-				monitor.cpuAlertCounter = hardware.nextCounters.cpu;
-				monitor.memoryAlertCounter = hardware.nextCounters.memory;
-				monitor.diskAlertCounter = hardware.nextCounters.disk;
-				monitor.tempAlertCounter = hardware.nextCounters.temp;
-				thresholdBreaches = hardware.breaches;
-				if (hardware.transitioned) {
-					newStatus = hardware.nextStatus;
-					statusChanged = true;
-				}
-			}
-
-			// Apply the final status
-			monitor.status = newStatus;
-
-			const updated = await this.monitorsRepository.updateById(monitor.id, monitor.teamId, monitor);
+			const updated = await this.monitorsRepository.updateById(updatedMonitor.id, updatedMonitor.teamId, patch);
 
 			return {
 				monitor: updated,

--- a/server/test/helpers/InMemoryMonitorsRepository.ts
+++ b/server/test/helpers/InMemoryMonitorsRepository.ts
@@ -1,5 +1,5 @@
 import type { IMonitorsRepository, TeamQueryConfig, SummaryConfig } from "../../src/repositories/monitors/IMonitorsRepository.ts";
-import type { Monitor, MonitorsSummary } from "../../src/types/index.ts";
+import type { Monitor, MonitorsSummary, CheckSnapshot } from "../../src/types/index.ts";
 
 export class InMemoryMonitorsRepository implements IMonitorsRepository {
 	private monitors: Monitor[] = [];
@@ -47,6 +47,37 @@ export class InMemoryMonitorsRepository implements IMonitorsRepository {
 		const updated = { ...this.monitors[index], ...updates, id: this.monitors[index].id, teamId: this.monitors[index].teamId };
 		this.monitors[index] = updated;
 		return { ...updated };
+	}
+
+	async updateStatusWindowAndChecks(
+		monitorId: string,
+		teamId: string,
+		status: boolean,
+		checkSnapshot: CheckSnapshot,
+		windowSize: number,
+		maxRecentChecks: number,
+		statusPatch?: Partial<Monitor>
+	): Promise<Monitor> {
+		const index = this.monitors.findIndex((m) => m.id === monitorId && m.teamId === teamId);
+		if (index === -1) {
+			throw new Error(`Monitor ${monitorId} not found`);
+		}
+		const monitor = this.monitors[index];
+		monitor.statusWindow = monitor.statusWindow || [];
+		monitor.statusWindow.push(status);
+		while (monitor.statusWindow.length > windowSize) {
+			monitor.statusWindow.shift();
+		}
+		monitor.recentChecks = monitor.recentChecks || [];
+		monitor.recentChecks.push(checkSnapshot);
+		while (monitor.recentChecks.length > maxRecentChecks) {
+			monitor.recentChecks.shift();
+		}
+		if (statusPatch) {
+			Object.assign(monitor, statusPatch);
+		}
+		this.monitors[index] = monitor;
+		return { ...monitor };
 	}
 
 	async togglePauseById(monitorId: string, teamId: string): Promise<Monitor> {

--- a/server/test/unit/services/statusService.test.ts
+++ b/server/test/unit/services/statusService.test.ts
@@ -11,11 +11,49 @@ const createBuffer = (): jest.Mocked<Pick<IBufferService, "addToBuffer">> => ({
 	addToBuffer: jest.fn(),
 });
 
-const createMonitorsRepo = () =>
-	({
-		findById: jest.fn(),
+const createMonitorsRepo = () => {
+	const findById = jest.fn();
+	const updateStatusWindowAndChecks = jest
+		.fn()
+		.mockImplementation(
+			(
+				_id: unknown,
+				_tid: unknown,
+				status: boolean,
+				checkSnapshot: unknown,
+				windowSize: number,
+				maxRecentChecks: number,
+				statusPatch?: Partial<Monitor>
+			) => {
+				// Grab the monitor that findById was configured to resolve with
+				const monitor = findById.mock.results.at(-1)?.value;
+				if (monitor && typeof monitor.then === "function") {
+					return monitor.then((m: any) => {
+						m.statusWindow = m.statusWindow || [];
+						m.statusWindow.push(status);
+						while (m.statusWindow.length > windowSize) {
+							m.statusWindow.shift();
+						}
+						m.recentChecks = m.recentChecks || [];
+						m.recentChecks.push(checkSnapshot);
+						while (m.recentChecks.length > maxRecentChecks) {
+							m.recentChecks.shift();
+						}
+						if (statusPatch) {
+							Object.assign(m, statusPatch);
+						}
+						return { ...m };
+					});
+				}
+				return Promise.reject(new Error("findById not mocked"));
+			}
+		);
+	return {
+		findById,
 		updateById: jest.fn(),
-	}) as unknown as jest.Mocked<IMonitorsRepository>;
+		updateStatusWindowAndChecks,
+	} as unknown as jest.Mocked<IMonitorsRepository>;
+};
 
 const createMonitorStatsRepo = () =>
 	({
@@ -233,11 +271,18 @@ describe("StatusService", () => {
 			(monitorsRepository.findById as jest.Mock).mockResolvedValue(monitor);
 			(monitorsRepository.updateById as jest.Mock).mockImplementation((_id: unknown, _tid: unknown, m: unknown) => Promise.resolve(m));
 
-			await service.updateMonitorStatus(makeStatusResponse({ status: false }), makeCheck());
+			await service.updateMonitorStatus(makeStatusResponse({ status: false }), makeCheck({ status: false }));
 
-			// Window should have shifted: [true, true, true, true, false]
-			expect(monitor.statusWindow).toHaveLength(5);
-			expect(monitor.statusWindow[4]).toBe(false);
+			// Atomic push should have been called with the correct status and window size
+			expect(monitorsRepository.updateStatusWindowAndChecks).toHaveBeenCalledWith(
+				"mon-1",
+				"team-1",
+				false,
+				expect.any(Object),
+				5,
+				25,
+				expect.objectContaining({ status: expect.any(String) })
+			);
 		});
 
 		it("pushes check snapshot to recentChecks and trims to 25", async () => {
@@ -542,7 +587,8 @@ describe("StatusService", () => {
 
 				expect(result.thresholdBreaches?.cpu).toBe(true);
 				expect(result.thresholdBreaches?.memory).toBe(false);
-				expect(monitor.cpuAlertCounter).toBe(0);
+				const patch = (monitorsRepository.updateStatusWindowAndChecks as jest.Mock).mock.calls.at(-1)?.[6];
+				expect(patch.cpuAlertCounter).toBe(0);
 				expect(result.statusChanged).toBe(true);
 				expect(result.monitor.status).toBe("breached");
 			});
@@ -557,7 +603,8 @@ describe("StatusService", () => {
 				const result = await service.updateMonitorStatus(response, makeCheck());
 
 				expect(result.thresholdBreaches?.memory).toBe(true);
-				expect(monitor.memoryAlertCounter).toBe(0);
+				const patch = (monitorsRepository.updateStatusWindowAndChecks as jest.Mock).mock.calls.at(-1)?.[6];
+				expect(patch.memoryAlertCounter).toBe(0);
 				expect(result.monitor.status).toBe("breached");
 			});
 
@@ -573,7 +620,8 @@ describe("StatusService", () => {
 				const result = await service.updateMonitorStatus(response, makeCheck());
 
 				expect(result.thresholdBreaches?.disk).toBe(true);
-				expect(monitor.diskAlertCounter).toBe(0);
+				const patch = (monitorsRepository.updateStatusWindowAndChecks as jest.Mock).mock.calls.at(-1)?.[6];
+				expect(patch.diskAlertCounter).toBe(0);
 				expect(result.monitor.status).toBe("breached");
 			});
 
@@ -589,7 +637,8 @@ describe("StatusService", () => {
 				const result = await service.updateMonitorStatus(response, makeCheck());
 
 				expect(result.thresholdBreaches?.temp).toBe(true);
-				expect(monitor.tempAlertCounter).toBe(0);
+				const patch = (monitorsRepository.updateStatusWindowAndChecks as jest.Mock).mock.calls.at(-1)?.[6];
+				expect(patch.tempAlertCounter).toBe(0);
 				expect(result.monitor.status).toBe("breached");
 			});
 
@@ -609,10 +658,11 @@ describe("StatusService", () => {
 				} as any);
 				await service.updateMonitorStatus(response, makeCheck());
 
-				expect(monitor.cpuAlertCounter).toBe(5);
-				expect(monitor.memoryAlertCounter).toBe(5);
-				expect(monitor.diskAlertCounter).toBe(5);
-				expect(monitor.tempAlertCounter).toBe(5);
+				const patch = (monitorsRepository.updateStatusWindowAndChecks as jest.Mock).mock.calls.at(-1)?.[6];
+				expect(patch.cpuAlertCounter).toBe(5);
+				expect(patch.memoryAlertCounter).toBe(5);
+				expect(patch.diskAlertCounter).toBe(5);
+				expect(patch.tempAlertCounter).toBe(5);
 			});
 
 			it("stays breached without statusChanged when already breached and counter still at 0", async () => {
@@ -841,7 +891,8 @@ describe("StatusService", () => {
 				const response = makeHardwareResponse({ data: { cpu: { usage_percent: 0.9 }, memory: { usage_percent: 0.1 }, disk: [], host: {} } } as any);
 				const result = await service.updateMonitorStatus(response, makeCheck());
 
-				expect(monitor.cpuAlertCounter).toBe(2);
+				const patch = (monitorsRepository.updateStatusWindowAndChecks as jest.Mock).mock.calls.at(-1)?.[6];
+				expect(patch.cpuAlertCounter).toBe(2);
 				expect(result.thresholdBreaches?.cpu).toBe(true);
 				expect(result.statusChanged).toBe(false);
 				expect(result.monitor.status).toBe("up");


### PR DESCRIPTION
This PR fixes a subtle race condition that occurs due to mutation of the status window on monitors during a check.

Currently, a monitor is read from the DB, its state is mutated in memory, and then it is rewritten to the DB.  This introduces a race condition whereby if two jobs are running on the same monitor, ie their ticks overlap, the latter operation will clobber the first operation.

This PR switches to using a projected status window and one atomic write operation to handle updating the monitor state, resolving this race condition