### PR TITLE
Feat/default notification channels

### DIFF
--- a/client/src/Hooks/useBulkMonitorActions.ts
+++ b/client/src/Hooks/useBulkMonitorActions.ts
@@ -9,7 +9,7 @@ import type { Monitor } from "@/Types/Monitor";
 interface ApiResponse {
 	success: boolean;
 	msg: string;
-	data: Monitor[];
+	data: Monitor[] | number;
 }
 
 interface UseBulkMonitorActionsReturn {
@@ -17,6 +17,8 @@ interface UseBulkMonitorActionsReturn {
 	setSelectedRows: (rows: string[]) => void;
 	handleBulkPause: () => Promise<void>;
 	handleBulkResume: () => Promise<void>;
+	handleBulkAddNotifications: (notificationIds: string[]) => Promise<void>;
+	handleBulkRemoveNotifications: (notificationIds: string[]) => Promise<void>;
 	handleCancelSelection: () => void;
 }
 
@@ -84,11 +86,59 @@ export const useBulkMonitorActions = (
 		setSelectedRows([]);
 	};
 
+	const handleBulkNotifications = (action: "add" | "remove") => {
+		return async (notificationIds: string[]) => {
+			try {
+				const res = await post<ApiResponse>("/monitors/notifications", {
+					monitorIds: selectedRows,
+					notificationIds,
+					action,
+				});
+
+				const affectedCount = typeof res.data?.data === "number" ? res.data.data : 0;
+
+				if (affectedCount === 0) {
+					toastInfo(
+						t("pages.common.monitors.bulkNotifications.noChange", {
+							count: selectedRows.length,
+						})
+					);
+				} else {
+					const key =
+						action === "add"
+							? "pages.common.monitors.bulkNotifications.added"
+							: "pages.common.monitors.bulkNotifications.removed";
+					toastSuccess(t(key, { count: affectedCount }));
+				}
+
+				setSelectedRows([]);
+				refetch();
+			} catch (err: unknown) {
+				let errMsg = "An error occurred";
+
+				if (axios.isAxiosError(err)) {
+					errMsg = err.response?.data?.msg || err.message || errMsg;
+				} else if (err instanceof Error) {
+					errMsg = err.message;
+				}
+
+				logger.error(
+					"Bulk notification update failed",
+					err instanceof Error ? err : undefined,
+					{ action }
+				);
+				toastError(errMsg);
+			}
+		};
+	};
+
 	return {
 		selectedRows,
 		setSelectedRows,
 		handleBulkPause,
 		handleBulkResume,
+		handleBulkAddNotifications: handleBulkNotifications("add"),
+		handleBulkRemoveNotifications: handleBulkNotifications("remove"),
 		handleCancelSelection,
 	};
 };

--- a/client/src/Hooks/useBulkMonitorActions.ts
+++ b/client/src/Hooks/useBulkMonitorActions.ts
@@ -42,7 +42,7 @@ export const useBulkMonitorActions = (
 				pause,
 			});
 
-			const affectedCount = res.data?.data?.length ?? 0;
+			const affectedCount = Array.isArray(res.data?.data) ? res.data.data.length : 0;
 
 			if (affectedCount === 0) {
 				const key = pause

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -6,13 +6,16 @@ import type { Monitor, MonitorType } from "@/Types/Monitor";
 interface UseMonitorFormOptions {
 	data?: Monitor | null;
 	defaultType?: MonitorType;
+	defaultNotifications?: string[];
 }
 
-const getBaseDefaults = (data?: Monitor | null) => ({
+const getBaseDefaults = (data?: Monitor | null, defaultNotifications?: string[]) => ({
 	name: data?.name || "",
 	description: data?.description || "",
 	interval: data?.interval || 60000,
-	notifications: data?.notifications || [],
+	notifications: data?.notifications?.length
+		? data.notifications
+		: (defaultNotifications ?? []),
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
@@ -23,10 +26,11 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 export const useMonitorForm = ({
 	data = null,
 	defaultType = "http",
+	defaultNotifications,
 }: UseMonitorFormOptions = {}) => {
 	return useMemo(() => {
 		const type = data?.type || defaultType;
-		const base = getBaseDefaults(data);
+		const base = getBaseDefaults(data, defaultNotifications);
 
 		let defaults: MonitorFormData;
 
@@ -136,5 +140,5 @@ export const useMonitorForm = ({
 		}
 
 		return { schema: monitorSchema, defaults };
-	}, [data, defaultType]);
+	}, [data, defaultType, defaultNotifications]);
 };

--- a/client/src/Hooks/useNotificationForm.ts
+++ b/client/src/Hooks/useNotificationForm.ts
@@ -8,6 +8,7 @@ interface UseNotificationFormOptions {
 }
 
 function buildDefaults(data: Notification | null): NotificationFormData {
+	const isDefault = data?.isDefault ?? false;
 	if (data?.type === "matrix") {
 		return {
 			type: "matrix",
@@ -15,6 +16,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			homeserverUrl: data.homeserverUrl || "",
 			roomId: data.roomId || "",
 			accessToken: data.accessToken || "",
+			isDefault,
 		};
 	}
 	if (data?.type === "telegram") {
@@ -23,6 +25,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			notificationName: data.notificationName || "",
 			address: data.address || "",
 			accessToken: data.accessToken || "",
+			isDefault,
 		};
 	}
 	if (data?.type === "slack") {
@@ -30,6 +33,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			type: "slack",
 			notificationName: data.notificationName || "",
 			address: data.address || "",
+			isDefault,
 		};
 	}
 	if (data?.type === "discord") {
@@ -37,6 +41,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			type: "discord",
 			notificationName: data.notificationName || "",
 			address: data.address || "",
+			isDefault,
 		};
 	}
 	if (data?.type === "webhook") {
@@ -44,6 +49,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			type: "webhook",
 			notificationName: data.notificationName || "",
 			address: data.address || "",
+			isDefault,
 		};
 	}
 	if (data?.type === "pager_duty") {
@@ -51,6 +57,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			type: "pager_duty",
 			notificationName: data.notificationName || "",
 			address: data.address || "",
+			isDefault,
 		};
 	}
 	if (data?.type === "teams") {
@@ -58,6 +65,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			type: "teams",
 			notificationName: data.notificationName || "",
 			address: data.address || "",
+			isDefault,
 		};
 	}
 	if (data?.type === "twilio") {
@@ -68,6 +76,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			accessToken: data.accessToken || "",
 			phone: data.phone || "",
 			twilioPhoneNumber: data.twilioPhoneNumber || "",
+			isDefault,
 		};
 	}
 	if (data?.type === "pushover") {
@@ -76,13 +85,14 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			notificationName: data.notificationName || "",
 			address: data.address || "",
 			accessToken: data.accessToken || "",
+			isDefault,
 		};
 	}
