### PR TITLE
feat: add bearer/basic auth option to webhooks

### DIFF
--- a/client/src/Hooks/useNotificationForm.ts
+++ b/client/src/Hooks/useNotificationForm.ts
@@ -44,6 +44,10 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			type: "webhook",
 			notificationName: data.notificationName || "",
 			address: data.address || "",
+			webhookAuthType: data.webhookAuthType ?? "none",
+			webhookAuthUsername: data.webhookAuthUsername || "",
+			webhookAuthPassword: data.webhookAuthPassword || "",
+			webhookAuthToken: data.webhookAuthToken || "",
 		};
 	}
 	if (data?.type === "pager_duty") {

--- a/client/src/Pages/Notifications/create/index.tsx
+++ b/client/src/Pages/Notifications/create/index.tsx
@@ -46,6 +46,7 @@ const NotificationsCreatePage = () => {
 	}, [defaults, reset]);
 
 	const watchedType = watch("type");
+	const watchedWebhookAuthType = watchedType === "webhook" ? watch("webhookAuthType" as any) : "none";
 
 	useEffect(() => {
 		clearErrors();
@@ -401,6 +402,86 @@ const NotificationsCreatePage = () => {
 									/>
 								)}
 							/>
+						</Stack>
+					}
+				/>
+			)}
+			{watchedType === "webhook" && (
+				<ConfigBox
+					title="Authentication"
+					subtitle="Optional auth headers sent with every webhook request."
+					rightContent={
+						<Stack spacing={theme.spacing(8)}>
+							<Controller
+								name={"webhookAuthType" as any}
+								control={control}
+								defaultValue="none"
+								render={({ field }) => (
+									<Select
+										value={field.value ?? "none"}
+										fieldLabel="Authentication type"
+										onChange={field.onChange}
+									>
+										<MenuItem value="none">None</MenuItem>
+										<MenuItem value="basic">Basic Auth</MenuItem>
+										<MenuItem value="bearer">Bearer Token</MenuItem>
+									</Select>
+								)}
+							/>
+							{watchedWebhookAuthType === "basic" && (
+								<>
+									<Controller
+										name={"webhookAuthUsername" as any}
+										control={control}
+										defaultValue=""
+										render={({ field, fieldState }) => (
+											<TextField
+												{...field}
+												type="text"
+												fieldLabel="Username"
+												placeholder="Enter username"
+												fullWidth
+												error={!!fieldState.error}
+												helperText={fieldState.error?.message ?? ""}
+											/>
+										)}
+									/>
+									<Controller
+										name={"webhookAuthPassword" as any}
+										control={control}
+										defaultValue=""
+										render={({ field, fieldState }) => (
+											<TextField
+												{...field}
+												type="password"
+												fieldLabel="Password"
+												placeholder="Enter password"
+												fullWidth
+												error={!!fieldState.error}
+												helperText={fieldState.error?.message ?? ""}
+											/>
+										)}
+									/>
+								</>
+							)}
+							{watchedWebhookAuthType === "bearer" && (
+								<Controller
+									name={"webhookAuthToken" as any}
+									control={control}
+									defaultValue=""
+									render={({ field, fieldState }) => (
+										<TextField
+											{...field}
+											type="password"
+											fieldLabel="Bearer token"
+											placeholder="Enter token"
+											fullWidth
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+										/>
+									)}
+								/>
+							)}
 						</Stack>
 					}
 				/>

--- a/client/src/Types/Notification.ts
+++ b/client/src/Types/Notification.ts
@@ -12,6 +12,9 @@ export const NotificationChannels = [
 ] as const;
 export type NotificationChannel = (typeof NotificationChannels)[number];
 
+export const WebhookAuthTypes = ["none", "basic", "bearer"] as const;
+export type WebhookAuthType = (typeof WebhookAuthTypes)[number];
+
 export interface Notification {
 	id: string;
 	userId: string;
@@ -25,6 +28,10 @@ export interface Notification {
 	accessToken?: string;
 	accountSid?: string;
 	twilioPhoneNumber?: string;
+	webhookAuthType?: WebhookAuthType;
+	webhookAuthUsername?: string;
+	webhookAuthPassword?: string;
+	webhookAuthToken?: string;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/client/src/Validation/notifications.ts
+++ b/client/src/Validation/notifications.ts
@@ -25,10 +25,30 @@ const discordSchema = baseSchema.extend({
 	address: z.string().min(1, "Webhook URL is required").url("Please enter a valid URL"),
 });
 
-const webhookSchema = baseSchema.extend({
-	type: z.literal("webhook"),
-	address: z.string().min(1, "Webhook URL is required").url("Please enter a valid URL"),
-});
+const webhookSchema = baseSchema
+	.extend({
+		type: z.literal("webhook"),
+		address: z.string().min(1, "Webhook URL is required").url("Please enter a valid URL"),
+		webhookAuthType: z.enum(["none", "basic", "bearer"]).default("none"),
+		webhookAuthUsername: z.string().optional(),
+		webhookAuthPassword: z.string().optional(),
+		webhookAuthToken: z.string().optional(),
+	})
+	.superRefine((data, ctx) => {
+		if (data.webhookAuthType === "basic") {
+			if (!data.webhookAuthUsername || data.webhookAuthUsername.trim() === "") {
+				ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Username is required for Basic Auth", path: ["webhookAuthUsername"] });
+			}
+			if (!data.webhookAuthPassword || data.webhookAuthPassword.trim() === "") {
+				ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Password is required for Basic Auth", path: ["webhookAuthPassword"] });
+			}
+		}
+		if (data.webhookAuthType === "bearer") {
+			if (!data.webhookAuthToken || data.webhookAuthToken.trim() === "") {
+				ctx.addIssue({ code: z.ZodIssueCode.custom, message: "Token is required for Bearer Auth", path: ["webhookAuthToken"] });
+			}
+		}
+	});
 
 const pagerDutySchema = baseSchema.extend({
 	type: z.literal("pager_duty"),

--- a/server/src/db/models/Notification.ts
+++ b/server/src/db/models/Notification.ts
@@ -1,5 +1,5 @@
 import { Schema, model, type Types } from "mongoose";
-import type { Notification, NotificationChannel } from "@/types/notification.js";
+import type { Notification, NotificationChannel, WebhookAuthType } from "@/types/notification.js";
 
 interface NotificationDocument extends Omit<Notification, "id" | "userId" | "teamId" | "createdAt" | "updatedAt"> {
 	_id: Types.ObjectId;
@@ -39,6 +39,14 @@ const NotificationSchema = new Schema<NotificationDocument>(
 		accessToken: { type: String },
 		accountSid: { type: String },
 		twilioPhoneNumber: { type: String },
+		webhookAuthType: {
+			type: String,
+			enum: ["none", "basic", "bearer"] as WebhookAuthType[],
+			default: "none",
+		},
+		webhookAuthUsername: { type: String },
+		webhookAuthPassword: { type: String },
+		webhookAuthToken: { type: String },
 	},
 	{
 		timestamps: true,

--- a/server/src/service/infrastructure/notificationProviders/webhook.ts
+++ b/server/src/service/infrastructure/notificationProviders/webhook.ts
@@ -6,6 +6,18 @@ import { getTestMessage } from "@/service/infrastructure/notificationProviders/u
 import got from "got";
 
 export class WebhookProvider extends NotificationProvider {
+	private buildAuthHeader(notification: Notification | Partial<Notification>): Record<string, string> {
+		const authType = notification.webhookAuthType ?? "none";
+		if (authType === "basic" && notification.webhookAuthUsername && notification.webhookAuthPassword) {
+			const credentials = Buffer.from(`${notification.webhookAuthUsername}:${notification.webhookAuthPassword}`).toString("base64");
+			return { Authorization: `Basic ${credentials}` };
+		}
+		if (authType === "bearer" && notification.webhookAuthToken) {
+			return { Authorization: `Bearer ${notification.webhookAuthToken}` };
+		}
+		return {};
+	}
+
 	sendMessage = async (notification: Notification, message: NotificationMessage): Promise<boolean> => {
 		if (!notification.address) {
 			return false;
@@ -19,6 +31,7 @@ export class WebhookProvider extends NotificationProvider {
 				json: payload,
 				headers: {
 					"Content-Type": "application/json",
+					...this.buildAuthHeader(notification),
 				},
 				...this.gotRequestOptions(),
 			});
@@ -101,6 +114,7 @@ export class WebhookProvider extends NotificationProvider {
 				json: { text: getTestMessage() },
 				headers: {
 					"Content-Type": "application/json",
+					...this.buildAuthHeader(notification),
 				},
 				...this.gotRequestOptions(),
 			});

--- a/server/src/types/notification.ts
+++ b/server/src/types/notification.ts
@@ -12,6 +12,9 @@ export const NotificationChannels = [
 ] as const;
 export type NotificationChannel = (typeof NotificationChannels)[number];
 
+export const WebhookAuthTypes = ["none", "basic", "bearer"] as const;
+export type WebhookAuthType = (typeof WebhookAuthTypes)[number];
+
 export interface Notification {
 	id: string;
 	userId: string;
@@ -25,6 +28,10 @@ export interface Notification {
 	accessToken?: string;
 	accountSid?: string;
 	twilioPhoneNumber?: string;
+	webhookAuthType?: WebhookAuthType;
+	webhookAuthUsername?: string;
+	webhookAuthPassword?: string;
+	webhookAuthToken?: string;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/validation/notificationValidation.ts
+++ b/server/src/validation/notificationValidation.ts
@@ -22,6 +22,10 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
 		roomId: z.union([z.string(), z.literal("")]).optional(),
 		accessToken: z.union([z.string(), z.literal("")]).optional(),
+		webhookAuthType: z.enum(["none", "basic", "bearer"]).default("none"),
+		webhookAuthUsername: z.union([z.string(), z.literal("")]).optional(),
+		webhookAuthPassword: z.union([z.string(), z.literal("")]).optional(),
+		webhookAuthToken: z.union([z.string(), z.literal("")]).optional(),
 	}),
 	// Slack notification
 	z.object({

--- a/server/test/unit/providers/notifications/webhookProvider.test.ts
+++ b/server/test/unit/providers/notifications/webhookProvider.test.ts
@@ -99,4 +99,73 @@ describe("WebhookProvider", () => {
 			expect(text).not.toContain("View Incident");
 		});
 	});
+
+	describe("webhook authentication", () => {
+		describe("sendMessage", () => {
+			it("sends no Authorization header when authType is none", async () => {
+				const { provider } = createProvider();
+				await provider.sendMessage(makeNotification({ webhookAuthType: "none" }) as any, makeMessage());
+				const headers = mockGotPost.mock.calls[0][1].headers;
+				expect(headers.Authorization).toBeUndefined();
+			});
+
+			it("sends no Authorization header when webhookAuthType is absent", async () => {
+				const { provider } = createProvider();
+				await provider.sendMessage(makeNotification() as any, makeMessage());
+				const headers = mockGotPost.mock.calls[0][1].headers;
+				expect(headers.Authorization).toBeUndefined();
+			});
+
+			it("sends Basic auth header with base64-encoded credentials", async () => {
+				const { provider } = createProvider();
+				await provider.sendMessage(
+					makeNotification({ webhookAuthType: "basic", webhookAuthUsername: "user", webhookAuthPassword: "pass" }) as any,
+					makeMessage()
+				);
+				const headers = mockGotPost.mock.calls[0][1].headers;
+				const expected = `Basic ${Buffer.from("user:pass").toString("base64")}`;
+				expect(headers.Authorization).toBe(expected);
+			});
+
+			it("sends no Authorization header for basic auth when credentials are missing", async () => {
+				const { provider } = createProvider();
+				await provider.sendMessage(makeNotification({ webhookAuthType: "basic" }) as any, makeMessage());
+				const headers = mockGotPost.mock.calls[0][1].headers;
+				expect(headers.Authorization).toBeUndefined();
+			});
+
+			it("sends Bearer auth header with token", async () => {
+				const { provider } = createProvider();
+				await provider.sendMessage(
+					makeNotification({ webhookAuthType: "bearer", webhookAuthToken: "my-secret-token" }) as any,
+					makeMessage()
+				);
+				const headers = mockGotPost.mock.calls[0][1].headers;
+				expect(headers.Authorization).toBe("Bearer my-secret-token");
+			});
+
+			it("sends no Authorization header for bearer auth when token is missing", async () => {
+				const { provider } = createProvider();
+				await provider.sendMessage(makeNotification({ webhookAuthType: "bearer" }) as any, makeMessage());
+				const headers = mockGotPost.mock.calls[0][1].headers;
+				expect(headers.Authorization).toBeUndefined();
+			});
+		});
+
+		describe("sendTestAlert", () => {
+			it("includes Basic auth header in test alert", async () => {
+				const { provider } = createProvider();
+				await provider.sendTestAlert(makeNotification({ webhookAuthType: "basic", webhookAuthUsername: "admin", webhookAuthPassword: "secret" }));
+				const headers = mockGotPost.mock.calls[0][1].headers;
+				expect(headers.Authorization).toBe(`Basic ${Buffer.from("admin:secret").toString("base64")}`);
+			});
+
+			it("includes Bearer auth header in test alert", async () => {
+				const { provider } = createProvider();
+				await provider.sendTestAlert(makeNotification({ webhookAuthType: "bearer", webhookAuthToken: "tok123" }));
+				const headers = mockGotPost.mock.calls[0][1].headers;
+				expect(headers.Authorization).toBe("Bearer tok123");
+			});
+		});
+	});
 });


### PR DESCRIPTION
Closes #2369.

Adds optional authentication to webhook notifications, exactly as specified in the issue.

## What's new

A new **Authentication type** dropdown appears when editing or creating a webhook notification:

| Option | Behavior |
|--------|----------|
| **None** (default) | No `Authorization` header sent |
| **Basic Auth** | Prompts for Username + Password; encodes as `Authorization: Basic base64(user:pass)` |
| **Bearer Token** | Prompts for Token; sends `Authorization: Bearer <token>` |

Auth is applied to both live alerts and the **Test** button.

## Files changed

| File | Change |
|------|--------|
| `server/src/types/notification.ts` | `WebhookAuthType` union + 4 new optional fields |
| `server/src/db/models/Notification.ts` | Persist auth fields in MongoDB |
| `server/src/validation/notificationValidation.ts` | Accept auth fields in webhook schema |
| `server/src/service/.../webhook.ts` | `buildAuthHeader()` helper; used in `sendMessage` + `sendTestAlert` |
| `client/src/Types/Notification.ts` | Mirror server-side `WebhookAuthType` |
| `client/src/Validation/notifications.ts` | `superRefine` validates credentials per auth type |
| `client/src/Hooks/useNotificationForm.ts` | Populate auth defaults from existing notification (edit mode) |
| `client/src/Pages/Notifications/create/index.tsx` | Auth type dropdown + conditional credential fields |
| `server/test/.../webhookProvider.test.ts` | 8 new unit tests covering all auth paths |

## Test results

```
PASS test/unit/providers/notifications/webhookProvider.test.ts
  webhook authentication
    sendMessage
      ✓ sends no Authorization header when authType is none
      ✓ sends no Authorization header when webhookAuthType is absent
      ✓ sends Basic auth header with base64-encoded credentials
      ✓ sends no Authorization header for basic auth when credentials are missing
      ✓ sends Bearer auth header with token
      ✓ sends no Authorization header for bearer auth when token is missing
    sendTestAlert
      ✓ includes Basic auth header in test alert
      ✓ includes Bearer auth header in test alert

Tests: 21 passed, 21 total
```

## Security notes

- Credentials stored in MongoDB using the same pattern as existing `accessToken` fields (Telegram, Pushover, etc.)
- Password and token fields render as `type="password"` in the UI
- No credentials are logged