### PR TITLE
chore(deps): bump multer to 1.4.5-lts.2

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -34,7 +34,7 @@
 				"mailersend": "^2.2.0",
 				"mjml": "^5.0.0-alpha.4",
 				"mongoose": "^8.3.3",
-				"multer": "^1.4.5-lts.1",
+				"multer": "^1.4.5-lts.2",
 				"nodemailer": "8.0.5",
 				"ping": "0.4.4",
 				"sharp": "0.33.5",
@@ -851,7 +851,6 @@
 			"integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
 				"@babel/generator": "^7.28.6",
@@ -1471,7 +1470,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -1516,7 +1514,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4230,7 +4227,6 @@
 			"integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/body-parser": "*",
 				"@types/express-serve-static-core": "^5.0.0",
@@ -4391,7 +4387,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
 			"integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -4629,7 +4624,6 @@
 			"integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.56.1",
 				"@typescript-eslint/types": "8.56.1",
@@ -5243,7 +5237,6 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -5822,7 +5815,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.19",
 				"caniuse-lite": "^1.0.30001751",
@@ -6716,7 +6708,6 @@
 			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.1.tgz",
 			"integrity": "sha512-fm4D8ti0dQmFPeF8DXSAA//btEmqCOgAc/9Oa3C1LW94h5usNrJEfrON7b4FkPZgnDEn6OUs5NdxiJZmAtGOpQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssnano-preset-default": "^7.0.9",
 				"lilconfig": "^3.1.3"
@@ -7481,7 +7472,6 @@
 			"integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -7843,7 +7833,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
 			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -9512,7 +9501,6 @@
 			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.2.0",
 				"@jest/types": "30.2.0",
@@ -12347,7 +12335,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -14370,7 +14357,6 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -14539,7 +14525,6 @@
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -14703,7 +14688,6 @@
 			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"devOptional": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/server/package.json
+++ b/server/package.json
@@ -52,7 +52,7 @@
 		"mailersend": "^2.2.0",
 		"mjml": "^5.0.0-alpha.4",
 		"mongoose": "^8.3.3",
-		"multer": "^1.4.5-lts.1",
+		"multer": "^1.4.5-lts.2",
 		"nodemailer": "8.0.5",
 		"ping": "0.4.4",
 		"sharp": "0.33.5",


### PR DESCRIPTION
## Summary
- Pins `multer` from `^1.4.5-lts.1` to `^1.4.5-lts.2` in `server/`
- Picks up the latest 1.x LTS patch (released 2025-03-20)
- Patch-level bump within existing semver range; no API changes
## Notes
- Two routes use multer (`authRoute`, `statusPageRoute`) and both rely only on the stable basic API
- The four `multer` DoS CVEs flagged on Dependabot all require the 2.x major to be fully resolved; this LTS patch is a low-risk first step. A separate PR can address the multer 2.x migration.
