### PR TITLE
chore(deps): bump vite to ^6.4.2

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -59,7 +59,7 @@
 				"lint-staged": "^16.2.7",
 				"prettier": "^3.3.3",
 				"typescript": "5.9.3",
-				"vite": "6.4.1"
+				"vite": "^6.4.2"
 			}
 		},
 		"node_modules/@babel/code-frame": {
@@ -7365,9 +7365,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.4.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+			"integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",

--- a/client/package.json
+++ b/client/package.json
@@ -68,6 +68,6 @@
 		"lint-staged": "^16.2.7",
 		"prettier": "^3.3.3",
 		"typescript": "5.9.3",
-		"vite": "6.4.1"
+		"vite": "^6.4.2"
 	}
 }


### PR DESCRIPTION
## Summary
Patches CVE-2026-39365 (medium — path traversal in optimized deps .map handling).
Relaxes pinned version 6.4.1 to ^6.4.2 patch range; semver-compatible.
