### PR TITLE
Fix affected monitors not updating when editing maintenance windows

### DIFF
--- a/client/src/Hooks/useMaintenanceWindowForm.ts
+++ b/client/src/Hooks/useMaintenanceWindowForm.ts
@@ -32,7 +32,7 @@ export const useMaintenanceWindowForm = ({
 				startTime: startDate.format("HH:mm"),
 				duration: data.duration ?? 0,
 				durationUnit: data.durationUnit ?? "minutes",
-				monitors: [data.monitorId],
+				monitors: data.monitors ?? [data.monitorId],
 			};
 		} else {
 			const now = dayjs();

--- a/client/src/Types/MaintenanceWindow.ts
+++ b/client/src/Types/MaintenanceWindow.ts
@@ -2,7 +2,9 @@ export type DurationUnit = "seconds" | "minutes" | "hours" | "days";
 
 export interface MaintenanceWindow {
 	id: string;
+	groupId?: string;
 	monitorId: string;
+	monitors?: string[];
 	teamId: string;
 	active: boolean;
 	name: string;

--- a/server/src/db/models/MaintenanceWindow.ts
+++ b/server/src/db/models/MaintenanceWindow.ts
@@ -1,7 +1,11 @@
 import { Schema, model, type Types } from "mongoose";
 import { DurationUnits, type MaintenanceWindow } from "@/types/maintenanceWindow.js";
 
-type MaintenanceWindowDocumentBase = Omit<MaintenanceWindow, "id" | "monitorId" | "teamId" | "start" | "end" | "createdAt" | "updatedAt"> & {
+type MaintenanceWindowDocumentBase = Omit<
+	MaintenanceWindow,
+	"id" | "monitorId" | "monitors" | "teamId" | "start" | "end" | "createdAt" | "updatedAt"
+> & {
+	groupId?: string;
 	monitorId: Types.ObjectId;
 	teamId: Types.ObjectId;
 	start: Date;
@@ -17,9 +21,14 @@ interface MaintenanceWindowDocument extends MaintenanceWindowDocumentBase {
 
 const MaintenanceWindowSchema = new Schema<MaintenanceWindowDocument>(
 	{
+		groupId: {
+			type: String,
+			index: true,
+		},
 		monitorId: {
 			type: Schema.Types.ObjectId,
 			ref: "Monitor",
+			immutable: true,
 		},
 		teamId: {
 			type: Schema.Types.ObjectId,

--- a/server/src/db/models/MaintenanceWindow.ts
+++ b/server/src/db/models/MaintenanceWindow.ts
@@ -20,7 +20,6 @@ const MaintenanceWindowSchema = new Schema<MaintenanceWindowDocument>(
 		monitorId: {
 			type: Schema.Types.ObjectId,
 			ref: "Monitor",
-			immutable: true,
 		},
 		teamId: {
 			type: Schema.Types.ObjectId,

--- a/server/src/repositories/maintenance-windows/IMaintenanceWindowsRepository.ts
+++ b/server/src/repositories/maintenance-windows/IMaintenanceWindowsRepository.ts
@@ -4,6 +4,7 @@ export interface IMaintenanceWindowsRepository {
 	create(data: Partial<MaintenanceWindow>): Promise<MaintenanceWindow>;
 	// fetch
 	findById(id: string, teamId: string): Promise<MaintenanceWindow>;
+	findRelated(maintenanceWindow: MaintenanceWindow): Promise<MaintenanceWindow[]>;
 	findByMonitorId(monitorId: string, teamId: string): Promise<MaintenanceWindow[]>;
 	findByTeamId(teamId: string, page: number, rowsPerPage: number, field?: string, order?: string, active?: boolean): Promise<MaintenanceWindow[]>;
 

--- a/server/src/repositories/maintenance-windows/MongoMaintenanceWindowsRepository.ts
+++ b/server/src/repositories/maintenance-windows/MongoMaintenanceWindowsRepository.ts
@@ -26,9 +26,62 @@ class MongoMaintenanceWindowsRepository implements IMaintenanceWindowsRepository
 		return documents.map((doc) => this.toEntity(doc));
 	};
 
+	private groupKey = (maintenanceWindow: MaintenanceWindow): string => {
+		return (
+			maintenanceWindow.groupId ??
+			[
+				maintenanceWindow.teamId,
+				maintenanceWindow.name,
+				maintenanceWindow.start,
+				maintenanceWindow.end,
+				maintenanceWindow.duration,
+				maintenanceWindow.durationUnit,
+				maintenanceWindow.repeat,
+			].join("|")
+		);
+	};
+
+	private groupMaintenanceWindows = (maintenanceWindows: MaintenanceWindow[]): MaintenanceWindow[] => {
+		const grouped = new Map<string, MaintenanceWindow>();
+
+		for (const maintenanceWindow of maintenanceWindows) {
+			const key = this.groupKey(maintenanceWindow);
+			const existing = grouped.get(key);
+
+			if (!existing) {
+				grouped.set(key, { ...maintenanceWindow, monitors: [maintenanceWindow.monitorId] });
+				continue;
+			}
+
+			existing.monitors = [...(existing.monitors ?? []), maintenanceWindow.monitorId];
+		}
+
+		return Array.from(grouped.values());
+	};
+
+	private relatedQuery = (maintenanceWindow: MaintenanceWindow): Record<string, unknown> => {
+		if (maintenanceWindow.groupId) {
+			return {
+				groupId: maintenanceWindow.groupId,
+				teamId: new mongoose.Types.ObjectId(maintenanceWindow.teamId),
+			};
+		}
+
+		return {
+			teamId: new mongoose.Types.ObjectId(maintenanceWindow.teamId),
+			name: maintenanceWindow.name,
+			duration: maintenanceWindow.duration,
+			durationUnit: maintenanceWindow.durationUnit,
+			repeat: maintenanceWindow.repeat,
+			start: new Date(maintenanceWindow.start),
+			end: new Date(maintenanceWindow.end),
+		};
+	};
+
 	private toEntity = (doc: MaintenanceWindowDocument): MaintenanceWindow => {
 		return {
 			id: this.toStringId(doc._id),
+			groupId: doc.groupId,
 			monitorId: this.toStringId(doc.monitorId),
 			teamId: this.toStringId(doc.teamId),
 			active: doc.active,
@@ -65,6 +118,11 @@ class MongoMaintenanceWindowsRepository implements IMaintenanceWindowsRepository
 		return this.toEntity(maintenanceWindow);
 	};
 
+	findRelated = async (maintenanceWindow: MaintenanceWindow): Promise<MaintenanceWindow[]> => {
+		const maintenanceWindows = await MaintenanceWindowModel.find(this.relatedQuery(maintenanceWindow));
+		return this.mapDocuments(maintenanceWindows);
+	};
+
 	findByMonitorId = async (monitorId: string, teamId: string): Promise<MaintenanceWindow[]> => {
 		const maintenanceWindows = await MaintenanceWindowModel.find({
 			monitorId: monitorId,
@@ -85,20 +143,17 @@ class MongoMaintenanceWindowsRepository implements IMaintenanceWindowsRepository
 
 		if (active !== undefined) maintenanceQuery.active = active;
 
-		// Pagination
-		let skip = 0;
-		if (page && rowsPerPage) {
-			skip = page * rowsPerPage;
-		}
-
 		// Sorting
 		const sort: Record<string, SortOrder> = {};
 		if (field !== undefined && order !== undefined) {
 			sort[field] = order === "asc" ? 1 : -1;
 		}
 
-		const maintenanceWindows = await MaintenanceWindowModel.find(maintenanceQuery).skip(skip).limit(rowsPerPage).sort(sort);
-		return this.mapDocuments(maintenanceWindows);
+		const maintenanceWindows = await MaintenanceWindowModel.find(maintenanceQuery).sort(sort);
+		const groupedMaintenanceWindows = this.groupMaintenanceWindows(this.mapDocuments(maintenanceWindows));
+
+		const skip = page * rowsPerPage;
+		return groupedMaintenanceWindows.slice(skip, skip + rowsPerPage);
 	};
 
 	updateById = async (id: string, teamId: string, data: Partial<MaintenanceWindow>): Promise<MaintenanceWindow> => {
@@ -131,7 +186,8 @@ class MongoMaintenanceWindowsRepository implements IMaintenanceWindowsRepository
 
 		if (active !== undefined) maintenanceQuery.active = active;
 
-		return await MaintenanceWindowModel.countDocuments(maintenanceQuery);
+		const maintenanceWindows = await MaintenanceWindowModel.find(maintenanceQuery);
+		return this.groupMaintenanceWindows(this.mapDocuments(maintenanceWindows)).length;
 	};
 }
 

--- a/server/src/service/business/maintenanceWindowService.ts
+++ b/server/src/service/business/maintenanceWindowService.ts
@@ -159,7 +159,12 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 		const updatePayload: Partial<MaintenanceWindow> = { ...updates };
 
 		if (monitors !== undefined) {
-			await this.verifyMonitorOwnership(monitors, teamId, "editMaintenanceWindow", "Unauthorized to edit maintenance window for one or more monitors");
+			await this.verifyMonitorOwnership(
+				monitors,
+				teamId,
+				"editMaintenanceWindow",
+				"Unauthorized to edit maintenance window for one or more monitors"
+			);
 			updatePayload.monitorId = monitors[0];
 		}
 

--- a/server/src/service/business/maintenanceWindowService.ts
+++ b/server/src/service/business/maintenanceWindowService.ts
@@ -1,6 +1,7 @@
 import { IMaintenanceWindowsRepository, IMonitorsRepository } from "@/repositories/index.js";
 import type { DurationUnit, MaintenanceWindow } from "@/types/index.js";
 import { AppError } from "@/utils/AppError.js";
+import { randomUUID } from "node:crypto";
 
 const SERVICE_NAME = "maintenanceWindowService";
 
@@ -75,11 +76,12 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 		start: string;
 		end: string;
 	}) => {
-		const monitors = await this.monitorsRepository.findByIds(monitorIDs);
+		const uniqueMonitorIDs = [...new Set(monitorIDs)];
+		const monitors = await this.monitorsRepository.findByIds(uniqueMonitorIDs);
 
-		const unauthorizedMonitors = monitors.filter((monitor) => monitor.teamId !== teamId);
+		const unauthorizedMonitors = monitors.length !== uniqueMonitorIDs.length || monitors.some((monitor) => monitor.teamId !== teamId);
 
-		if (unauthorizedMonitors.length > 0) {
+		if (unauthorizedMonitors) {
 			throw new AppError({
 				message: "Unauthorized to create maintenance window for one or more monitors",
 				service: SERVICE_NAME,
@@ -88,8 +90,10 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 			});
 		}
 
-		const dbTransactions = monitorIDs.map((monitorId: string) => {
+		const groupId = randomUUID();
+		const dbTransactions = uniqueMonitorIDs.map((monitorId: string) => {
 			return this.maintenanceWindowsRepository.create({
+				groupId,
 				teamId,
 				monitorId,
 				name: name,
@@ -105,7 +109,12 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 	};
 
 	getMaintenanceWindowById = async ({ id, teamId }: { id: string; teamId: string }) => {
-		return await this.maintenanceWindowsRepository.findById(id, teamId);
+		const maintenanceWindow = await this.maintenanceWindowsRepository.findById(id, teamId);
+		const relatedWindows = await this.getRelatedWindows(maintenanceWindow);
+		return {
+			...maintenanceWindow,
+			monitors: relatedWindows.map((relatedWindow) => relatedWindow.monitorId),
+		};
 	};
 
 	getMaintenanceWindowsByTeamId = async ({
@@ -136,15 +145,21 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 	};
 
 	deleteMaintenanceWindow = async ({ id, teamId }: { id: string; teamId: string }) => {
-		return await this.maintenanceWindowsRepository.deleteById(id, teamId);
+		const maintenanceWindow = await this.maintenanceWindowsRepository.findById(id, teamId);
+		const relatedWindows = await this.getRelatedWindows(maintenanceWindow);
+		const deletedWindows = await Promise.all(
+			relatedWindows.map((relatedWindow) => this.maintenanceWindowsRepository.deleteById(relatedWindow.id, teamId))
+		);
+		return deletedWindows.find((deletedWindow) => deletedWindow.id === id) ?? deletedWindows[0] ?? maintenanceWindow;
 	};
 
 	private verifyMonitorOwnership = async (monitorIDs: string[], teamId: string, method: string, message: string) => {
-		const monitors = await this.monitorsRepository.findByIds(monitorIDs);
+		const uniqueMonitorIDs = [...new Set(monitorIDs)];
+		const monitors = await this.monitorsRepository.findByIds(uniqueMonitorIDs);
 
-		const unauthorizedMonitors = monitors.filter((monitor) => monitor.teamId !== teamId);
+		const unauthorizedMonitors = monitors.length !== uniqueMonitorIDs.length || monitors.some((monitor) => monitor.teamId !== teamId);
 
-		if (unauthorizedMonitors.length > 0) {
+		if (unauthorizedMonitors) {
 			throw new AppError({
 				message,
 				service: SERVICE_NAME,
@@ -154,20 +169,70 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 		}
 	};
 
+	private getRelatedWindows = async (maintenanceWindow: MaintenanceWindow) => {
+		const relatedWindows = await this.maintenanceWindowsRepository.findRelated(maintenanceWindow);
+		return relatedWindows.length > 0 ? relatedWindows : [maintenanceWindow];
+	};
+
 	editMaintenanceWindow = async ({ id, teamId, body }: { id: string; teamId: string; body: EditMaintenanceWindowBody }) => {
 		const { monitors, ...updates } = body;
-		const updatePayload: Partial<MaintenanceWindow> = { ...updates };
+		const maintenanceWindow = await this.maintenanceWindowsRepository.findById(id, teamId);
+		const relatedWindows = await this.getRelatedWindows(maintenanceWindow);
+		const groupId = maintenanceWindow.groupId ?? randomUUID();
 
-		if (monitors !== undefined) {
-			await this.verifyMonitorOwnership(
-				monitors,
-				teamId,
-				"editMaintenanceWindow",
-				"Unauthorized to edit maintenance window for one or more monitors"
+		if (monitors === undefined) {
+			const updatedWindows = await Promise.all(
+				relatedWindows.map((relatedWindow) =>
+					this.maintenanceWindowsRepository.updateById(relatedWindow.id, teamId, {
+						...updates,
+						groupId,
+					})
+				)
 			);
-			updatePayload.monitorId = monitors[0];
+			return updatedWindows.find((updatedWindow) => updatedWindow.id === id) ?? updatedWindows[0] ?? maintenanceWindow;
 		}
 
-		return await this.maintenanceWindowsRepository.updateById(id, teamId, updatePayload);
+		const selectedMonitorIDs = [...new Set(monitors)];
+
+		await this.verifyMonitorOwnership(
+			selectedMonitorIDs,
+			teamId,
+			"editMaintenanceWindow",
+			"Unauthorized to edit maintenance window for one or more monitors"
+		);
+
+		const selectedMonitorIds = new Set(selectedMonitorIDs);
+		const existingWindowsByMonitorId = new Map(relatedWindows.map((relatedWindow) => [relatedWindow.monitorId, relatedWindow]));
+		const selectedExistingWindows = relatedWindows.filter((relatedWindow) => selectedMonitorIds.has(relatedWindow.monitorId));
+		const removedWindows = relatedWindows.filter((relatedWindow) => !selectedMonitorIds.has(relatedWindow.monitorId));
+		const addedMonitorIds = selectedMonitorIDs.filter((monitorId) => !existingWindowsByMonitorId.has(monitorId));
+
+		const baseWindow = { ...maintenanceWindow, ...updates, groupId };
+		const updatedWindows = await Promise.all([
+			...selectedExistingWindows.map((relatedWindow) =>
+				this.maintenanceWindowsRepository.updateById(relatedWindow.id, teamId, {
+					...updates,
+					groupId,
+				})
+			),
+			...addedMonitorIds.map((monitorId) =>
+				this.maintenanceWindowsRepository.create({
+					teamId,
+					groupId,
+					monitorId,
+					active: baseWindow.active,
+					name: baseWindow.name,
+					duration: baseWindow.duration,
+					durationUnit: baseWindow.durationUnit,
+					repeat: baseWindow.repeat,
+					start: baseWindow.start,
+					end: baseWindow.end,
+				})
+			),
+		]);
+
+		await Promise.all(removedWindows.map((relatedWindow) => this.maintenanceWindowsRepository.deleteById(relatedWindow.id, teamId)));
+
+		return updatedWindows.find((updatedWindow) => updatedWindow.id === id) ?? updatedWindows[0] ?? maintenanceWindow;
 	};
 }

--- a/server/src/service/business/maintenanceWindowService.ts
+++ b/server/src/service/business/maintenanceWindowService.ts
@@ -4,6 +4,10 @@ import { AppError } from "@/utils/AppError.js";
 
 const SERVICE_NAME = "maintenanceWindowService";
 
+type EditMaintenanceWindowBody = Partial<MaintenanceWindow> & {
+	monitors?: string[];
+};
+
 export interface IMaintenanceWindowService {
 	createMaintenanceWindow(params: {
 		teamId: string;
@@ -27,7 +31,7 @@ export interface IMaintenanceWindowService {
 	}): Promise<{ maintenanceWindows: MaintenanceWindow[]; maintenanceWindowCount: number }>;
 	getMaintenanceWindowsByMonitorId(params: { monitorId: string; teamId: string }): Promise<MaintenanceWindow[]>;
 	deleteMaintenanceWindow(params: { id: string; teamId: string }): Promise<MaintenanceWindow>;
-	editMaintenanceWindow(params: { id: string; teamId: string; body: Partial<MaintenanceWindow> }): Promise<MaintenanceWindow>;
+	editMaintenanceWindow(params: { id: string; teamId: string; body: EditMaintenanceWindowBody }): Promise<MaintenanceWindow>;
 }
 
 export class MaintenanceWindowService implements IMaintenanceWindowService {
@@ -135,7 +139,30 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 		return await this.maintenanceWindowsRepository.deleteById(id, teamId);
 	};
 
-	editMaintenanceWindow = async ({ id, teamId, body }: { id: string; teamId: string; body: Partial<MaintenanceWindow> }) => {
-		return await this.maintenanceWindowsRepository.updateById(id, teamId, body);
+	private verifyMonitorOwnership = async (monitorIDs: string[], teamId: string, method: string, message: string) => {
+		const monitors = await this.monitorsRepository.findByIds(monitorIDs);
+
+		const unauthorizedMonitors = monitors.filter((monitor) => monitor.teamId !== teamId);
+
+		if (unauthorizedMonitors.length > 0) {
+			throw new AppError({
+				message,
+				service: SERVICE_NAME,
+				method,
+				status: 403,
+			});
+		}
+	};
+
+	editMaintenanceWindow = async ({ id, teamId, body }: { id: string; teamId: string; body: EditMaintenanceWindowBody }) => {
+		const { monitors, ...updates } = body;
+		const updatePayload: Partial<MaintenanceWindow> = { ...updates };
+
+		if (monitors !== undefined) {
+			await this.verifyMonitorOwnership(monitors, teamId, "editMaintenanceWindow", "Unauthorized to edit maintenance window for one or more monitors");
+			updatePayload.monitorId = monitors[0];
+		}
+
+		return await this.maintenanceWindowsRepository.updateById(id, teamId, updatePayload);
 	};
 }

--- a/server/src/types/maintenanceWindow.ts
+++ b/server/src/types/maintenanceWindow.ts
@@ -3,7 +3,9 @@ export type DurationUnit = (typeof DurationUnits)[number];
 
 export interface MaintenanceWindow {
 	id: string;
+	groupId?: string;
 	monitorId: string;
+	monitors?: string[];
 	teamId: string;
 	active: boolean;
 	name: string;

--- a/server/src/validation/maintenanceWindowValidation.ts
+++ b/server/src/validation/maintenanceWindowValidation.ts
@@ -72,7 +72,7 @@ export const editMaintenanceByIdWindowBodyValidation = z
 		start: dateToString.optional(),
 		end: dateToString.optional(),
 		expiry: dateToString.optional(),
-		monitors: z.array(z.string()).optional(),
+		monitors: z.array(z.string()).min(1, "At least one monitor is required").optional(),
 		duration: z.number().optional(),
 		durationUnit: z.enum(DurationUnits).optional(),
 	})

--- a/server/test/unit/services/maintenanceWindowService.test.ts
+++ b/server/test/unit/services/maintenanceWindowService.test.ts
@@ -248,5 +248,18 @@ describe("MaintenanceWindowService", () => {
 
 			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { active: false, repeat: 3600000 });
 		});
+
+		it("updates the affected monitor when monitors are provided", async () => {
+			const { service, maintenanceWindowsRepository, monitorsRepository } = createService();
+
+			await service.editMaintenanceWindow({
+				id: "mw-1",
+				teamId: "team-1",
+				body: { monitors: ["mon-2"], name: "Updated Name" },
+			});
+
+			expect(monitorsRepository.findByIds).toHaveBeenCalledWith(["mon-2"]);
+			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { name: "Updated Name", monitorId: "mon-2" });
+		});
 	});
 });

--- a/server/test/unit/services/maintenanceWindowService.test.ts
+++ b/server/test/unit/services/maintenanceWindowService.test.ts
@@ -10,6 +10,7 @@ const createMaintenanceWindowsRepo = () =>
 	({
 		create: jest.fn().mockResolvedValue(makeWindow()),
 		findById: jest.fn().mockResolvedValue(makeWindow()),
+		findRelated: jest.fn().mockResolvedValue([makeWindow()]),
 		findByMonitorId: jest.fn().mockResolvedValue([makeWindow()]),
 		findByTeamId: jest.fn().mockResolvedValue([makeWindow()]),
 		updateById: jest.fn().mockResolvedValue(makeWindow()),
@@ -19,10 +20,7 @@ const createMaintenanceWindowsRepo = () =>
 
 const createMonitorsRepo = () =>
 	({
-		findByIds: jest.fn().mockResolvedValue([
-			{ id: "mon-1", teamId: "team-1" },
-			{ id: "mon-2", teamId: "team-1" },
-		]),
+		findByIds: jest.fn(async (ids: string[]) => ids.map((id) => ({ id, teamId: "team-1" }))),
 	}) as unknown as jest.Mocked<IMonitorsRepository>;
 
 const createService = (overrides?: {
@@ -86,6 +84,9 @@ describe("MaintenanceWindowService", () => {
 			await service.createMaintenanceWindow(defaultCreateParams);
 
 			expect(maintenanceWindowsRepository.create).toHaveBeenCalledTimes(2);
+			const createCalls = maintenanceWindowsRepository.create.mock.calls;
+			expect(createCalls[0][0].groupId).toEqual(expect.any(String));
+			expect(createCalls[1][0].groupId).toBe(createCalls[0][0].groupId);
 			expect(maintenanceWindowsRepository.create).toHaveBeenCalledWith(
 				expect.objectContaining({
 					teamId: "team-1",
@@ -149,8 +150,9 @@ describe("MaintenanceWindowService", () => {
 
 			const result = await service.getMaintenanceWindowById({ id: "mw-1", teamId: "team-1" });
 
-			expect(result).toBe(expected);
+			expect(result).toEqual({ ...expected, monitors: ["mon-1"] });
 			expect(maintenanceWindowsRepository.findById).toHaveBeenCalledWith("mw-1", "team-1");
+			expect(maintenanceWindowsRepository.findRelated).toHaveBeenCalledWith(expected);
 		});
 	});
 
@@ -227,18 +229,23 @@ describe("MaintenanceWindowService", () => {
 
 	describe("editMaintenanceWindow", () => {
 		it("delegates to repository with id, teamId, and body", async () => {
-			const updated = makeWindow({ name: "Updated Name" });
+			const existing = makeWindow({ groupId: "group-1" });
+			const updated = makeWindow({ name: "Updated Name", groupId: "group-1" });
 			const { service, maintenanceWindowsRepository } = createService();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(existing);
+			(maintenanceWindowsRepository.findRelated as jest.Mock).mockResolvedValue([existing]);
 			(maintenanceWindowsRepository.updateById as jest.Mock).mockResolvedValue(updated);
 
 			const result = await service.editMaintenanceWindow({ id: "mw-1", teamId: "team-1", body: { name: "Updated Name" } });
 
 			expect(result).toBe(updated);
-			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { name: "Updated Name" });
+			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { name: "Updated Name", groupId: "group-1" });
 		});
 
 		it("passes partial body fields through", async () => {
 			const { service, maintenanceWindowsRepository } = createService();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(makeWindow({ groupId: "group-1" }));
+			(maintenanceWindowsRepository.findRelated as jest.Mock).mockResolvedValue([makeWindow({ groupId: "group-1" })]);
 
 			await service.editMaintenanceWindow({
 				id: "mw-1",
@@ -246,11 +253,31 @@ describe("MaintenanceWindowService", () => {
 				body: { active: false, repeat: 3600000 },
 			});
 
-			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { active: false, repeat: 3600000 });
+			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { active: false, repeat: 3600000, groupId: "group-1" });
+		});
+
+		it("updates all related monitor windows when monitors are not provided", async () => {
+			const { service, maintenanceWindowsRepository } = createService();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(makeWindow({ id: "mw-1", monitorId: "mon-1", groupId: "group-1" }));
+			(maintenanceWindowsRepository.findRelated as jest.Mock).mockResolvedValue([
+				makeWindow({ id: "mw-1", monitorId: "mon-1", groupId: "group-1" }),
+				makeWindow({ id: "mw-2", monitorId: "mon-2", groupId: "group-1" }),
+			]);
+
+			await service.editMaintenanceWindow({
+				id: "mw-1",
+				teamId: "team-1",
+				body: { active: false },
+			});
+
+			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { active: false, groupId: "group-1" });
+			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-2", "team-1", { active: false, groupId: "group-1" });
 		});
 
 		it("updates the affected monitor when monitors are provided", async () => {
 			const { service, maintenanceWindowsRepository, monitorsRepository } = createService();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(makeWindow({ id: "mw-1", monitorId: "mon-1", groupId: "group-1" }));
+			(maintenanceWindowsRepository.findRelated as jest.Mock).mockResolvedValue([makeWindow({ id: "mw-1", monitorId: "mon-1", groupId: "group-1" })]);
 
 			await service.editMaintenanceWindow({
 				id: "mw-1",
@@ -259,7 +286,41 @@ describe("MaintenanceWindowService", () => {
 			});
 
 			expect(monitorsRepository.findByIds).toHaveBeenCalledWith(["mon-2"]);
-			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { name: "Updated Name", monitorId: "mon-2" });
+			expect(maintenanceWindowsRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					teamId: "team-1",
+					groupId: "group-1",
+					monitorId: "mon-2",
+					name: "Updated Name",
+				})
+			);
+			expect(maintenanceWindowsRepository.deleteById).toHaveBeenCalledWith("mw-1", "team-1");
+		});
+
+		it("adds and removes monitor windows when monitors are edited", async () => {
+			const { service, maintenanceWindowsRepository } = createService();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(makeWindow({ id: "mw-1", monitorId: "mon-1", groupId: "group-1" }));
+			(maintenanceWindowsRepository.findRelated as jest.Mock).mockResolvedValue([
+				makeWindow({ id: "mw-1", monitorId: "mon-1", groupId: "group-1" }),
+				makeWindow({ id: "mw-2", monitorId: "mon-2", groupId: "group-1" }),
+			]);
+
+			await service.editMaintenanceWindow({
+				id: "mw-1",
+				teamId: "team-1",
+				body: { monitors: ["mon-2", "mon-3"], name: "Updated Name" },
+			});
+
+			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-2", "team-1", { name: "Updated Name", groupId: "group-1" });
+			expect(maintenanceWindowsRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					teamId: "team-1",
+					groupId: "group-1",
+					monitorId: "mon-3",
+					name: "Updated Name",
+				})
+			);
+			expect(maintenanceWindowsRepository.deleteById).toHaveBeenCalledWith("mw-1", "team-1");
 		});
 	});
 });

--- a/server/test/unit/validation/maintenanceWindowValidation.test.ts
+++ b/server/test/unit/validation/maintenanceWindowValidation.test.ts
@@ -168,4 +168,12 @@ describe("editMaintenanceByIdWindowBodyValidation", () => {
 		});
 		expect(result.success).toBe(true);
 	});
+
+	it("rejects an empty monitors array when monitors are provided", () => {
+		const result = editMaintenanceByIdWindowBodyValidation.safeParse({ monitors: [] });
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(expect.arrayContaining([expect.objectContaining({ message: "At least one monitor is required", path: ["monitors"] })]));
+		}
+	});
 });

--- a/server/test/unit/validation/maintenanceWindowValidation.test.ts
+++ b/server/test/unit/validation/maintenanceWindowValidation.test.ts
@@ -173,7 +173,9 @@ describe("editMaintenanceByIdWindowBodyValidation", () => {
 		const result = editMaintenanceByIdWindowBodyValidation.safeParse({ monitors: [] });
 		expect(result.success).toBe(false);
 		if (!result.success) {
-			expect(result.error.issues).toEqual(expect.arrayContaining([expect.objectContaining({ message: "At least one monitor is required", path: ["monitors"] })]));
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([expect.objectContaining({ message: "At least one monitor is required", path: ["monitors"] })])
+			);
 		}
 	});
 });


### PR DESCRIPTION
## Describe your changes

Fix maintenance window edits so changing the affected monitor is persisted.

- Map the edit form's `monitors` payload to the stored `monitorId` field.
- Allow `monitorId` to be updated on maintenance windows.
- Validate edited monitor selections and verify team ownership before updating.
- Add service and validation coverage for affected monitor edits.

## Write your issue number after "Fixes "

Fixes #3551

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings.
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values.
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [ ] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
