### PR TITLE
Fix SSL certificate lookup for HTTPS URLs with custom ports

### DIFF
--- a/server/src/controllers/controllerUtils.ts
+++ b/server/src/controllers/controllerUtils.ts
@@ -6,7 +6,9 @@ type SSLCheckerType = typeof sslChecker;
 export const fetchMonitorCertificate = async (checker: SSLCheckerType, monitor: Monitor): Promise<SSLDetails> => {
 	const monitorUrl = new URL(monitor.url);
 	const hostname = monitorUrl.hostname;
-	const cert = await checker(hostname);
+	const urlPort = monitorUrl.port ? Number(monitorUrl.port) : undefined;
+	const port = monitor.port ?? urlPort;
+	const cert = await checker(hostname, port ? { port } : undefined);
 	if (cert?.validTo === null || cert?.validTo === undefined) {
 		throw new Error("Certificate not found");
 	}

--- a/server/test/unit/controllers/controllerUtils.test.ts
+++ b/server/test/unit/controllers/controllerUtils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { fetchMonitorCertificate } from "../../../src/controllers/controllerUtils.ts";
+import type { Monitor } from "../../../src/types/index.ts";
+import type { SSLDetails } from "ssl-checker";
+
+const certificate: SSLDetails = {
+	daysRemaining: 30,
+	valid: true,
+	validFrom: "2026-01-01T00:00:00.000Z",
+	validTo: "2026-06-01T00:00:00.000Z",
+	validFor: ["checkmate.example.org"],
+};
+
+const makeMonitor = (overrides?: Partial<Monitor>): Monitor =>
+	({
+		id: "monitor-1",
+		teamId: "team-1",
+		url: "https://checkmate.example.org",
+		ignoreTlsErrors: false,
+		...overrides,
+	}) as Monitor;
+
+describe("controllerUtils", () => {
+	describe("fetchMonitorCertificate", () => {
+		it("checks the explicit HTTPS URL port when present", async () => {
+			const checker = jest.fn().mockResolvedValue(certificate);
+
+			await fetchMonitorCertificate(checker as any, makeMonitor({ url: "https://checkmate.example.org:54321/status" }));
+
+			expect(checker).toHaveBeenCalledWith("checkmate.example.org", { port: 54321 });
+		});
+
+		it("uses the monitor port when the URL does not include one", async () => {
+			const checker = jest.fn().mockResolvedValue(certificate);
+
+			await fetchMonitorCertificate(checker as any, makeMonitor({ url: "https://checkmate.example.org/status", port: 8443 }));
+
+			expect(checker).toHaveBeenCalledWith("checkmate.example.org", { port: 8443 });
+		});
+
+		it("keeps the previous default-port behavior when no port is configured", async () => {
+			const checker = jest.fn().mockResolvedValue(certificate);
+
+			await fetchMonitorCertificate(checker as any, makeMonitor());
+
+			expect(checker).toHaveBeenCalledWith("checkmate.example.org", undefined);
+		});
+
+		it("throws when no certificate expiry is returned", async () => {
+			const checker = jest.fn().mockResolvedValue({ ...certificate, validTo: undefined });
+
+			await expect(fetchMonitorCertificate(checker as any, makeMonitor())).rejects.toThrow("Certificate not found");
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes

`fetchMonitorCertificate` now passes the configured HTTPS port to `ssl-checker` when a monitor URL includes a non-standard port, e.g. `https://checkmate.example.org:54321/status`. It also still supports the existing `monitor.port` field and keeps the previous default behavior when no port is configured.

Added a focused regression test for:

- URL port parsed from an HTTPS monitor URL
- `monitor.port` fallback
- no-port default behavior
- missing certificate expiry error handling

## Write your issue number after \"Fixes \"

Fixes #3646

## Please ensure all items are checked off before requesting a review. \"Checked off\" means you need to add an \"x\" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally. Server build completed; this is a server utility fix with no UI path changed.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings. N/A, no visible strings added.
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed.
- [x] I didn't use any hardcoded values.
- [x] I made sure font sizes, color choices etc are all referenced from the theme. N/A, no UI/CSS changes.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code. Touched server files pass Prettier check; no client files changed.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change. N/A, no UI change.

Verification:

- `npm test -- --runTestsByPath test/unit/controllers/controllerUtils.test.ts --coverage=false`
- `npm run build`
- `npx prettier --check src/controllers/controllerUtils.ts test/unit/controllers/controllerUtils.test.ts`
- `npx eslint src/controllers/controllerUtils.ts test/unit/controllers/controllerUtils.test.ts` (0 errors; test file is ignored by the repo ESLint ignore pattern)

Optional: if this saves you time and you are open to a small direct-fix payment, I use this checkout: https://nicdunz.gumroad.com/l/tiny-codex-teardown-direct?wanted=true