### PR TITLE
chore(deps): bump flatted (transitive)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4191,7 +4191,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.3",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},


### PR DESCRIPTION
## Summary
Patches CVE-2026-33228 (high — prototype pollution via parse() in flatted).
Transitive bump within existing semver range; no package.json change.
