### PR TITLE
chore(deps): bump postcss (transitive)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5912,7 +5912,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
+			"version": "8.5.12",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+			"integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
 			"funding": [
 				{
 					"type": "opencollective",


### PR DESCRIPTION
## Summary
Patches CVE-2026-41305 (medium — XSS via unescaped </style> in CSS stringify output).
Transitive bump within existing semver range; no package.json change.
