### PR TITLE
fix(client): allow configurable Vite allowed hosts

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,11 +9,20 @@ const __dirname = path.dirname(__filename);
 export default defineConfig(({}) => {
 	let version = "3.6.1";
 
+	const allowedHosts = process.env.VITE_ALLOWED_HOSTS
+		? process.env.VITE_ALLOWED_HOSTS.split(",").map((h) => h.trim())
+		: true;
+
 	return {
 		base: "/",
 		plugins: [svgr(), react()],
 		server: {
 			host: true,
+			allowedHosts,
+		},
+		preview: {
+			host: true,
+			allowedHosts,
 		},
 		resolve: {
 			alias: {


### PR DESCRIPTION
## Summary
- Vite >=4.3 rejects requests for any `Host` header not in its allowlist, which causes `Blocked request. This host (...) is not allowed.` errors for users serving Checkmate behind a reverse proxy after upgrading.
- Adds `VITE_ALLOWED_HOSTS` env var (comma-separated) applied to both `server.allowedHosts` and `preview.allowedHosts`.
- When unset, falls back to `true` so existing self-hosted deployments keep working without any config change.

## Test plan
- [ ] `cd client && npm run build` succeeds
- [ ] `cd client && npm run format-check` passes
- [ ] With `VITE_ALLOWED_HOSTS` unset: requests from any host still served (no regression for current users)
- [ ] With `VITE_ALLOWED_HOSTS="checkmate.example.com"`: request from that host served, request from another host blocked

Closes #3397
Closes #2951