### PR TITLE
Fix/reveresed status page checks

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "client",
-	"version": "3.7.0",
+	"version": "3.7.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "client",
-			"version": "3.7.0",
+			"version": "3.7.1",
 			"dependencies": {
 				"@emotion/react": "^11.13.3",
 				"@emotion/styled": "^11.13.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "client",
 	"private": true,
-	"version": "3.7.0",
+	"version": "3.7.1",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/client/src/Pages/StatusPage/Status/themes/shared/ThemedHeatmap.tsx
+++ b/client/src/Pages/StatusPage/Status/themes/shared/ThemedHeatmap.tsx
@@ -31,10 +31,10 @@ export const ThemedHeatmap = ({ checks, containerSx, cellSx }: Props) => {
 	const { t } = useTranslation();
 	const uiTimezone = useSelector((state: RootState) => state.ui.timezone);
 
-	const source = checks.slice(0, CELLS).reverse();
+	const source = checks.slice(-CELLS);
 	const padded: (CheckSnapshot | null)[] = [
-		...Array.from({ length: Math.max(0, CELLS - source.length) }, () => null),
 		...source,
+		...Array.from({ length: Math.max(0, CELLS - source.length) }, () => null),
 	];
 
 	return (

--- a/client/src/Pages/StatusPage/Status/themes/shared/ThemedHistogram.tsx
+++ b/client/src/Pages/StatusPage/Status/themes/shared/ThemedHistogram.tsx
@@ -37,10 +37,10 @@ export const ThemedHistogram = ({
 	const uiTimezone = useSelector((state: RootState) => state.ui.timezone);
 
 	const { padded, max, avg, peak } = useMemo(() => {
-		const source = checks.slice(0, CELLS).reverse();
+		const source = checks.slice(-CELLS);
 		const out: (CheckSnapshot | null)[] = [
-			...Array.from({ length: Math.max(0, CELLS - source.length) }, () => null),
 			...source,
+			...Array.from({ length: Math.max(0, CELLS - source.length) }, () => null),
 		];
 		const valid = out.filter((c): c is CheckSnapshot => c !== null && c.responseTime > 0);
 		const maxRt = valid.length ? Math.max(...valid.map((c) => c.responseTime)) : 1;


### PR DESCRIPTION
Status page checks were reversed
- remove `.reverse` call
- bump to 3.7.1