### PR TITLE
fix(client): source app version from package.json

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "client",
 	"private": true,
-	"version": "0.0.0",
+	"version": "3.6.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -3,11 +3,13 @@ import react from "@vitejs/plugin-react";
 import svgr from "vite-plugin-svgr";
 import path from "path";
 import { fileURLToPath } from "url";
+import { readFileSync } from "fs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 export default defineConfig(({}) => {
-	let version = "3.6.1";
+	const pkg = JSON.parse(readFileSync(path.resolve(__dirname, "package.json"), "utf-8"));
+	const version = pkg.version;
 
 	return {
 		base: "/",


### PR DESCRIPTION
## Summary
- The client version shown on the Settings page was hardcoded as a literal in `client/vite.config.ts`, while `client/package.json` sat at the placeholder `0.0.0`. Bumping the displayed version required editing two unrelated places, and stale Docker client images kept showing the old number after upgrades.
- Makes `client/package.json` the single source of truth and reads it at build time via Vite's `define`.
- Bumps `client/package.json` from `0.0.0` to `3.6.1` to preserve current behaviour.

## Test plan
- [ ] `cd client && npm run build` succeeds
- [ ] `cd client && npm run format-check` passes
- [ ] Built bundle contains `"3.6.1"` (verified locally — `__APP_VERSION__` is replaced at build time)
- [ ] Settings page renders the version next to the app name

Closes #3271