### PR TITLE
chore(deps): bump lodash to 4.18.1 (transitive)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5313,7 +5313,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {


### PR DESCRIPTION
## Summary
Patches CVE-2026-4800 (high — code injection via _.template) and
CVE-2026-2950 (medium — prototype pollution via array path bypass).
Transitive bump within existing semver range; no package.json change.