-	// Default: email (covers both data === null and data.type === "email")
 	return {
 		type: "email",
 		notificationName: data?.notificationName || "",
 		address: data?.address || "",
+		isDefault,
 	};
 }
 

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -236,11 +236,16 @@ const CreateMonitorPage = () => {
 	);
 
 	const { data: notifications } = useGet<Notification[]>("/notifications/team");
+	const { data: defaultNotifications } = useGet<Notification[]>(
+		"/notifications/defaults"
+	);
+	const defaultNotificationIds = defaultNotifications?.map((n) => n.id) ?? [];
 	const { data: games } = useGet<GamesMap>("/monitors/games");
 
 	const { schema, defaults } = useMonitorForm({
 		data: existingMonitor ?? null,
 		defaultType,
+		defaultNotifications: defaultNotificationIds,
 	});
 
 	const form = useForm<MonitorFormData>({

--- a/client/src/Pages/Infrastructure/Monitors/index.tsx
+++ b/client/src/Pages/Infrastructure/Monitors/index.tsx
@@ -10,7 +10,7 @@ import {
 import { TextField, Dialog, Button, Autocomplete } from "@/Components/inputs";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
-import { MonitorsTable } from "@/Pages/Infrastructure/Monitors/Components/MonitorsTable";
+import { InfraMonitorsTable } from "@/Pages/Infrastructure/Monitors/Components/MonitorsTable";
 import { Play, Pause, Bell } from "lucide-react";
 
 import { useTranslation } from "react-i18next";
@@ -245,7 +245,7 @@ const InfrastructureMonitors = () => {
 				</BulkActionsBar>
 			)}
 
-			<MonitorsTable
+			<InfraMonitorsTable
 				monitors={monitorsWithChecksData?.monitors || []}
 				refetch={refetch}
 				setSelectedMonitor={setSelectedMonitor}
@@ -302,7 +302,7 @@ const InfrastructureMonitors = () => {
 							selectedNotificationIds.includes(n.id)
 						)}
 						onChange={(_, newValue) =>
-							setSelectedNotificationIds(newValue.map((n) => n.id))
+							setSelectedNotificationIds(newValue.map((n: Notification) => n.id))
 						}
 						renderInput={(params) => (
 							<TextField

--- a/client/src/Pages/Infrastructure/Monitors/index.tsx
+++ b/client/src/Pages/Infrastructure/Monitors/index.tsx
@@ -7,21 +7,24 @@ import {
 	HeaderMonitorsSummary,
 	BulkActionsBar,
 } from "@/Components/monitors";
-import { TextField, Dialog, Button } from "@/Components/inputs";
-import { Play, Pause } from "lucide-react";
+import { TextField, Dialog, Button, Autocomplete } from "@/Components/inputs";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { MonitorsTable } from "@/Pages/Infrastructure/Monitors/Components/MonitorsTable";
+import { Play, Pause, Bell } from "lucide-react";
 
-import { useGet, useDelete } from "@/Hooks/UseApi";
-import { useIsAdmin } from "@/Hooks/useIsAdmin";
-import type { Monitor, MonitorsWithChecksResponse } from "@/Types/Monitor";
-import { useTheme } from "@mui/material";
-import { useState, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { useGet, useDelete } from "@/Hooks/UseApi";
+import type { Monitor, MonitorsWithChecksResponse } from "@/Types/Monitor";
+import { useState, useMemo, useCallback } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { setRowsPerPage } from "@/Features/UI/uiSlice.js";
+import { useIsAdmin } from "@/Hooks/useIsAdmin";
 import type { RootState } from "@/Types/state";
-import { InfraMonitorsTable } from "./Components/MonitorsTable";
+import { useTheme } from "@mui/material";
 import useDebounce from "@/Hooks/useDebounce";
 import { useBulkMonitorActions } from "@/Hooks/useBulkMonitorActions";
+import type { Notification } from "@/Types/Notification";
 
 const InfrastructureMonitors = () => {
 	const { t } = useTranslation();
@@ -43,6 +46,9 @@ const InfrastructureMonitors = () => {
 	const [sortField, setSortField] = useState<string>("");
 	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 	const [selectedMonitor, setSelectedMonitor] = useState<Monitor | null>(null);
+	const [notificationDialogOpen, setNotificationDialogOpen] = useState(false);
+	const [selectedNotificationIds, setSelectedNotificationIds] = useState<string[]>([]);
+	const [notificationAction, setNotificationAction] = useState<"add" | "remove">("add");
 
 	const isDialogOpen = Boolean(selectedMonitor);
 
@@ -104,12 +110,16 @@ const InfrastructureMonitors = () => {
 	const { summary, count } = monitorsWithChecksData ?? { summary: null, count: 0 };
 	const isLoading = monitorsWithChecksLoading;
 
+	const { data: notifications } = useGet<Notification[]>("/notifications/team");
+
 	// Bulk actions
 	const {
 		selectedRows,
 		setSelectedRows,
 		handleBulkPause,
 		handleBulkResume,
+		handleBulkAddNotifications,
+		handleBulkRemoveNotifications,
 		handleCancelSelection,
 	} = useBulkMonitorActions(refetch, page);
 
@@ -134,6 +144,28 @@ const InfrastructureMonitors = () => {
 
 	const handleCancel = () => {
 		setSelectedMonitor(null);
+	};
+
+	const openAddNotifications = () => {
+		setNotificationAction("add");
+		setSelectedNotificationIds([]);
+		setNotificationDialogOpen(true);
+	};
+
+	const openRemoveNotifications = () => {
+		setNotificationAction("remove");
+		setSelectedNotificationIds([]);
+		setNotificationDialogOpen(true);
+	};
+
+	const handleNotificationConfirm = async () => {
+		if (notificationAction === "add") {
+			await handleBulkAddNotifications(selectedNotificationIds);
+		} else {
+			await handleBulkRemoveNotifications(selectedNotificationIds);
+		}
+		setNotificationDialogOpen(false);
+		setSelectedNotificationIds([]);
 	};
 
 	return (
@@ -195,10 +227,25 @@ const InfrastructureMonitors = () => {
 					>
 						{t("common.buttons.pause")}
 					</Button>
+					<Button
+						size="small"
+						startIcon={<Bell size={16} />}
+						onClick={openAddNotifications}
+					>
+						{t("pages.uptime.monitors.bulkActions.addNotifications")}
+					</Button>
+					<Button
+						size="small"
+						color="error"
+						startIcon={<Bell size={16} />}
+						onClick={openRemoveNotifications}
+					>
+						{t("pages.uptime.monitors.bulkActions.removeNotifications")}
+					</Button>
 				</BulkActionsBar>
 			)}
 
-			<InfraMonitorsTable
+			<MonitorsTable
 				monitors={monitorsWithChecksData?.monitors || []}
 				refetch={refetch}
 				setSelectedMonitor={setSelectedMonitor}
@@ -230,6 +277,42 @@ const InfrastructureMonitors = () => {
 				onCancel={handleCancel}
 				loading={isDeleting}
 			/>
+			<Dialog
+				open={notificationDialogOpen}
+				title={
+					notificationAction === "add"
+						? t("pages.uptime.monitors.bulkActions.addNotifications")
+						: t("pages.uptime.monitors.bulkActions.removeNotifications")
+				}
+				onConfirm={handleNotificationConfirm}
+				onCancel={() => setNotificationDialogOpen(false)}
+				confirmText={t("common.buttons.confirm")}
+			>
+				<Box>
+					<Typography mb={2}>
+						{notificationAction === "add"
+							? t("pages.uptime.monitors.bulkActions.selectToAdd")
+							: t("pages.uptime.monitors.bulkActions.selectToRemove")}
+					</Typography>
+					<Autocomplete
+						multiple
+						options={notifications ?? []}
+						getOptionLabel={(option) => option.notificationName}
+						value={(notifications ?? []).filter((n) =>
+							selectedNotificationIds.includes(n.id)
+						)}
+						onChange={(_, newValue) =>
+							setSelectedNotificationIds(newValue.map((n) => n.id))
+						}
+						renderInput={(params) => (
+							<TextField
+								{...params}
+								placeholder={t("pages.uptime.monitors.bulkActions.selectPlaceholder")}
+							/>
+						)}
+					/>
+				</Box>
+			</Dialog>
 		</MonitorBasePageWithStates>
 	);
 };

--- a/client/src/Pages/Notifications/components/NotificationsTable.tsx
+++ b/client/src/Pages/Notifications/components/NotificationsTable.tsx
@@ -1,6 +1,7 @@
 import { ActionsMenu, type ActionMenuItem } from "@/Components/actions-menu";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
+import Chip from "@mui/material/Chip";
 import type { Header } from "@/Components/design-elements/Table";
 import { Table } from "@/Components/design-elements";
 import { Pagination } from "@/Components/design-elements/Table";
@@ -57,7 +58,22 @@ export const NotificationsTable = ({
 				id: "name",
 				content: t("common.table.headers.name"),
 				render: (row) => {
-					return <Typography>{row?.notificationName}</Typography>;
+					return (
+						<Box
+							display="flex"
+							alignItems="center"
+							gap={1}
+						>
+							<Typography>{row?.notificationName}</Typography>
+							{row?.isDefault && (
+								<Chip
+									label="Default"
+									size="small"
+									sx={{ height: 20, fontSize: "0.65rem" }}
+								/>
+							)}
+						</Box>
+					);
 				},
 			},
 

--- a/client/src/Pages/Notifications/create/index.tsx
+++ b/client/src/Pages/Notifications/create/index.tsx
@@ -34,7 +34,7 @@ const NotificationsCreatePage = () => {
 	const { patch, loading: isPatching } = usePatch<NotificationFormData, Notification>();
 	const { post: testPost, loading: isTesting } = usePost<NotificationFormData, void>();
 	const { post: applyPost, loading: isApplying } = usePost<
-		void,
+		Record<string, never>,
 		{ modifiedCount: number }
 	>();
 

--- a/client/src/Pages/Notifications/create/index.tsx
+++ b/client/src/Pages/Notifications/create/index.tsx
@@ -3,6 +3,8 @@ import { TextField, Select, Button } from "@/Components/inputs";
 import MenuItem from "@mui/material/MenuItem";
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
+import FormControlLabel from "@mui/material/FormControlLabel";
+import Switch from "@mui/material/Switch";
 import { useTheme } from "@mui/material/styles";
 
 import { useEffect, useMemo } from "react";
@@ -31,6 +33,10 @@ const NotificationsCreatePage = () => {
 	const { post, loading: isSubmitting } = usePost<NotificationFormData, Notification>();
 	const { patch, loading: isPatching } = usePatch<NotificationFormData, Notification>();
 	const { post: testPost, loading: isTesting } = usePost<NotificationFormData, void>();
+	const { post: applyPost, loading: isApplying } = usePost<
+		void,
+		{ modifiedCount: number }
+	>();
 
 	const { schema, defaults } = useNotificationForm({ data: existingNotification });
 
@@ -92,6 +98,11 @@ const NotificationsCreatePage = () => {
 		await testPost("/notifications/test", data);
 	};
 
+	const handleApplyToAll = async () => {
+		if (!notificationId) return;
+		await applyPost(`/notifications/${notificationId}/apply-to-all`, {});
+	};
+
 	return (
 		<BasePage
 			component="form"
@@ -114,6 +125,29 @@ const NotificationsCreatePage = () => {
 								fullWidth
 								error={!!fieldState.error}
 								helperText={fieldState.error?.message ?? ""}
+							/>
+						)}
+					/>
+				}
+			/>
+			<ConfigBox
+				title={t("pages.notifications.form.isDefault.title")}
+				subtitle={t("pages.notifications.form.isDefault.description")}
+				rightContent={
+					<Controller
+						name="isDefault"
+						control={control}
+						defaultValue={defaults.isDefault ?? false}
+						render={({ field }) => (
+							<FormControlLabel
+								control={
+									<Switch
+										checked={field.value ?? false}
+										onChange={field.onChange}
+										color="primary"
+									/>
+								}
+								label=""
 							/>
 						)}
 					/>
@@ -410,6 +444,16 @@ const NotificationsCreatePage = () => {
 				justifyContent="flex-end"
 				spacing={theme.spacing(2)}
 			>
+				{isEditMode && (
+					<Button
+						variant="outlined"
+						color="primary"
+						onClick={handleApplyToAll}
+						loading={isApplying}
+					>
+						{t("pages.notifications.form.applyToAll.button")}
+					</Button>
+				)}
 				<Button
 					variant="contained"
 					color="primary"

--- a/client/src/Pages/Uptime/Monitors/index.tsx
+++ b/client/src/Pages/Uptime/Monitors/index.tsx
@@ -320,7 +320,7 @@ const UptimeMonitorsPage = () => {
 							selectedNotificationIds.includes(n.id)
 						)}
 						onChange={(_, newValue) =>
-							setSelectedNotificationIds(newValue.map((n) => n.id))
+							setSelectedNotificationIds(newValue.map((n: Notification) => n.id))
 						}
 						renderInput={(params) => (
 							<TextField

--- a/client/src/Pages/Uptime/Monitors/index.tsx
+++ b/client/src/Pages/Uptime/Monitors/index.tsx
@@ -4,11 +4,13 @@ import {
 	BulkActionsBar,
 } from "@/Components/monitors";
 import { MonitorBasePageWithStates } from "@/Components/design-elements";
-import { TextField, Dialog, Button } from "@/Components/inputs";
+import { TextField, Dialog, Button, Autocomplete } from "@/Components/inputs";
 import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import { MonitorTable } from "@/Pages/Uptime/Monitors/Components/UptimeMonitorsTable";
 import { HeaderCreate } from "@/Components/common";
-import { Play, Pause } from "lucide-react";
+import { Play, Pause, Bell } from "lucide-react";
 
 import { useTranslation } from "react-i18next";
 import useMediaQuery from "@mui/material/useMediaQuery";
@@ -22,6 +24,7 @@ import type { RootState } from "@/Types/state";
 import { useTheme } from "@mui/material";
 import useDebounce from "@/Hooks/useDebounce";
 import { useBulkMonitorActions } from "@/Hooks/useBulkMonitorActions";
+import type { Notification } from "@/Types/Notification";
 
 const UptimeMonitorsPage = () => {
 	const { t } = useTranslation();
@@ -43,6 +46,9 @@ const UptimeMonitorsPage = () => {
 	const [sortField, setSortField] = useState<string>("");
 	const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 	const [selectedMonitor, setSelectedMonitor] = useState<Monitor | null>(null);
+	const [notificationDialogOpen, setNotificationDialogOpen] = useState(false);
+	const [selectedNotificationIds, setSelectedNotificationIds] = useState<string[]>([]);
+	const [notificationAction, setNotificationAction] = useState<"add" | "remove">("add");
 
 	const isDialogOpen = Boolean(selectedMonitor);
 
@@ -109,12 +115,16 @@ const UptimeMonitorsPage = () => {
 		count,
 	} = monitorsWithChecksData ?? { monitors: null, summary: null, count: 0 };
 
+	const { data: notifications } = useGet<Notification[]>("/notifications/team");
+
 	// Bulk actions
 	const {
 		selectedRows,
 		setSelectedRows,
 		handleBulkPause,
 		handleBulkResume,
+		handleBulkAddNotifications,
+		handleBulkRemoveNotifications,
 		handleCancelSelection,
 	} = useBulkMonitorActions(refetch, page);
 
@@ -138,6 +148,28 @@ const UptimeMonitorsPage = () => {
 
 	const handleCancel = () => {
 		setSelectedMonitor(null);
+	};
+
+	const openAddNotifications = () => {
+		setNotificationAction("add");
+		setSelectedNotificationIds([]);
+		setNotificationDialogOpen(true);
+	};
+
+	const openRemoveNotifications = () => {
+		setNotificationAction("remove");
+		setSelectedNotificationIds([]);
+		setNotificationDialogOpen(true);
+	};
+
+	const handleNotificationConfirm = async () => {
+		if (notificationAction === "add") {
+			await handleBulkAddNotifications(selectedNotificationIds);
+		} else {
+			await handleBulkRemoveNotifications(selectedNotificationIds);
+		}
+		setNotificationDialogOpen(false);
+		setSelectedNotificationIds([]);
 	};
 
 	const isLoading = monitorsWithChecksLoading;
@@ -213,6 +245,21 @@ const UptimeMonitorsPage = () => {
 					>
 						{t("common.buttons.pause")}
 					</Button>
+					<Button
+						size="small"
+						startIcon={<Bell size={16} />}
+						onClick={openAddNotifications}
+					>
+						{t("pages.uptime.monitors.bulkActions.addNotifications")}
+					</Button>
+					<Button
+						size="small"
+						color="error"
+						startIcon={<Bell size={16} />}
+						onClick={openRemoveNotifications}
+					>
+						{t("pages.uptime.monitors.bulkActions.removeNotifications")}
+					</Button>
 				</BulkActionsBar>
 			)}
 
@@ -248,6 +295,42 @@ const UptimeMonitorsPage = () => {
 				onCancel={handleCancel}
 				loading={isDeleting}
 			/>
+			<Dialog
+				open={notificationDialogOpen}
+				title={
+					notificationAction === "add"
+						? t("pages.uptime.monitors.bulkActions.addNotifications")
+						: t("pages.uptime.monitors.bulkActions.removeNotifications")
+				}
+				onConfirm={handleNotificationConfirm}
+				onCancel={() => setNotificationDialogOpen(false)}
+				confirmText={t("common.buttons.confirm")}
+			>
+				<Box>
+					<Typography mb={2}>
+						{notificationAction === "add"
+							? t("pages.uptime.monitors.bulkActions.selectToAdd")
+							: t("pages.uptime.monitors.bulkActions.selectToRemove")}
+					</Typography>
+					<Autocomplete
+						multiple
+						options={notifications ?? []}
+						getOptionLabel={(option) => option.notificationName}
+						value={(notifications ?? []).filter((n) =>
+							selectedNotificationIds.includes(n.id)
+						)}
+						onChange={(_, newValue) =>
+							setSelectedNotificationIds(newValue.map((n) => n.id))
+						}
+						renderInput={(params) => (
+							<TextField
+								{...params}
+								placeholder={t("pages.uptime.monitors.bulkActions.selectPlaceholder")}
+							/>
+						)}
+					/>
+				</Box>
+			</Dialog>
 		</MonitorBasePageWithStates>
 	);
 };

--- a/client/src/Types/Notification.ts
+++ b/client/src/Types/Notification.ts
@@ -25,6 +25,7 @@ export interface Notification {
 	accessToken?: string;
 	accountSid?: string;
 	twilioPhoneNumber?: string;
+	isDefault?: boolean;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/client/src/Validation/notifications.ts
+++ b/client/src/Validation/notifications.ts
@@ -5,6 +5,7 @@ const baseSchema = z.object({
 		.string()
 		.min(1, "Notification name is required")
 		.max(100, "Notification name must be at most 100 characters"),
+	isDefault: z.boolean().optional(),
 });
 
 const emailSchema = baseSchema.extend({

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -441,42 +441,15 @@
 					"selectMonitor": "Select {{name}}"
 				},
 				"bulkPause": {
-					"alreadyPaused_one": "The selected monitor is already paused",
-					"alreadyPaused_other": "All selected monitors are already paused",
-					"alreadyRunning_one": "The selected monitor is already running",
-					"alreadyRunning_other": "All selected monitors are already running",
-					"paused_one": "{{count}} monitor paused",
-					"paused_other": "{{count}} monitors paused",
-					"resumed_one": "{{count}} monitor resumed",
-					"resumed_other": "{{count}} monitors resumed"
+					"paused": "Paused {count} monitor(s)",
+					"resumed": "Resumed {count} monitor(s)",
+					"alreadyPaused": "{count} monitor(s) already paused",
+					"alreadyRunning": "{count} monitor(s) already running"
 				},
-				"statBoxes": {
-					"activeFor": "Active for",
-					"certificateExpiry": "Certificate expiry",
-					"lastCheck": "Last check",
-					"lastResponseTime": "Last response time",
-					"serviceIsDown": "Service is down"
-				},
-				"status": {
-					"down": "down",
-					"breached": "threshold exceeded",
-					"initializing": "initializing",
-					"maintenance": "maintenance",
-					"paused": "paused",
-					"total": "total",
-					"up": "up"
-				},
-				"monitorTypes": {
-					"optionDocker": "Docker",
-					"optionGame": "Game",
-					"optionHttp": "HTTP(S)",
-					"optionPing": "Ping",
-					"optionPort": "Port",
-					"optionPagespeed": "PageSpeed",
-					"optionHardware": "Infrastructure",
-					"optionGrpc": "gRPC",
-					"optionWebSocket": "WebSocket",
-					"optionDns": "DNS"
+				"bulkNotifications": {
+					"added": "Notification added to {count} monitor(s)",
+					"removed": "Notification removed from {count} monitor(s)",
+					"noChange": "No changes made to {count} monitor(s)"
 				}
 			}
 		},
@@ -1094,6 +1067,13 @@
 					"placeholderFromNumber": "+15551234567",
 					"optionToNumber": "To number (recipient)",
 					"placeholderToNumber": "+15559876543"
+				},
+				"isDefault": {
+					"title": "Default channel",
+					"description": "When enabled, this channel will be automatically attached to every new monitor you create."
+				},
+				"applyToAll": {
+					"button": "Apply to all monitors"
 				}
 			},
 			"table": {
@@ -1538,6 +1518,15 @@
 			"header": {
 				"title": "Uptime monitors",
 				"description": "Watch HTTP endpoints, pings, containers, and ports — and get alerted the moment something goes down."
+			},
+			"monitors": {
+				"bulkActions": {
+					"addNotifications": "Add notification",
+					"removeNotifications": "Remove notification",
+					"selectToAdd": "Select the notification channels to add to the selected monitors:",
+					"selectToRemove": "Select the notification channels to remove from the selected monitors:",
+					"selectPlaceholder": "Select channels..."
+				}
 			}
 		}
 	}

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -9266,6 +9266,330 @@
 				}
 			}
 		},
+		"/notifications/defaults": {
+			"get": {
+				"tags": ["notifications"],
+				"summary": "Get default notification channels",
+				"description": "Retrieve all notification channels marked as default for the team. These are automatically attached to new monitors.",
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"type": "array",
+											"items": {
+												"$ref": "#/components/schemas/NotificationChannel"
+											}
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/notifications/{id}/default": {
+			"patch": {
+				"tags": ["notifications"],
+				"summary": "Set or remove default status",
+				"description": "Mark a notification channel as default or remove the default status. Default notifications are automatically attached to new monitors.",
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string",
+							"minLength": 1
+						},
+						"required": true,
+						"name": "id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"type": "object",
+								"properties": {
+									"isDefault": {
+										"type": "boolean",
+										"description": "Set to true to mark as default, false to remove"
+									}
+								},
+								"required": ["isDefault"]
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"type": "number",
+											"description": "Number of notifications updated (0 or 1)"
+										}
+									},
+									"required": ["success", "msg"]
+								},
+								"example": {
+									"success": true,
+									"msg": "OK",
+									"data": 1
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Forbidden",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/notifications/{id}/apply-to-all": {
+			"post": {
+				"tags": ["notifications"],
+				"summary": "Apply notification to all monitors",
+				"description": "Add a notification channel to all monitors in the team. Useful for adding a new notification channel to existing infrastructure.",
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string",
+							"minLength": 1
+						},
+						"required": true,
+						"name": "id",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"type": "number",
+											"description": "Number of monitors updated"
+										}
+									},
+									"required": ["success", "msg"]
+								},
+								"example": {
+									"success": true,
+									"msg": "OK",
+									"data": 15
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Forbidden",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/queue/jobs": {
 			"get": {
 				"tags": ["queue"],

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -350,6 +350,7 @@ export const initializeServices = async ({
 		monitorStatsRepository,
 		statusPagesRepository,
 		incidentsRepository,
+		notificationsRepository,
 	});
 
 	const statusPageService = new StatusPageService(statusPagesRepository, settingsService);

--- a/server/src/controllers/notificationController.ts
+++ b/server/src/controllers/notificationController.ts
@@ -7,6 +7,8 @@ import {
 	testNotificationBodyValidation,
 	editNotificationParamValidation,
 	testAllNotificationsBodyValidation,
+	setDefaultNotificationBodyValidation,
+	applyToAllBodyValidation,
 } from "@/validation/notificationValidation.js";
 import { AppError } from "@/utils/AppError.js";
 import { INotificationsService } from "@/service/index.js";
@@ -19,10 +21,13 @@ export interface INotificationController {
 	testNotification: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	createNotification: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	getNotificationsByTeamId: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
+	getDefaultNotifications: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	deleteNotification: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	getNotificationById: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	editNotification: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	testAllNotifications: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
+	setDefaultNotification: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
+	applyToAllMonitors: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 }
 class NotificationController implements INotificationController {
 	private notificationsService: INotificationsService;
@@ -74,6 +79,21 @@ class NotificationController implements INotificationController {
 				success: true,
 				msg: "Notifications fetched successfully",
 				data: notifications,
+			});
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	getDefaultNotifications = async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			const teamId = requireTeamId(req.user?.teamId);
+			const defaults = await this.notificationsService.findDefaultsByTeamId(teamId);
+
+			return res.status(200).json({
+				success: true,
+				msg: "Default notifications fetched successfully",
+				data: defaults,
 			});
 		} catch (error) {
 			next(error);
@@ -153,6 +173,43 @@ class NotificationController implements INotificationController {
 			return res.status(200).json({
 				success: true,
 				msg: "All notifications sent successfully",
+			});
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	setDefaultNotification = async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			const validatedBody = setDefaultNotificationBodyValidation.parse(req.body);
+			const validatedParams = editNotificationParamValidation.parse(req.params);
+
+			const teamId = requireTeamId(req.user?.teamId);
+			const notificationId = validatedParams.id;
+
+			const modifiedCount = await this.notificationsService.setDefault(notificationId, teamId, validatedBody.isDefault);
+			return res.status(200).json({
+				success: true,
+				msg: `Default notification ${validatedBody.isDefault ? "set" : "removed"}`,
+				data: { modifiedCount },
+			});
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	applyToAllMonitors = async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			const validatedParams = editNotificationParamValidation.parse(req.params);
+
+			const teamId = requireTeamId(req.user?.teamId);
+			const notificationId = validatedParams.id;
+
+			const modifiedCount = await this.notificationsService.applyToAllMonitors(notificationId, teamId);
+			return res.status(200).json({
+				success: true,
+				msg: `Notification applied to ${modifiedCount} monitor(s)`,
+				data: { modifiedCount },
 			});
 		} catch (error) {
 			next(error);

--- a/server/src/db/models/Notification.ts
+++ b/server/src/db/models/Notification.ts
@@ -5,6 +5,7 @@ interface NotificationDocument extends Omit<Notification, "id" | "userId" | "tea
 	_id: Types.ObjectId;
 	userId: Types.ObjectId;
 	teamId: Types.ObjectId;
+	isDefault: boolean;
 	createdAt: Date;
 	updatedAt: Date;
 }
@@ -39,6 +40,10 @@ const NotificationSchema = new Schema<NotificationDocument>(
 		accessToken: { type: String },
 		accountSid: { type: String },
 		twilioPhoneNumber: { type: String },
+		isDefault: {
+			type: Boolean,
+			default: false,
+		},
 	},
 	{
 		timestamps: true,

--- a/server/src/repositories/monitors/IMonitorsRepository.ts
+++ b/server/src/repositories/monitors/IMonitorsRepository.ts
@@ -52,6 +52,7 @@ export interface IMonitorsRepository {
 	findGroupsByTeamId(teamId: string): Promise<string[]>;
 	removeNotificationFromMonitors(notificationId: string): Promise<void>;
 	updateNotifications(teamId: string, monitorIds: string[], notificationIds: string[], action: "add" | "remove" | "set"): Promise<number>;
+	addNotificationToAllMonitors(teamId: string, notificationId: string): Promise<number>;
 	deleteByTeamIdsNotIn(teamIds: string[]): Promise<number>;
 	findAllMonitorIds(): Promise<string[]>;
 }

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -544,6 +544,14 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		};
 	};
 
+	addNotificationToAllMonitors = async (teamId: string, notificationId: string): Promise<number> => {
+		const result = await MonitorModel.updateMany(
+			{ teamId: new mongoose.Types.ObjectId(teamId) },
+			{ $addToSet: { notifications: new mongoose.Types.ObjectId(notificationId) } }
+		);
+		return result.modifiedCount;
+	};
+
 	deleteByTeamIdsNotIn = async (teamIds: string[]): Promise<number> => {
 		const objectIds = teamIds.map((id) => new mongoose.Types.ObjectId(id));
 		const result = await MonitorModel.deleteMany({ teamId: { $nin: objectIds } });

--- a/server/src/repositories/notifications/INotificationsRepository.ts
+++ b/server/src/repositories/notifications/INotificationsRepository.ts
@@ -8,6 +8,8 @@ export interface INotificationsRepository {
 	findByTeamId(teamId: string): Promise<Notification[]>;
 	// update
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
+	setDefault(id: string, teamId: string, isDefault: boolean): Promise<number>;
+	findDefaultsByTeamId(teamId: string): Promise<Notification[]>;
 	// delete
 	deleteById(id: string, teamId: string): Promise<Notification>;
 }

--- a/server/src/repositories/notifications/MongoNotificationsRepository.ts
+++ b/server/src/repositories/notifications/MongoNotificationsRepository.ts
@@ -34,6 +34,7 @@ class MongoNotificationsRepository implements INotificationsRepository {
 			accessToken: doc.accessToken ?? undefined,
 			accountSid: doc.accountSid ?? undefined,
 			twilioPhoneNumber: doc.twilioPhoneNumber ?? undefined,
+			isDefault: doc.isDefault ?? false,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};
@@ -93,6 +94,25 @@ class MongoNotificationsRepository implements INotificationsRepository {
 			throw new AppError({ message: "Notification not found or could not be deleted", status: 404 });
 		}
 		return this.toEntity(deleted);
+	};
+
+	setDefault = async (id: string, teamId: string, isDefault: boolean): Promise<number> => {
+		if (isDefault) {
+			await NotificationModel.updateMany({ teamId: new mongoose.Types.ObjectId(teamId) }, { $set: { isDefault: false } });
+		}
+		const result = await NotificationModel.updateOne(
+			{ _id: new mongoose.Types.ObjectId(id), teamId: new mongoose.Types.ObjectId(teamId) },
+			{ $set: { isDefault } }
+		);
+		return result.modifiedCount;
+	};
+
+	findDefaultsByTeamId = async (teamId: string): Promise<Notification[]> => {
+		const documents = await NotificationModel.find({
+			teamId: new mongoose.Types.ObjectId(teamId),
+			isDefault: true,
+		});
+		return this.mapDocuments(documents);
 	};
 }
 

--- a/server/src/routes/notificationRoute.ts
+++ b/server/src/routes/notificationRoute.ts
@@ -17,10 +17,13 @@ class NotificationRoutes {
 		this.router.post("/test", this.notificationController.testNotification);
 
 		this.router.get("/team", this.notificationController.getNotificationsByTeamId);
+		this.router.get("/defaults", this.notificationController.getDefaultNotifications);
 
 		this.router.get("/:id", this.notificationController.getNotificationById);
 		this.router.delete("/:id", this.notificationController.deleteNotification);
 		this.router.patch("/:id", this.notificationController.editNotification);
+		this.router.patch("/:id/default", this.notificationController.setDefaultNotification);
+		this.router.post("/:id/apply-to-all", this.notificationController.applyToAllMonitors);
 	}
 
 	getRouter() {

--- a/server/src/service/business/monitorService.ts
+++ b/server/src/service/business/monitorService.ts
@@ -19,6 +19,7 @@ import type {
 	IMonitorsRepository,
 	IMonitorStatsRepository,
 	IStatusPagesRepository,
+	INotificationsRepository,
 } from "@/repositories/index.js";
 import demoMonitorsData from "@/utils/demoMonitors.json" with { type: "json" };
 import { AppError } from "@/utils/AppError.js";
@@ -103,6 +104,7 @@ export class MonitorService implements IMonitorService {
 	private monitorStatsRepository: IMonitorStatsRepository;
 	private statusPagesRepository: IStatusPagesRepository;
 	private incidentsRepository: IIncidentsRepository;
+	private notificationsRepository: INotificationsRepository;
 
 	constructor({
 		jobQueue,
@@ -114,6 +116,7 @@ export class MonitorService implements IMonitorService {
 		monitorStatsRepository,
 		statusPagesRepository,
 		incidentsRepository,
+		notificationsRepository,
 	}: {
 		jobQueue: ISuperSimpleQueue;
 		logger: ILogger;
@@ -124,6 +127,7 @@ export class MonitorService implements IMonitorService {
 		monitorStatsRepository: IMonitorStatsRepository;
 		statusPagesRepository: IStatusPagesRepository;
 		incidentsRepository: IIncidentsRepository;
+		notificationsRepository: INotificationsRepository;
 	}) {
 		this.jobQueue = jobQueue;
 		this.logger = logger;
@@ -134,6 +138,7 @@ export class MonitorService implements IMonitorService {
 		this.monitorStatsRepository = monitorStatsRepository;
 		this.statusPagesRepository = statusPagesRepository;
 		this.incidentsRepository = incidentsRepository;
+		this.notificationsRepository = notificationsRepository;
 	}
 
 	get serviceName(): string {
@@ -166,7 +171,14 @@ export class MonitorService implements IMonitorService {
 	};
 
 	createMonitor = async (teamId: string, userId: string, body: Monitor): Promise<void> => {
-		const monitor = await this.monitorsRepository.create(body, teamId, userId);
+		let notifications = body.notifications ?? [];
+		if (notifications.length === 0) {
+			const defaults = await this.notificationsRepository.findDefaultsByTeamId(teamId);
+			if (defaults.length > 0) {
+				notifications = defaults.map((n) => n.id);
+			}
+		}
+		const monitor = await this.monitorsRepository.create({ ...body, notifications }, teamId, userId);
 		if (!monitor) {
 			throw new AppError({ message: "Failed to create monitor", status: 500, service: SERVICE_NAME, method: "createMonitor" });
 		}

--- a/server/src/service/infrastructure/notificationsService.ts
+++ b/server/src/service/infrastructure/notificationsService.ts
@@ -11,8 +11,11 @@ export interface INotificationsService {
 	createNotification: (notificationData: Partial<Notification>, userId: string, teamId: string) => Promise<Notification>;
 	findById: (id: string, teamId: string) => Promise<Notification>;
 	findNotificationsByTeamId: (teamId: string) => Promise<Notification[]>;
+	findDefaultsByTeamId: (teamId: string) => Promise<Notification[]>;
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
+	setDefault(id: string, teamId: string, isDefault: boolean): Promise<number>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
+	applyToAllMonitors: (notificationId: string, teamId: string) => Promise<number>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
@@ -217,5 +220,17 @@ export class NotificationsService implements INotificationsService {
 		await this.monitorsRepository.removeNotificationFromMonitors(id);
 		const deleted = await this.notificationsRepository.deleteById(id, teamId);
 		return deleted;
+	};
+
+	setDefault = async (id: string, teamId: string, isDefault: boolean): Promise<number> => {
+		return await this.notificationsRepository.setDefault(id, teamId, isDefault);
+	};
+
+	findDefaultsByTeamId = async (teamId: string): Promise<Notification[]> => {
+		return await this.notificationsRepository.findDefaultsByTeamId(teamId);
+	};
+
+	applyToAllMonitors = async (notificationId: string, teamId: string): Promise<number> => {
+		return await this.monitorsRepository.addNotificationToAllMonitors(teamId, notificationId);
 	};
 }

--- a/server/src/types/notification.ts
+++ b/server/src/types/notification.ts
@@ -25,6 +25,7 @@ export interface Notification {
 	accessToken?: string;
 	accountSid?: string;
 	twilioPhoneNumber?: string;
+	isDefault?: boolean;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/validation/notificationValidation.ts
+++ b/server/src/validation/notificationValidation.ts
@@ -13,6 +13,7 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
 		roomId: z.union([z.string(), z.literal("")]).optional(),
 		accessToken: z.union([z.string(), z.literal("")]).optional(),
+		isDefault: z.boolean().optional(),
 	}),
 	// Webhook notification
 	z.object({
@@ -22,6 +23,7 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
 		roomId: z.union([z.string(), z.literal("")]).optional(),
 		accessToken: z.union([z.string(), z.literal("")]).optional(),
+		isDefault: z.boolean().optional(),
 	}),
 	// Slack notification
 	z.object({
@@ -31,6 +33,7 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
 		roomId: z.union([z.string(), z.literal("")]).optional(),
 		accessToken: z.union([z.string(), z.literal("")]).optional(),
+		isDefault: z.boolean().optional(),
 	}),
 	// Discord notification
 	z.object({
@@ -40,6 +43,7 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
 		roomId: z.union([z.string(), z.literal("")]).optional(),
 		accessToken: z.union([z.string(), z.literal("")]).optional(),
+		isDefault: z.boolean().optional(),
 	}),
 	// PagerDuty notification
 	z.object({
@@ -49,6 +53,7 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
 		roomId: z.union([z.string(), z.literal("")]).optional(),
 		accessToken: z.union([z.string(), z.literal("")]).optional(),
+		isDefault: z.boolean().optional(),
 	}),
 	// Matrix notification
 	z.object({
@@ -58,12 +63,14 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		homeserverUrl: z.url({ message: "Please enter a valid Homeserver URL" }),
 		roomId: z.string().min(1, "Room ID is required"),
 		accessToken: z.string().min(1, "Access Token is required"),
+		isDefault: z.boolean().optional(),
 	}),
 	// Teams notification
 	z.object({
 		notificationName: z.string().min(1, "Notification name is required"),
 		type: z.literal("teams"),
 		address: z.url({ message: "Please enter a valid Webhook URL" }),
+		isDefault: z.boolean().optional(),
 	}),
 	// Telegram notification
 	z.object({
@@ -71,6 +78,7 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		type: z.literal("telegram"),
 		address: z.string().min(1, "Chat ID is required"),
 		accessToken: z.string().min(1, "Bot token is required"),
+		isDefault: z.boolean().optional(),
 	}),
 	// Pushover notification
 	z.object({
@@ -78,6 +86,7 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		type: z.literal("pushover"),
 		address: z.string().min(1, "User key is required"),
 		accessToken: z.string().min(1, "App token is required"),
+		isDefault: z.boolean().optional(),
 	}),
 	// Twilio SMS notification
 	z.object({
@@ -87,6 +96,7 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		accessToken: z.string().min(1, "Auth token is required"),
 		phone: z.string().min(1, "Recipient phone number is required"),
 		twilioPhoneNumber: z.string().min(1, "Twilio phone number is required"),
+		isDefault: z.boolean().optional(),
 	}),
 ]);
 

--- a/server/src/validation/notificationValidation.ts
+++ b/server/src/validation/notificationValidation.ts
@@ -139,3 +139,9 @@ export const updateNotificationsValidation = z
 			path: ["notificationIds"],
 		}
 	);
+
+export const setDefaultNotificationBodyValidation = z.object({
+	isDefault: z.boolean(),
+});
+
+export const applyToAllBodyValidation = z.object({});


### PR DESCRIPTION
## Describe your changes
Briefly describe the changes you made and their purpose.

This PR implements the ability to bulk-assign Notification Channels to Alerts as requested in issue #3601. The implementation includes:

1. **Default Channel**: Added the ability to mark a notification channel as 'Default' so it is automatically attached to any new monitor created.
2. **Bulk Edit Mode**: Added checkbox selection on the Uptime and Infrastructure monitor lists to "Add Notification Channel" or "Remove Notification Channel" to all selected items.
3. **Global Defaults (Apply to All)**: Added an "Apply to All" button in the notification edit form that applies the notification channel to all existing monitors in the team.

Backend changes:
- Added isDefault field to Notification model
- Added API endpoints: GET /notifications/defaults, PATCH /notifications/:id/default, POST /notifications/:id/apply-to-all
- Added PATCH /monitors/notifications endpoint for bulk add/remove operations
Frontend changes:
- Added "Default channel" toggle in notification creation/edit form
- Added bulk notification actions (Add/Remove) in Uptime and Infrastructure monitor pages
- Added "Apply to All" button in notification edit form
- Auto-attaches default notifications to new monitors

## Write your issue number after "Fixes "

Fixes #3601 

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
<img width="1892" height="851" alt="checkmate  1" src="https://github.com/user-attachments/assets/4104d4f0-3eab-423f-b450-500869976eb7" />
<img width="1902" height="861" alt="checkmate" src="https://github.com/user-attachments/assets/7909f2eb-790a-49da-8f2b-08650395237f" />
