### PR TITLE
fix: allow mono and arm containers to run as non-root user (UID 1000)

### DIFF
--- a/docker/dist-arm/server.Dockerfile
+++ b/docker/dist-arm/server.Dockerfile
@@ -44,7 +44,6 @@ RUN chown -R node:node ./public \
     && chown -R node:node ./dist \
     && chown -R node:node ./scripts
 
-USER node
 
 EXPOSE 52345
 

--- a/docker/dist-arm/server.Dockerfile
+++ b/docker/dist-arm/server.Dockerfile
@@ -40,6 +40,12 @@ RUN npm run build
 
 COPY --from=frontend-build /app/client/dist ./public
 
+RUN chown -R node:node ./public \
+    && chown -R node:node ./dist \
+    && chown -R node:node ./scripts
+
+USER node
+
 EXPOSE 52345
 
 CMD ["sh", "-c", "./scripts/inject-vars.sh && node ./dist/index.js"]

--- a/docker/dist-mono/server.Dockerfile
+++ b/docker/dist-mono/server.Dockerfile
@@ -31,7 +31,6 @@ RUN chmod +x ./scripts/inject-vars.sh \
     && chown -R node:node ./dist \
     && chown -R node:node ./scripts
 
-USER node
 
 EXPOSE 52345
 

--- a/docker/dist-mono/server.Dockerfile
+++ b/docker/dist-mono/server.Dockerfile
@@ -26,8 +26,13 @@ RUN cp -r src/templates dist/templates
 
 COPY --from=frontend-build /app/client/dist ./public
 
-RUN chmod +x ./scripts/inject-vars.sh
+RUN chmod +x ./scripts/inject-vars.sh \
+    && chown -R node:node ./public \
+    && chown -R node:node ./dist \
+    && chown -R node:node ./scripts
+
+USER node
 
 EXPOSE 52345
 
-CMD ./scripts/inject-vars.sh && node ./dist/index.js
+CMD ["sh", "-c", "./scripts/inject-vars.sh && node ./dist/index.js"]


### PR DESCRIPTION
## Problem

When running the container with `--user 1000` in environments that
don't allow containers to run as root (e.g. Kubernetes with
`runAsNonRoot: true`, OpenShift, or any hardened deployment), the
container crashes immediately:
sed: couldn't open temporary file ./public/assets/sednxgh3x: Permission denied

This happens because `inject-vars.sh` uses `sed -i`, which creates a
temporary file in the same directory as the file being edited.
The `./public/assets/` directory is owned by root after the COPY
instruction, so a non-root process can't write there.

## Solution

In both `dist-mono/server.Dockerfile` and `dist-arm/server.Dockerfile`:

1. `chown -R node:node` on `public/`, `dist/`, and `scripts/` after
   the frontend build is copied
2. `USER node` before `EXPOSE` so the container runs as UID 1000 by default

The `node` user (UID 1000) is already present in the `node:20-slim`
base image — no new users are created.

## Impact

- Existing deployments running as root: **no change**
- Deployments with `--user 1000` or `runAsNonRoot: true`: **now work**

Closes #3577
