### PR TITLE
fix: monitor summary with tags

### DIFF
--- a/server/src/repositories/monitors/IMonitorsRepository.ts
+++ b/server/src/repositories/monitors/IMonitorsRepository.ts
@@ -13,6 +13,7 @@ export interface TeamQueryConfig {
 
 export interface SummaryConfig {
 	type?: MonitorType | MonitorType[];
+	tags?: string | string[];
 }
 
 export interface IMonitorsRepository {

--- a/server/src/repositories/monitors/MongoMonitorsRepository.ts
+++ b/server/src/repositories/monitors/MongoMonitorsRepository.ts
@@ -292,6 +292,10 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		if (config?.type !== undefined) {
 			match.type = Array.isArray(config.type) ? { $in: config.type } : config.type;
 		}
+		if (config?.tags !== undefined) {
+			const tagIds = (Array.isArray(config.tags) ? config.tags : [config.tags]).map((tag) => new mongoose.Types.ObjectId(tag));
+			match.tags = { $in: tagIds };
+		}
 		const pipeline = [
 			{ $match: match },
 			{

--- a/server/src/service/business/monitorService.ts
+++ b/server/src/service/business/monitorService.ts
@@ -391,7 +391,7 @@ export class MonitorService implements IMonitorService {
 		field?: string;
 		order?: "asc" | "desc";
 	}): Promise<MonitorsWithChecksByTeamIdResult> => {
-		const summary = await this.monitorsRepository.findMonitorsSummaryByTeamId(teamId, { type });
+		const summary = await this.monitorsRepository.findMonitorsSummaryByTeamId(teamId, { type, tags });
 		const count = await this.monitorsRepository.findMonitorCountByTeamIdAndType(teamId, { type, tags, filter });
 		const monitors = await this.monitorsRepository.findByTeamId(teamId, {
 			limit,


### PR DESCRIPTION
Currently, tags are not accounted for when aggregating the monitor summary.  This PR resolves that.

- [x] Add tags to aggregation pipeline