### PR TITLE
Fix/maintenance recurring edit validation

### DIFF
--- a/client/src/Hooks/useMaintenanceWindowForm.ts
+++ b/client/src/Hooks/useMaintenanceWindowForm.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import dayjs from "dayjs";
 import {
 	maintenanceWindowSchema,
+	maintenanceWindowEditSchema,
 	repeatOptions,
 	type MaintenanceWindowFormData,
 } from "@/Validation/maintenanceWindow";
@@ -47,6 +48,6 @@ export const useMaintenanceWindowForm = ({
 			};
 		}
 
-		return { schema: maintenanceWindowSchema, defaults };
+		return { schema: data ? maintenanceWindowEditSchema : maintenanceWindowSchema, defaults };
 	}, [data]);
 };

--- a/client/src/Hooks/useMaintenanceWindowForm.ts
+++ b/client/src/Hooks/useMaintenanceWindowForm.ts
@@ -48,6 +48,9 @@ export const useMaintenanceWindowForm = ({
 			};
 		}
 
-		return { schema: data ? maintenanceWindowEditSchema : maintenanceWindowSchema, defaults };
+		return {
+			schema: data ? maintenanceWindowEditSchema : maintenanceWindowSchema,
+			defaults,
+		};
 	}, [data]);
 };

--- a/client/src/Validation/maintenanceWindow.ts
+++ b/client/src/Validation/maintenanceWindow.ts
@@ -14,30 +14,32 @@ export const durationUnitOptions = [
 	{ id: "days", name: "days", multiplier: 86400000 },
 ] as const;
 
-export const maintenanceWindowSchema = z
-	.object({
-		name: z
-			.string()
-			.min(1, "Name is required")
-			.max(100, "Name must be at most 100 characters"),
-		repeat: z.string(),
-		startDate: z.string().min(1, "Start date is required"),
-		startTime: z.string().min(1, "Start time is required"),
-		duration: z.number().int().min(1, "Duration must be at least 1"),
-		durationUnit: z.string(),
-		monitors: z.array(z.string()).min(1, "At least one monitor is required"),
-	})
-	.refine(
-		(data) => {
-			const startDateTime = dayjs(data.startDate)
-				.set("hour", parseInt(data.startTime.split(":")[0], 10))
-				.set("minute", parseInt(data.startTime.split(":")[1], 10));
-			return startDateTime.isAfter(dayjs());
-		},
-		{
-			message: "Start date and time must be in the future",
-			path: ["startDate"],
-		}
-	);
+const maintenanceWindowBaseSchema = z.object({
+	name: z
+		.string()
+		.min(1, "Name is required")
+		.max(100, "Name must be at most 100 characters"),
+	repeat: z.string(),
+	startDate: z.string().min(1, "Start date is required"),
+	startTime: z.string().min(1, "Start time is required"),
+	duration: z.number().int().min(1, "Duration must be at least 1"),
+	durationUnit: z.string(),
+	monitors: z.array(z.string()).min(1, "At least one monitor is required"),
+});
+
+export const maintenanceWindowSchema = maintenanceWindowBaseSchema.refine(
+	(data) => {
+		const startDateTime = dayjs(data.startDate)
+			.set("hour", parseInt(data.startTime.split(":")[0], 10))
+			.set("minute", parseInt(data.startTime.split(":")[1], 10));
+		return startDateTime.isAfter(dayjs());
+	},
+	{
+		message: "Start date and time must be in the future",
+		path: ["startDate"],
+	}
+);
+
+export const maintenanceWindowEditSchema = maintenanceWindowBaseSchema;
 
 export type MaintenanceWindowFormData = z.infer<typeof maintenanceWindowSchema>;


### PR DESCRIPTION
**(Please remove this line only before submitting your PR. Ensure that all relevant items are checked before submission.)** 

## Describe your changes

When editing a repeating maintenance window whose first occurrence has already passed, the form validation rejected the existing start date with "Start date and time must be in the future", making it impossible to save any edits.
The fix extracts the base object schema into maintenanceWindowBaseSchema and derives two schemas from it: maintenanceWindowSchema (with the future date refine, used on create) and maintenanceWindowEditSchema (without it, used on edit). Since one-time windows are auto-deleted by MongoDB's TTL index once they expire, skipping the future date check in edit mode is safe for all cases.

## Write your issue number after "Fixes "

Fixes #3546 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): 
```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] There are two database implementations (MongoDB and PostgreSQL TimescaleDB) and I have taken care of them appropriately.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

