### PR TITLE
chore(deps): bump protocol-buffers-schema (transitive)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -6004,9 +6004,9 @@
 			"license": "MIT"
 		},
 		"node_modules/protocol-buffers-schema": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-			"integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+			"integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
 			"license": "MIT"
 		},
 		"node_modules/proxy-from-env": {


### PR DESCRIPTION
## Summary
Patches CVE-2026-5758 (medium — prototype pollution in protocol-buffers-schema).
Transitive bump within existing semver range; no package.json change.
