### PR TITLE
Fix: prevent blank screen crash when clearing timezone search field

### DIFF
--- a/client/src/Features/UI/uiSlice.ts
+++ b/client/src/Features/UI/uiSlice.ts
@@ -89,7 +89,9 @@ const uiSlice = createSlice({
 		},
 
 		setTimezone: (state, action: PayloadAction<{ timezone: string }>) => {
-			state.timezone = action.payload.timezone;
+			if (action.payload.timezone) {
+				state.timezone = action.payload.timezone;
+			}
 		},
 		setLanguage: (state, action: PayloadAction<string>) => {
 			state.language = action.payload;

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -127,8 +127,8 @@ export const SettingsPage = () => {
 		timezoneOptions.find((tz) => tz.id === selectedTimezoneId) ?? null;
 
 	const handleTimezoneChange = (newValue: Timezone | null) => {
-		const newId = newValue?.id ?? "";
-		dispatch(setTimezone({ timezone: newId }));
+		if (!newValue?.id) return; 
+		dispatch(setTimezone({ timezone: newValue.id }));
 	};
 
 	const handleModeChange = (e: SelectChangeEvent<ThemeMode>) => {

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -127,7 +127,7 @@ export const SettingsPage = () => {
 		timezoneOptions.find((tz) => tz.id === selectedTimezoneId) ?? null;
 
 	const handleTimezoneChange = (newValue: Timezone | null) => {
-		if (!newValue?.id) return; 
+		if (!newValue?.id) return;
 		dispatch(setTimezone({ timezone: newValue.id }));
 	};
 

--- a/client/src/Utils/TimeUtils.ts
+++ b/client/src/Utils/TimeUtils.ts
@@ -19,8 +19,11 @@ export const formatDateWithTz = (timestamp: string, format: string, timezone: st
 	if (!timestamp) {
 		return "Unknown time";
 	}
-	const formattedDate = dayjs(timestamp).tz(timezone).format(format);
-	return formattedDate;
+	try {
+		return dayjs(timestamp).tz(timezone).format(format);
+	} catch {
+		return dayjs(timestamp).utc().format(format);
+	}
 };
 
 export const tickDateFormatLookup = (range: string) => {


### PR DESCRIPTION
## Describe your changes

Fixed a crash that caused the entire screen to go blank when a user typed partial or invalid text in the timezone search field in the Settings page or cleared the text.

- `handleTimezoneChange` in Settings/index.tsx now returns when `newValue` is empty.
- `setTimezone` in uiSlice.ts now ignores any empty string payload
- `formatDateWithTz` in Utils/TimeUtils.ts has a try/catch block so users with already corrupted timezone see etc-formatted times instead of blank screen

## Write your issue number after "Fixes "

Fixes #3582

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.
