### PR TITLE
fix(server): suppress mongoose reserved-key warning on Check.errors

### DIFF
--- a/server/src/db/models/Check.ts
+++ b/server/src/db/models/Check.ts
@@ -271,6 +271,7 @@ const CheckSchema = new Schema<CheckDocument>(
 	{
 		timestamps: true,
 		strict: false,
+		suppressReservedKeysWarning: true,
 		timeseries: {
 			timeField: "createdAt",
 			metaField: "metadata",


### PR DESCRIPTION
## Summary
- Mongoose 8 logs a reserved-key warning at boot because the `Check` schema defines an `errors` field, which collides with Mongoose's internal document `errors` accessor.
- The field is intentional and safe; this PR opts out of the warning via `suppressReservedKeysWarning: true`.

## Test plan
- [ ] `cd server && npm run build` succeeds
- [ ] `cd server && npm run format-check` passes
- [ ] Boot the server locally and verify the `errors is a reserved schema pathname` warning no longer appears in logs

Closes #1539