### PR TITLE
docs(openapi): document all query params on /monitors/team/with-checks

### DIFF
--- a/server/openapi.json
+++ b/server/openapi.json
@@ -597,8 +597,79 @@
 						"schema": {
 							"type": "integer",
 							"minimum": 1,
-							"maximum": 50,
-							"default": 10
+							"maximum": 100
+						}
+					},
+					{
+						"name": "page",
+						"in": "query",
+						"description": "Zero-based page index for pagination",
+						"schema": {
+							"type": "integer",
+							"minimum": 0
+						}
+					},
+					{
+						"name": "rowsPerPage",
+						"in": "query",
+						"description": "Number of monitors per page",
+						"schema": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 100
+						}
+					},
+					{
+						"name": "filter",
+						"in": "query",
+						"description": "Search filter value",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "field",
+						"in": "query",
+						"description": "Field to sort by",
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"name": "order",
+						"in": "query",
+						"description": "Sort order",
+						"schema": {
+							"type": "string",
+							"enum": ["asc", "desc"]
+						}
+					},
+					{
+						"name": "type",
+						"in": "query",
+						"description": "Filter by monitor type",
+						"schema": {
+							"oneOf": [
+								{
+									"type": "string",
+									"enum": ["http", "ping", "pagespeed", "docker", "hardware", "port", "game", "grpc", "websocket"]
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string",
+										"enum": ["http", "ping", "pagespeed", "docker", "hardware", "port", "game", "grpc", "websocket"]
+									}
+								}
+							]
+						}
+					},
+					{
+						"name": "explain",
+						"in": "query",
+						"description": "Include MongoDB query explain output (debug)",
+						"schema": {
+							"type": "boolean"
 						}
 					}
 				],


### PR DESCRIPTION
## Summary
- The OpenAPI spec only listed `limit` for `GET /monitors/team/with-checks`, but the route's Zod schema (`getMonitorsWithChecksQueryValidation`) also accepts `page`, `rowsPerPage`, `filter`, `field`, `order`, `type`, and `explain`.
- Users exploring the API via Swagger UI either got rejected with `"page" is not allowed` after guessing param names, or never knew pagination was available.
- Adds the missing parameters to the spec with constraints mirrored from `server/src/validation/monitorValidation.ts:32-46`.
- Also corrects `limit` max from 50 to 100 to match the actual validation.

## Test plan
- [ ] `cd server && npm run build` succeeds
- [ ] `cd server && npm run format-check` passes
- [ ] `python3 -m json.tool server/openapi.json` parses cleanly
- [ ] Open `/api-docs` in the browser and confirm `/monitors/team/with-checks` lists all eight params with correct types

Closes #3354