### PR TITLE
fix(client): hide Open site action when URL is not browser-openable

### DIFF
--- a/client/src/Pages/Infrastructure/Monitors/Components/MonitorsTable.tsx
+++ b/client/src/Pages/Infrastructure/Monitors/Components/MonitorsTable.tsx
@@ -81,14 +81,6 @@ export const InfraMonitorsTable = ({
 	const getActions = (monitor: Monitor): ActionMenuItem[] => {
 		return [
 			{
-				id: 1,
-				label: t("pages.common.monitors.actions.openSite"),
-				action: () => {
-					window.open(monitor.url, "_blank", "noreferrer");
-				},
-				closeMenu: true,
-			},
-			{
 				id: 2,
 				label: t("pages.common.monitors.actions.details"),
 				action: () => {

--- a/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
+++ b/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
@@ -71,16 +71,24 @@ export const MonitorTable = ({
 		refetch();
 	};
 
+	const isBrowserOpenable = (monitor: Monitor): boolean => {
+		if (monitor.type !== "http" && monitor.type !== "pagespeed") return false;
+		return /^https?:\/\//i.test(monitor.url ?? "");
+	};
+
 	const getActions = (monitor: Monitor): ActionMenuItem[] => {
-		return [
-			{
+		const actions: ActionMenuItem[] = [];
+		if (isBrowserOpenable(monitor)) {
+			actions.push({
 				id: 1,
 				label: t("pages.common.monitors.actions.openSite"),
 				action: () => {
 					window.open(monitor.url, "_blank", "noreferrer");
 				},
 				closeMenu: true,
-			},
+			});
+		}
+		actions.push(
 			{
 				id: 2,
 				label: t("pages.common.monitors.actions.details"),
@@ -130,8 +138,9 @@ export const MonitorTable = ({
 				),
 				action: () => setSelectedMonitor(monitor),
 				closeMenu: true,
-			},
-		];
+			}
+		);
+		return actions;
 	};
 
 	const getHeaders = (chartType: string) => {


### PR DESCRIPTION
## Summary
The `Open site` action in monitor row menus called `window.open(monitor.url)` unconditionally, which produced unresolvable navigation for monitors targeting internal services:

- Hardware monitors always point at a Capture agent (e.g. `http://capture:59232/api/v1/metrics`) that the user's browser can't reach.
- Port, ping, docker, game, grpc, and websocket monitors store hostnames or non-HTTP endpoints that browsers can't load anyway.

This PR hides the action where it can't possibly work:
- **Infrastructure (hardware) monitors table**: removed entirely.
- **Uptime monitors table**: only shown for `http` and `pagespeed` monitor types whose URL starts with `http://` or `https://`.

A more comprehensive fix — adding a separate user-facing `siteUrl` field on the Monitor schema (as the issue suggests) — is left for a follow-up.

## Test plan
- [ ] `cd client && npm run build` succeeds
- [ ] `cd client && npm run format-check` passes
- [ ] Hardware monitor row: `Open site` action does not appear
- [ ] HTTP monitor with `https://example.com`: `Open site` appears and opens the URL
- [ ] HTTP monitor with `http://internal-thing` (still http://): `Open site` appears (regex matches) — this PR scopes by type, not by network reachability
- [ ] Ping / port / docker monitor: `Open site` does not appear

Closes #3434