### PR TITLE
Feat: Uptime Progress Indicator

### DIFF
--- a/client/src/Components/design-elements/StepProgress.tsx
+++ b/client/src/Components/design-elements/StepProgress.tsx
@@ -14,29 +14,30 @@ export const StepProgress = ({ steps, current }: StepProgressProps) => {
 	const activeBg = `linear-gradient(135deg, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 100%)`;
 	const completedBg = `linear-gradient(135deg, ${alpha(theme.palette.primary.light, 0.5)} 0%, ${alpha(theme.palette.primary.main, 0.5)} 100%)`;
 
+	const getSegmentBackground = (index: number) => {
+		if (index < current) return completedBg;
+		if (index === current) return activeBg;
+		return theme.palette.divider;
+	};
+
 	return (
 		<Stack
 			direction="row"
 			gap={theme.spacing(LAYOUT.XS)}
 			width="100%"
 		>
-			{Array.from({ length: steps }).map((_, index) => {
-				const background =
-					index < current
-						? completedBg
-						: index === current
-							? activeBg
-							: theme.palette.divider;
-				return (
-					<Box
-						key={index}
-						flex={1}
-						height={theme.spacing(LAYOUT.XXS)}
-						borderRadius={theme.shape.borderRadius}
-						sx={{ background, transition: "background 0.2s ease" }}
-					/>
-				);
-			})}
+			{Array.from({ length: steps }).map((_, index) => (
+				<Box
+					key={index}
+					flex={1}
+					height={theme.spacing(LAYOUT.XXS)}
+					borderRadius={theme.shape.borderRadius}
+					sx={{
+						background: getSegmentBackground(index),
+						transition: "background 0.2s ease",
+					}}
+				/>
+			))}
 		</Stack>
 	);
 };

--- a/client/src/Components/design-elements/StepProgress.tsx
+++ b/client/src/Components/design-elements/StepProgress.tsx
@@ -1,7 +1,6 @@
 import Stack from "@mui/material/Stack";
 import Box from "@mui/material/Box";
-import { useTheme } from "@mui/material/styles";
-import { alpha } from "@mui/material/styles";
+import { useTheme, alpha } from "@mui/material/styles";
 import { LAYOUT } from "@/Utils/Theme/constants";
 
 interface StepProgressProps {

--- a/client/src/Components/design-elements/StepProgress.tsx
+++ b/client/src/Components/design-elements/StepProgress.tsx
@@ -1,0 +1,42 @@
+import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import { useTheme } from "@mui/material/styles";
+import { alpha } from "@mui/material/styles";
+import { LAYOUT } from "@/Utils/Theme/constants";
+
+interface StepProgressProps {
+	steps: number;
+	current: number;
+}
+
+export const StepProgress = ({ steps, current }: StepProgressProps) => {
+	const theme = useTheme();
+	const activeBg = `linear-gradient(135deg, ${theme.palette.primary.light} 0%, ${theme.palette.primary.main} 100%)`;
+	const completedBg = `linear-gradient(135deg, ${alpha(theme.palette.primary.light, 0.5)} 0%, ${alpha(theme.palette.primary.main, 0.5)} 100%)`;
+
+	return (
+		<Stack
+			direction="row"
+			gap={theme.spacing(LAYOUT.XS)}
+			width="100%"
+		>
+			{Array.from({ length: steps }).map((_, index) => {
+				const background =
+					index < current
+						? completedBg
+						: index === current
+							? activeBg
+							: theme.palette.divider;
+				return (
+					<Box
+						key={index}
+						flex={1}
+						height={theme.spacing(LAYOUT.XXS)}
+						borderRadius={theme.shape.borderRadius}
+						sx={{ background, transition: "background 0.2s ease" }}
+					/>
+				);
+			})}
+		</Stack>
+	);
+};

--- a/client/src/Components/design-elements/index.tsx
+++ b/client/src/Components/design-elements/index.tsx
@@ -27,3 +27,4 @@ export * from "./OfflineBanner";
 export * from "./Avatar";
 export * from "./StatusCodeLabel";
 export * from "./StrategyBadge";
+export * from "./StepProgress";

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -16,6 +16,10 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	tags: data?.tags || [],
 	statusWindowSize: data?.statusWindowSize || 5,
 	statusWindowThreshold: data?.statusWindowThreshold || 60,
+});
+
+// Geo-check defaults — only http and ping support geo checks.
+const getGeoCheckDefaults = (data?: Monitor | null) => ({
 	geoCheckEnabled: data?.geoCheckEnabled ?? false,
 	geoCheckLocations: data?.geoCheckLocations || [],
 	geoCheckInterval: data?.geoCheckInterval || 300000,
@@ -33,6 +37,7 @@ export const getMonitorDefaults = (
 		case "http":
 			defaults = {
 				...base,
+				...getGeoCheckDefaults(data),
 				type: "http",
 				url: data?.url || "",
 				ignoreTlsErrors: data?.ignoreTlsErrors || false,
@@ -45,6 +50,7 @@ export const getMonitorDefaults = (
 		case "ping":
 			defaults = {
 				...base,
+				...getGeoCheckDefaults(data),
 				type: "ping",
 				url: data?.url || "",
 			};
@@ -124,6 +130,7 @@ export const getMonitorDefaults = (
 		default:
 			defaults = {
 				...base,
+				...getGeoCheckDefaults(data),
 				type: "http",
 				url: "",
 				ignoreTlsErrors: false,

--- a/client/src/Hooks/useMonitorForm.ts
+++ b/client/src/Hooks/useMonitorForm.ts
@@ -21,121 +21,128 @@ const getBaseDefaults = (data?: Monitor | null) => ({
 	geoCheckInterval: data?.geoCheckInterval || 300000,
 });
 
+export const getMonitorDefaults = (
+	type: MonitorType,
+	data: Monitor | null = null
+): MonitorFormData => {
+	const base = getBaseDefaults(data);
+
+	let defaults: MonitorFormData;
+
+	switch (type) {
+		case "http":
+			defaults = {
+				...base,
+				type: "http",
+				url: data?.url || "",
+				ignoreTlsErrors: data?.ignoreTlsErrors || false,
+				useAdvancedMatching: data?.useAdvancedMatching || false,
+				matchMethod: data?.matchMethod || "",
+				expectedValue: data?.expectedValue || "",
+				jsonPath: data?.jsonPath || "",
+			};
+			break;
+		case "ping":
+			defaults = {
+				...base,
+				type: "ping",
+				url: data?.url || "",
+			};
+			break;
+		case "port":
+			defaults = {
+				...base,
+				type: "port",
+				url: data?.url || "",
+				port: data?.port || 80,
+			};
+			break;
+		case "docker":
+			defaults = {
+				...base,
+				type: "docker",
+				url: data?.url || "",
+			};
+			break;
+		case "game":
+			defaults = {
+				...base,
+				type: "game",
+				url: data?.url || "",
+				port: data?.port || 27015,
+				gameId: data?.gameId || "",
+			};
+			break;
+		case "grpc":
+			defaults = {
+				...base,
+				type: "grpc",
+				url: data?.url || "",
+				port: data?.port || 50051,
+				grpcServiceName: data?.grpcServiceName || "",
+				ignoreTlsErrors: data?.ignoreTlsErrors || false,
+			};
+			break;
+		case "pagespeed":
+			defaults = {
+				...base,
+				type: "pagespeed",
+				url: data?.url || "",
+				strategy: data?.strategy ?? DefaultPageSpeedStrategy,
+			};
+			break;
+		case "hardware":
+			defaults = {
+				...base,
+				type: "hardware",
+				url: data?.url || "",
+				secret: data?.secret || "",
+				cpuAlertThreshold: data?.cpuAlertThreshold ?? 100,
+				memoryAlertThreshold: data?.memoryAlertThreshold ?? 100,
+				diskAlertThreshold: data?.diskAlertThreshold ?? 100,
+				tempAlertThreshold: data?.tempAlertThreshold ?? 100,
+				selectedDisks: data?.selectedDisks || [],
+			};
+			break;
+		case "websocket":
+			defaults = {
+				...base,
+				type: "websocket",
+				url: data?.url || "",
+				ignoreTlsErrors: data?.ignoreTlsErrors || false,
+			};
+			break;
+		case "dns":
+			defaults = {
+				...base,
+				type: "dns",
+				url: data?.url || "",
+				dnsServer: data?.dnsServer || "",
+				dnsRecordType: data?.dnsRecordType || "A",
+			};
+			break;
+		default:
+			defaults = {
+				...base,
+				type: "http",
+				url: "",
+				ignoreTlsErrors: false,
+				useAdvancedMatching: false,
+				matchMethod: "",
+				expectedValue: "",
+				jsonPath: "",
+			};
+	}
+
+	return defaults;
+};
+
 export const useMonitorForm = ({
 	data = null,
 	defaultType = "http",
 }: UseMonitorFormOptions = {}) => {
 	return useMemo(() => {
 		const type = data?.type || defaultType;
-		const base = getBaseDefaults(data);
-
-		let defaults: MonitorFormData;
-
-		switch (type) {
-			case "http":
-				defaults = {
-					...base,
-					type: "http",
-					url: data?.url || "",
-					ignoreTlsErrors: data?.ignoreTlsErrors || false,
-					useAdvancedMatching: data?.useAdvancedMatching || false,
-					matchMethod: data?.matchMethod || "",
-					expectedValue: data?.expectedValue || "",
-					jsonPath: data?.jsonPath || "",
-				};
-				break;
-			case "ping":
-				defaults = {
-					...base,
-					type: "ping",
-					url: data?.url || "",
-				};
-				break;
-			case "port":
-				defaults = {
-					...base,
-					type: "port",
-					url: data?.url || "",
-					port: data?.port || 80,
-				};
-				break;
-			case "docker":
-				defaults = {
-					...base,
-					type: "docker",
-					url: data?.url || "",
-				};
-				break;
-			case "game":
-				defaults = {
-					...base,
-					type: "game",
-					url: data?.url || "",
-					port: data?.port || 27015,
-					gameId: data?.gameId || "",
-				};
-				break;
-			case "grpc":
-				defaults = {
-					...base,
-					type: "grpc",
-					url: data?.url || "",
-					port: data?.port || 50051,
-					grpcServiceName: data?.grpcServiceName || "",
-					ignoreTlsErrors: data?.ignoreTlsErrors || false,
-				};
-				break;
-			case "pagespeed":
-				defaults = {
-					...base,
-					type: "pagespeed",
-					url: data?.url || "",
-					strategy: data?.strategy ?? DefaultPageSpeedStrategy,
-				};
-				break;
-			case "hardware":
-				defaults = {
-					...base,
-					type: "hardware",
-					url: data?.url || "",
-					secret: data?.secret || "",
-					cpuAlertThreshold: data?.cpuAlertThreshold ?? 100,
-					memoryAlertThreshold: data?.memoryAlertThreshold ?? 100,
-					diskAlertThreshold: data?.diskAlertThreshold ?? 100,
-					tempAlertThreshold: data?.tempAlertThreshold ?? 100,
-					selectedDisks: data?.selectedDisks || [],
-				};
-				break;
-			case "websocket":
-				defaults = {
-					...base,
-					type: "websocket",
-					url: data?.url || "",
-					ignoreTlsErrors: data?.ignoreTlsErrors || false,
-				};
-				break;
-			case "dns":
-				defaults = {
-					...base,
-					type: "dns",
-					url: data?.url || "",
-					dnsServer: data?.dnsServer || "",
-					dnsRecordType: data?.dnsRecordType || "A",
-				};
-				break;
-			default:
-				defaults = {
-					...base,
-					type: "http",
-					url: "",
-					ignoreTlsErrors: false,
-					useAdvancedMatching: false,
-					matchMethod: "",
-					expectedValue: "",
-					jsonPath: "",
-				};
-		}
-
-		return { schema: monitorSchema, defaults };
+		return { schema: monitorSchema, defaults: getMonitorDefaults(type, data) };
 	}, [data, defaultType]);
 };

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
 import { useForm, Controller } from "react-hook-form";
+import type { FieldPath } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTheme } from "@mui/material";
 import Stack from "@mui/material/Stack";
@@ -18,7 +19,12 @@ import { Trash2 } from "lucide-react";
 import { HeaderDeleteControls } from "@/Components/monitors";
 import { GeoContinents } from "@/Types/GeoCheck";
 
-import { BasePage, ColoredLabel, ConfigBox } from "@/Components/design-elements";
+import {
+	BasePage,
+	ColoredLabel,
+	ConfigBox,
+	StepProgress,
+} from "@/Components/design-elements";
 import {
 	RadioWithDescription,
 	Button,
@@ -207,6 +213,33 @@ const getGeneralSettingsConfig = (
 	return configs[type] || configs.http;
 };
 
+const TOTAL_STEPS = 3;
+
+// Fields validated before advancing past each wizard step (uptime create only).
+const STEP_FIELDS: FieldPath<MonitorFormData>[][] = [
+	[
+		"type",
+		"url",
+		"name",
+		"port",
+		"gameId",
+		"grpcServiceName",
+		"dnsServer",
+		"dnsRecordType",
+	],
+	["interval", "statusWindowSize", "statusWindowThreshold", "notifications", "tags"],
+	[
+		"ignoreTlsErrors",
+		"useAdvancedMatching",
+		"matchMethod",
+		"expectedValue",
+		"jsonPath",
+		"geoCheckEnabled",
+		"geoCheckLocations",
+		"geoCheckInterval",
+	],
+];
+
 const CreateMonitorPage = () => {
 	const theme = useTheme();
 	const { t } = useTranslation();
@@ -249,11 +282,24 @@ const CreateMonitorPage = () => {
 		resolver: zodResolver(schema),
 		defaultValues: defaults,
 	});
-	const { control, watch, handleSubmit, clearErrors } = form;
+	const { control, watch, handleSubmit, clearErrors, trigger } = form;
 
 	useEffect(() => {
 		form.reset(defaults);
 	}, [defaults, form]);
+
+	// Multi-step wizard (uptime create only). Other flows keep the flat form.
+	const isWizard = showTypeSelector;
+	const [currentStep, setCurrentStep] = useState(0);
+	const showStep = (step: number) => !isWizard || currentStep === step;
+
+	const handleNext = async () => {
+		const isValid = await trigger(STEP_FIELDS[currentStep]);
+		if (isValid) {
+			setCurrentStep((step) => Math.min(step + 1, TOTAL_STEPS - 1));
+		}
+	};
+	const handleBack = () => setCurrentStep((step) => Math.max(step - 1, 0));
 
 	const watchedType = watch("type") as MonitorType;
 
@@ -332,8 +378,14 @@ const CreateMonitorPage = () => {
 				refetch={refetchMonitor}
 				onDelete={handleDeleteClick}
 			/>
+			{isWizard && (
+				<StepProgress
+					steps={TOTAL_STEPS}
+					current={currentStep}
+				/>
+			)}
 			{/* Monitor Type Selection - only shown for uptime monitors */}
-			{showTypeSelector && (
+			{showTypeSelector && showStep(0) && (
 				<ConfigBox
 					title={t("pages.createMonitor.form.type.title")}
 					subtitle={t("pages.createMonitor.form.type.description")}
@@ -411,331 +463,341 @@ const CreateMonitorPage = () => {
 				/>
 			)}
 
-			<ConfigBox
-				title={t("pages.createMonitor.form.general.title")}
-				subtitle={
-					<Trans
-						i18nKey={`pages.createMonitor.form.general.description.${watchedType}`}
-						components={{
-							gamedigLink: (
-								<Link
-									href="https://github.com/gamedig/node-gamedig/blob/master/GAMES_LIST.md"
-									target="_blank"
-									rel="noopener noreferrer"
-								/>
-							),
-						}}
-					/>
-				}
-				rightContent={
-					<Stack spacing={theme.spacing(LAYOUT.MD)}>
-						{/* URL/Host/Container field - not shown for hardware */}
-						{generalSettingsConfig.showUrl && (
-							<Controller
-								name="url"
-								control={control}
-								render={({ field, fieldState }) => (
-									<TextField
-										{...field}
-										type="text"
-										fieldLabel={generalSettingsConfig.urlLabel}
-										placeholder={generalSettingsConfig.urlPlaceholder}
-										fullWidth
-										disabled={isEditMode}
-										error={!!fieldState.error}
-										helperText={fieldState.error?.message ?? ""}
+			{showStep(0) && (
+				<ConfigBox
+					title={t("pages.createMonitor.form.general.title")}
+					subtitle={
+						<Trans
+							i18nKey={`pages.createMonitor.form.general.description.${watchedType}`}
+							components={{
+								gamedigLink: (
+									<Link
+										href="https://github.com/gamedig/node-gamedig/blob/master/GAMES_LIST.md"
+										target="_blank"
+										rel="noopener noreferrer"
 									/>
-								)}
-							/>
-						)}
-
-						{/* Strategy field - only for pagespeed type */}
-						{generalSettingsConfig.showStrategy && (
-							<Controller
-								name="strategy"
-								control={control}
-								render={({ field, fieldState }) => (
-									<Select
-										{...field}
-										value={field.value ?? DefaultPageSpeedStrategy}
-										fieldLabel={t(
-											"pages.createMonitor.form.general.option.strategy.label"
-										)}
-										error={!!fieldState.error}
-									>
-										<MenuItem value="desktop">
-											{t("pages.createMonitor.form.general.option.strategy.desktop")}
-										</MenuItem>
-										<MenuItem value="mobile">
-											{t("pages.createMonitor.form.general.option.strategy.mobile")}
-										</MenuItem>
-									</Select>
-								)}
-							/>
-						)}
-
-						{/* Port field - only for port and game types */}
-						{generalSettingsConfig.showPort && (
-							<Controller
-								name="port"
-								control={control}
-								render={({ field, fieldState }) => (
-									<TextField
-										{...field}
-										value={field.value === 0 ? "" : field.value}
-										onChange={(e) => {
-											const val = e.target.value;
-											field.onChange(val === "" ? 0 : Number(val));
-										}}
-										type="number"
-										fieldLabel={t("pages.createMonitor.form.general.option.port.label")}
-										placeholder={t(
-											"pages.createMonitor.form.general.option.port.placeholder"
-										)}
-										fullWidth
-										error={!!fieldState.error}
-										helperText={fieldState.error?.message ?? ""}
-									/>
-								)}
-							/>
-						)}
-
-						{/* Game select - only for game type */}
-						{generalSettingsConfig.showGameSelect && (
-							<Controller
-								name="gameId"
-								control={control}
-								render={({ field, fieldState }) => (
-									<Select
-										{...field}
-										value={field.value ?? ""}
-										fieldLabel={t("pages.createMonitor.form.general.option.game.label")}
-										error={!!fieldState.error}
-									>
-										<MenuItem value="">
-											{t("pages.createMonitor.form.general.option.game.placeholder")}{" "}
-										</MenuItem>
-										{games &&
-											Object.entries(games).map(([key, game]) => (
-												<MenuItem
-													key={key}
-													value={key}
-												>
-													{game.name}
-												</MenuItem>
-											))}
-									</Select>
-								)}
-							/>
-						)}
-
-						{/* gRPC Service Name field - only for grpc type */}
-						{generalSettingsConfig.showGrpcServiceName && (
-							<Controller
-								name="grpcServiceName"
-								control={control}
-								render={({ field, fieldState }) => (
-									<TextField
-										{...field}
-										value={field.value ?? ""}
-										type="text"
-										fieldLabel={t(
-											"pages.createMonitor.form.general.option.grpcServiceName.label"
-										)}
-										placeholder={t(
-											"pages.createMonitor.form.general.option.grpcServiceName.placeholder"
-										)}
-										fullWidth
-										error={!!fieldState.error}
-										helperText={fieldState.error?.message ?? ""}
-									/>
-								)}
-							/>
-						)}
-
-						{/* Secret field - only for hardware type */}
-						{generalSettingsConfig.showSecret && (
-							<Controller
-								name="secret"
-								control={control}
-								render={({ field, fieldState }) => (
-									<TextField
-										{...field}
-										value={field.value ?? ""}
-										type="text"
-										fieldLabel={t("pages.createMonitor.form.general.option.secret.label")}
-										placeholder={t(
-											"pages.createMonitor.form.general.option.secret.placeholder"
-										)}
-										fullWidth
-										error={!!fieldState.error}
-										helperText={fieldState.error?.message ?? ""}
-									/>
-								)}
-							/>
-						)}
-						{generalSettingsConfig.showDnsServer && (
-							<Controller
-								name="dnsServer"
-								control={control}
-								render={({ field, fieldState }) => (
-									<TextField
-										{...field}
-										value={field.value ?? ""}
-										type="text"
-										fieldLabel={t(
-											"pages.createMonitor.form.general.option.dnsServer.label"
-										)}
-										placeholder={t(
-											"pages.createMonitor.form.general.option.dnsServer.placeholder"
-										)}
-										fullWidth
-										error={!!fieldState.error}
-										helperText={fieldState.error?.message ?? ""}
-									/>
-								)}
-							/>
-						)}
-						{generalSettingsConfig.showDnsRecordType && (
-							<Controller
-								name="dnsRecordType"
-								control={control}
-								defaultValue="A"
-								render={({ field, fieldState }) => (
-									<Select
-										{...field}
-										value={field.value ?? "A"}
-										fieldLabel={t(
-											"pages.createMonitor.form.general.option.dnsRecordType.label"
-										)}
-										error={!!fieldState.error}
-									>
-										<MenuItem value={"A"}>
-											{t("pages.createMonitor.form.general.option.dnsRecordType.value.A")}
-										</MenuItem>
-										<MenuItem value={"AAAA"}>
-											{t(
-												"pages.createMonitor.form.general.option.dnsRecordType.value.AAAA"
-											)}
-										</MenuItem>
-										<MenuItem value={"CNAME"}>
-											{t(
-												"pages.createMonitor.form.general.option.dnsRecordType.value.CNAME"
-											)}
-										</MenuItem>
-										<MenuItem value={"MX"}>
-											{t(
-												"pages.createMonitor.form.general.option.dnsRecordType.value.MX"
-											)}
-										</MenuItem>
-										<MenuItem value={"NS"}>
-											{t(
-												"pages.createMonitor.form.general.option.dnsRecordType.value.NS"
-											)}
-										</MenuItem>
-										<MenuItem value={"TXT"}>
-											{t(
-												"pages.createMonitor.form.general.option.dnsRecordType.value.TXT"
-											)}
-										</MenuItem>
-									</Select>
-								)}
-							/>
-						)}
-
-						<Controller
-							name="name"
-							control={control}
-							render={({ field, fieldState }) => (
-								<TextField
-									{...field}
-									type="text"
-									fieldLabel={t("pages.createMonitor.form.general.option.name.label")}
-									placeholder={generalSettingsConfig.namePlaceholder}
-									fullWidth
-									error={!!fieldState.error}
-									helperText={fieldState.error?.message ?? ""}
+								),
+							}}
+						/>
+					}
+					rightContent={
+						<Stack spacing={theme.spacing(LAYOUT.MD)}>
+							{/* URL/Host/Container field - not shown for hardware */}
+							{generalSettingsConfig.showUrl && (
+								<Controller
+									name="url"
+									control={control}
+									render={({ field, fieldState }) => (
+										<TextField
+											{...field}
+											type="text"
+											fieldLabel={generalSettingsConfig.urlLabel}
+											placeholder={generalSettingsConfig.urlPlaceholder}
+											fullWidth
+											disabled={isEditMode}
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+										/>
+									)}
 								/>
 							)}
-						/>
-					</Stack>
-				}
-			/>
 
-			<ConfigBox
-				title={t("pages.createMonitor.form.frequency.title")}
-				subtitle={t("pages.createMonitor.form.frequency.description")}
-				rightContent={
-					<Controller
-						name="interval"
-						control={control}
-						render={({ field, fieldState }) => (
-							<Select
-								{...field}
-								value={field.value ?? 60000}
-								fieldLabel={t(
-									"pages.createMonitor.form.frequency.option.frequency.label"
+							{/* Strategy field - only for pagespeed type */}
+							{generalSettingsConfig.showStrategy && (
+								<Controller
+									name="strategy"
+									control={control}
+									render={({ field, fieldState }) => (
+										<Select
+											{...field}
+											value={field.value ?? DefaultPageSpeedStrategy}
+											fieldLabel={t(
+												"pages.createMonitor.form.general.option.strategy.label"
+											)}
+											error={!!fieldState.error}
+										>
+											<MenuItem value="desktop">
+												{t("pages.createMonitor.form.general.option.strategy.desktop")}
+											</MenuItem>
+											<MenuItem value="mobile">
+												{t("pages.createMonitor.form.general.option.strategy.mobile")}
+											</MenuItem>
+										</Select>
+									)}
+								/>
+							)}
+
+							{/* Port field - only for port and game types */}
+							{generalSettingsConfig.showPort && (
+								<Controller
+									name="port"
+									control={control}
+									render={({ field, fieldState }) => (
+										<TextField
+											{...field}
+											value={field.value === 0 ? "" : field.value}
+											onChange={(e) => {
+												const val = e.target.value;
+												field.onChange(val === "" ? 0 : Number(val));
+											}}
+											type="number"
+											fieldLabel={t("pages.createMonitor.form.general.option.port.label")}
+											placeholder={t(
+												"pages.createMonitor.form.general.option.port.placeholder"
+											)}
+											fullWidth
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+										/>
+									)}
+								/>
+							)}
+
+							{/* Game select - only for game type */}
+							{generalSettingsConfig.showGameSelect && (
+								<Controller
+									name="gameId"
+									control={control}
+									render={({ field, fieldState }) => (
+										<Select
+											{...field}
+											value={field.value ?? ""}
+											fieldLabel={t("pages.createMonitor.form.general.option.game.label")}
+											error={!!fieldState.error}
+										>
+											<MenuItem value="">
+												{t(
+													"pages.createMonitor.form.general.option.game.placeholder"
+												)}{" "}
+											</MenuItem>
+											{games &&
+												Object.entries(games).map(([key, game]) => (
+													<MenuItem
+														key={key}
+														value={key}
+													>
+														{game.name}
+													</MenuItem>
+												))}
+										</Select>
+									)}
+								/>
+							)}
+
+							{/* gRPC Service Name field - only for grpc type */}
+							{generalSettingsConfig.showGrpcServiceName && (
+								<Controller
+									name="grpcServiceName"
+									control={control}
+									render={({ field, fieldState }) => (
+										<TextField
+											{...field}
+											value={field.value ?? ""}
+											type="text"
+											fieldLabel={t(
+												"pages.createMonitor.form.general.option.grpcServiceName.label"
+											)}
+											placeholder={t(
+												"pages.createMonitor.form.general.option.grpcServiceName.placeholder"
+											)}
+											fullWidth
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+										/>
+									)}
+								/>
+							)}
+
+							{/* Secret field - only for hardware type */}
+							{generalSettingsConfig.showSecret && (
+								<Controller
+									name="secret"
+									control={control}
+									render={({ field, fieldState }) => (
+										<TextField
+											{...field}
+											value={field.value ?? ""}
+											type="text"
+											fieldLabel={t(
+												"pages.createMonitor.form.general.option.secret.label"
+											)}
+											placeholder={t(
+												"pages.createMonitor.form.general.option.secret.placeholder"
+											)}
+											fullWidth
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+										/>
+									)}
+								/>
+							)}
+							{generalSettingsConfig.showDnsServer && (
+								<Controller
+									name="dnsServer"
+									control={control}
+									render={({ field, fieldState }) => (
+										<TextField
+											{...field}
+											value={field.value ?? ""}
+											type="text"
+											fieldLabel={t(
+												"pages.createMonitor.form.general.option.dnsServer.label"
+											)}
+											placeholder={t(
+												"pages.createMonitor.form.general.option.dnsServer.placeholder"
+											)}
+											fullWidth
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+										/>
+									)}
+								/>
+							)}
+							{generalSettingsConfig.showDnsRecordType && (
+								<Controller
+									name="dnsRecordType"
+									control={control}
+									defaultValue="A"
+									render={({ field, fieldState }) => (
+										<Select
+											{...field}
+											value={field.value ?? "A"}
+											fieldLabel={t(
+												"pages.createMonitor.form.general.option.dnsRecordType.label"
+											)}
+											error={!!fieldState.error}
+										>
+											<MenuItem value={"A"}>
+												{t(
+													"pages.createMonitor.form.general.option.dnsRecordType.value.A"
+												)}
+											</MenuItem>
+											<MenuItem value={"AAAA"}>
+												{t(
+													"pages.createMonitor.form.general.option.dnsRecordType.value.AAAA"
+												)}
+											</MenuItem>
+											<MenuItem value={"CNAME"}>
+												{t(
+													"pages.createMonitor.form.general.option.dnsRecordType.value.CNAME"
+												)}
+											</MenuItem>
+											<MenuItem value={"MX"}>
+												{t(
+													"pages.createMonitor.form.general.option.dnsRecordType.value.MX"
+												)}
+											</MenuItem>
+											<MenuItem value={"NS"}>
+												{t(
+													"pages.createMonitor.form.general.option.dnsRecordType.value.NS"
+												)}
+											</MenuItem>
+											<MenuItem value={"TXT"}>
+												{t(
+													"pages.createMonitor.form.general.option.dnsRecordType.value.TXT"
+												)}
+											</MenuItem>
+										</Select>
+									)}
+								/>
+							)}
+
+							<Controller
+								name="name"
+								control={control}
+								render={({ field, fieldState }) => (
+									<TextField
+										{...field}
+										type="text"
+										fieldLabel={t("pages.createMonitor.form.general.option.name.label")}
+										placeholder={generalSettingsConfig.namePlaceholder}
+										fullWidth
+										error={!!fieldState.error}
+										helperText={fieldState.error?.message ?? ""}
+									/>
 								)}
-								error={!!fieldState.error}
-							>
-								<MenuItem value={15000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.fifteenSeconds"
+							/>
+						</Stack>
+					}
+				/>
+			)}
+
+			{showStep(1) && (
+				<ConfigBox
+					title={t("pages.createMonitor.form.frequency.title")}
+					subtitle={t("pages.createMonitor.form.frequency.description")}
+					rightContent={
+						<Controller
+							name="interval"
+							control={control}
+							render={({ field, fieldState }) => (
+								<Select
+									{...field}
+									value={field.value ?? 60000}
+									fieldLabel={t(
+										"pages.createMonitor.form.frequency.option.frequency.label"
 									)}
-								</MenuItem>
-								<MenuItem value={30000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.thirtySeconds"
-									)}
-								</MenuItem>
-								<MenuItem value={60000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.oneMinute"
-									)}
-								</MenuItem>
-								<MenuItem value={120000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.twoMinutes"
-									)}
-								</MenuItem>
-								<MenuItem value={180000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.threeMinutes"
-									)}
-								</MenuItem>
-								<MenuItem value={240000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.fourMinutes"
-									)}
-								</MenuItem>
-								<MenuItem value={300000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.fiveMinutes"
-									)}
-								</MenuItem>
-								<MenuItem value={600000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.tenMinutes"
-									)}
-								</MenuItem>
-								<MenuItem value={900000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.fifteenMinutes"
-									)}
-								</MenuItem>
-								<MenuItem value={1800000}>
-									{t(
-										"pages.createMonitor.form.frequency.option.frequency.value.thirtyMinutes"
-									)}
-								</MenuItem>
-							</Select>
-						)}
-					/>
-				}
-			/>
+									error={!!fieldState.error}
+								>
+									<MenuItem value={15000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.fifteenSeconds"
+										)}
+									</MenuItem>
+									<MenuItem value={30000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.thirtySeconds"
+										)}
+									</MenuItem>
+									<MenuItem value={60000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.oneMinute"
+										)}
+									</MenuItem>
+									<MenuItem value={120000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.twoMinutes"
+										)}
+									</MenuItem>
+									<MenuItem value={180000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.threeMinutes"
+										)}
+									</MenuItem>
+									<MenuItem value={240000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.fourMinutes"
+										)}
+									</MenuItem>
+									<MenuItem value={300000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.fiveMinutes"
+										)}
+									</MenuItem>
+									<MenuItem value={600000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.tenMinutes"
+										)}
+									</MenuItem>
+									<MenuItem value={900000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.fifteenMinutes"
+										)}
+									</MenuItem>
+									<MenuItem value={1800000}>
+										{t(
+											"pages.createMonitor.form.frequency.option.frequency.value.thirtyMinutes"
+										)}
+									</MenuItem>
+								</Select>
+							)}
+						/>
+					}
+				/>
+			)}
 
 			{/* Alert Thresholds - only for hardware type */}
-			{generalSettingsConfig.showSecret && (
+			{generalSettingsConfig.showSecret && showStep(1) && (
 				<ConfigBox
 					title={t("pages.createMonitor.form.thresholds.title")}
 					subtitle={t("pages.createMonitor.form.thresholds.description")}
@@ -818,216 +880,227 @@ const CreateMonitorPage = () => {
 				/>
 			)}
 
-			<ConfigBox
-				title={t("pages.createMonitor.form.incidents.title")}
-				subtitle={t("pages.createMonitor.form.incidents.description")}
-				rightContent={
-					<Stack spacing={theme.spacing(LAYOUT.MD)}>
-						<Controller
-							name="statusWindowSize"
-							control={control}
-							render={({ field }) => (
-								<SliderWithLabel
-									{...field}
-									sliderMaxWidth={{ xs: "100%", md: "50%" }}
-									fieldLabel={t("pages.createMonitor.form.incidents.option.checks.label")}
-									min={1}
-									max={25}
-									valueLabelDisplay="auto"
-								/>
-							)}
-						/>
-						<Controller
-							name="statusWindowThreshold"
-							control={control}
-							render={({ field }) => (
-								<SliderWithLabel
-									{...field}
-									sliderMaxWidth={{ xs: "100%", md: "50%" }}
-									fieldLabel={t(
-										"pages.createMonitor.form.incidents.option.percentage.label"
-									)}
-									min={1}
-									max={100}
-									valueLabelDisplay="auto"
-								/>
-							)}
-						/>
-					</Stack>
-				}
-			/>
-
-			<ConfigBox
-				title={t("pages.createMonitor.form.notifications.title")}
-				subtitle={t("pages.createMonitor.form.notifications.description")}
-				rightContent={
-					<Controller
-						name="notifications"
-						control={control}
-						render={({ field }) => {
-							// Map notifications to have 'name' property for Autocomplete
-							const notificationOptions = (notifications ?? []).map((n) => ({
-								...n,
-								name: n.notificationName,
-							}));
-							const selectedNotifications = notificationOptions.filter((n) =>
-								(field.value ?? []).includes(n.id)
-							);
-							return (
-								<Stack spacing={theme.spacing(LAYOUT.MD)}>
-									<Autocomplete
-										multiple
-										options={notificationOptions}
-										value={selectedNotifications}
-										getOptionLabel={(option) => option.name}
-										onChange={(_: unknown, newValue: typeof notificationOptions) => {
-											field.onChange(newValue.map((n) => n.id));
-										}}
-										isOptionEqualToValue={(option, value) => option.id === value.id}
-									/>
-									{selectedNotifications.length > 0 && (
-										<Stack
-											flex={1}
-											width="100%"
-										>
-											{selectedNotifications.map((notification, index) => (
-												<Stack
-													direction="row"
-													alignItems="center"
-													key={notification.id}
-													width="100%"
-												>
-													<Typography flexGrow={1}>
-														{notification.notificationName}
-													</Typography>
-													<IconButton
-														size="small"
-														onClick={() => {
-															field.onChange(
-																(field.value ?? []).filter(
-																	(id: string) => id !== notification.id
-																)
-															);
-														}}
-														aria-label="Remove notification"
-													>
-														<Trash2 size={16} />
-													</IconButton>
-													{index < selectedNotifications.length - 1 && <Divider />}
-												</Stack>
-											))}
-										</Stack>
-									)}
-								</Stack>
-							);
-						}}
-					/>
-				}
-			/>
-
-			<ConfigBox
-				title={t("pages.createMonitor.form.tags.title")}
-				subtitle={t("pages.createMonitor.form.tags.description")}
-				rightContent={
-					<Controller
-						name="tags"
-						control={control}
-						render={({ field }) => {
-							const tagOptions = tags ?? [];
-							const selectedTags = tagOptions.filter((tag) =>
-								(field.value ?? []).includes(tag.id)
-							);
-							return (
-								<Stack spacing={theme.spacing(LAYOUT.MD)}>
-									<Autocomplete
-										multiple
-										options={tagOptions}
-										value={selectedTags}
-										getOptionLabel={(option) => option.name}
-										onChange={(_: unknown, newValue: typeof tagOptions) => {
-											field.onChange(newValue.map((tag) => tag.id));
-										}}
-										isOptionEqualToValue={(option, value) => option.id === value.id}
-										renderOptionContent={(option) => (
-											<ColoredLabel
-												text={option.name}
-												color={option.color}
-											/>
-										)}
-									/>
-									{selectedTags.length > 0 && (
-										<Stack
-											flex={1}
-											gap={theme.spacing(SPACING.XL)}
-											width="100%"
-										>
-											{selectedTags.map((tag, index) => (
-												<Stack
-													direction="row"
-													justifyContent={"space-between"}
-													alignItems="center"
-													key={tag.id}
-													width="100%"
-												>
-													<ColoredLabel
-														text={tag.name}
-														color={tag.color}
-													/>
-													<div style={{ flexGrow: 1 }} />
-													<IconButton
-														size="small"
-														onClick={() => {
-															field.onChange(
-																(field.value ?? []).filter((id: string) => id !== tag.id)
-															);
-														}}
-														aria-label="Remove tag"
-													>
-														<Trash2 size={16} />
-													</IconButton>
-													{index < selectedTags.length - 1 && <Divider />}
-												</Stack>
-											))}
-										</Stack>
-									)}
-								</Stack>
-							);
-						}}
-					/>
-				}
-			/>
-
-			{(watchedType === "http" ||
-				watchedType === "grpc" ||
-				watchedType === "websocket") && (
+			{showStep(1) && (
 				<ConfigBox
-					title={t("pages.createMonitor.form.ignoreTls.title")}
-					subtitle={t("pages.createMonitor.form.ignoreTls.description")}
+					title={t("pages.createMonitor.form.incidents.title")}
+					subtitle={t("pages.createMonitor.form.incidents.description")}
+					rightContent={
+						<Stack spacing={theme.spacing(LAYOUT.MD)}>
+							<Controller
+								name="statusWindowSize"
+								control={control}
+								render={({ field }) => (
+									<SliderWithLabel
+										{...field}
+										sliderMaxWidth={{ xs: "100%", md: "50%" }}
+										fieldLabel={t(
+											"pages.createMonitor.form.incidents.option.checks.label"
+										)}
+										min={1}
+										max={25}
+										valueLabelDisplay="auto"
+									/>
+								)}
+							/>
+							<Controller
+								name="statusWindowThreshold"
+								control={control}
+								render={({ field }) => (
+									<SliderWithLabel
+										{...field}
+										sliderMaxWidth={{ xs: "100%", md: "50%" }}
+										fieldLabel={t(
+											"pages.createMonitor.form.incidents.option.percentage.label"
+										)}
+										min={1}
+										max={100}
+										valueLabelDisplay="auto"
+									/>
+								)}
+							/>
+						</Stack>
+					}
+				/>
+			)}
+
+			{showStep(1) && (
+				<ConfigBox
+					title={t("pages.createMonitor.form.notifications.title")}
+					subtitle={t("pages.createMonitor.form.notifications.description")}
 					rightContent={
 						<Controller
-							name="ignoreTlsErrors"
+							name="notifications"
 							control={control}
-							render={({ field }) => (
-								<Stack
-									direction="row"
-									alignItems="center"
-									spacing={theme.spacing(SPACING.LG)}
-								>
-									<Switch
-										checked={field.value ?? false}
-										onChange={(e) => field.onChange(e.target.checked)}
-									/>
-									<Typography>
-										{t("pages.createMonitor.form.ignoreTls.option.tls.label")}
-									</Typography>
-								</Stack>
-							)}
+							render={({ field }) => {
+								// Map notifications to have 'name' property for Autocomplete
+								const notificationOptions = (notifications ?? []).map((n) => ({
+									...n,
+									name: n.notificationName,
+								}));
+								const selectedNotifications = notificationOptions.filter((n) =>
+									(field.value ?? []).includes(n.id)
+								);
+								return (
+									<Stack spacing={theme.spacing(LAYOUT.MD)}>
+										<Autocomplete
+											multiple
+											options={notificationOptions}
+											value={selectedNotifications}
+											getOptionLabel={(option) => option.name}
+											onChange={(_: unknown, newValue: typeof notificationOptions) => {
+												field.onChange(newValue.map((n) => n.id));
+											}}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+										/>
+										{selectedNotifications.length > 0 && (
+											<Stack
+												flex={1}
+												width="100%"
+											>
+												{selectedNotifications.map((notification, index) => (
+													<Stack
+														direction="row"
+														alignItems="center"
+														key={notification.id}
+														width="100%"
+													>
+														<Typography flexGrow={1}>
+															{notification.notificationName}
+														</Typography>
+														<IconButton
+															size="small"
+															onClick={() => {
+																field.onChange(
+																	(field.value ?? []).filter(
+																		(id: string) => id !== notification.id
+																	)
+																);
+															}}
+															aria-label="Remove notification"
+														>
+															<Trash2 size={16} />
+														</IconButton>
+														{index < selectedNotifications.length - 1 && <Divider />}
+													</Stack>
+												))}
+											</Stack>
+										)}
+									</Stack>
+								);
+							}}
 						/>
 					}
 				/>
 			)}
 
-			{watchedType === "http" && (
+			{showStep(1) && (
+				<ConfigBox
+					title={t("pages.createMonitor.form.tags.title")}
+					subtitle={t("pages.createMonitor.form.tags.description")}
+					rightContent={
+						<Controller
+							name="tags"
+							control={control}
+							render={({ field }) => {
+								const tagOptions = tags ?? [];
+								const selectedTags = tagOptions.filter((tag) =>
+									(field.value ?? []).includes(tag.id)
+								);
+								return (
+									<Stack spacing={theme.spacing(LAYOUT.MD)}>
+										<Autocomplete
+											multiple
+											options={tagOptions}
+											value={selectedTags}
+											getOptionLabel={(option) => option.name}
+											onChange={(_: unknown, newValue: typeof tagOptions) => {
+												field.onChange(newValue.map((tag) => tag.id));
+											}}
+											isOptionEqualToValue={(option, value) => option.id === value.id}
+											renderOptionContent={(option) => (
+												<ColoredLabel
+													text={option.name}
+													color={option.color}
+												/>
+											)}
+										/>
+										{selectedTags.length > 0 && (
+											<Stack
+												flex={1}
+												gap={theme.spacing(SPACING.XL)}
+												width="100%"
+											>
+												{selectedTags.map((tag, index) => (
+													<Stack
+														direction="row"
+														justifyContent={"space-between"}
+														alignItems="center"
+														key={tag.id}
+														width="100%"
+													>
+														<ColoredLabel
+															text={tag.name}
+															color={tag.color}
+														/>
+														<div style={{ flexGrow: 1 }} />
+														<IconButton
+															size="small"
+															onClick={() => {
+																field.onChange(
+																	(field.value ?? []).filter(
+																		(id: string) => id !== tag.id
+																	)
+																);
+															}}
+															aria-label="Remove tag"
+														>
+															<Trash2 size={16} />
+														</IconButton>
+														{index < selectedTags.length - 1 && <Divider />}
+													</Stack>
+												))}
+											</Stack>
+										)}
+									</Stack>
+								);
+							}}
+						/>
+					}
+				/>
+			)}
+
+			{showStep(2) &&
+				(watchedType === "http" ||
+					watchedType === "grpc" ||
+					watchedType === "websocket") && (
+					<ConfigBox
+						title={t("pages.createMonitor.form.ignoreTls.title")}
+						subtitle={t("pages.createMonitor.form.ignoreTls.description")}
+						rightContent={
+							<Controller
+								name="ignoreTlsErrors"
+								control={control}
+								render={({ field }) => (
+									<Stack
+										direction="row"
+										alignItems="center"
+										spacing={theme.spacing(SPACING.LG)}
+									>
+										<Switch
+											checked={field.value ?? false}
+											onChange={(e) => field.onChange(e.target.checked)}
+										/>
+										<Typography>
+											{t("pages.createMonitor.form.ignoreTls.option.tls.label")}
+										</Typography>
+									</Stack>
+								)}
+							/>
+						}
+					/>
+				)}
+
+			{showStep(2) && watchedType === "http" && (
 				<ConfigBox
 					title={t("pages.createMonitor.form.advanced.title")}
 					subtitle={t("pages.createMonitor.form.advanced.description")}
@@ -1142,7 +1215,7 @@ const CreateMonitorPage = () => {
 				/>
 			)}
 
-			{supportsGeoCheck(watchedType) && (
+			{showStep(2) && supportsGeoCheck(watchedType) && (
 				<ConfigBox
 					title={t("pages.createMonitor.form.geoChecks.title")}
 					subtitle={t("pages.createMonitor.form.geoChecks.description")}
@@ -1278,16 +1351,38 @@ const CreateMonitorPage = () => {
 
 			<Stack
 				direction="row"
-				justifyContent="flex-end"
+				justifyContent={isWizard ? "space-between" : "flex-end"}
 			>
-				<Button
-					loading={isSubmitting}
-					type="submit"
-					variant="contained"
-					color="primary"
-				>
-					{t("common.buttons.save")}
-				</Button>
+				{isWizard && (
+					<Button
+						type="button"
+						variant="outlined"
+						color="secondary"
+						disabled={currentStep === 0}
+						onClick={handleBack}
+					>
+						{t("common.buttons.back")}
+					</Button>
+				)}
+				{isWizard && currentStep < TOTAL_STEPS - 1 ? (
+					<Button
+						type="button"
+						variant="contained"
+						color="primary"
+						onClick={handleNext}
+					>
+						{t("common.buttons.next")}
+					</Button>
+				) : (
+					<Button
+						loading={isSubmitting}
+						type="submit"
+						variant="contained"
+						color="primary"
+					>
+						{t("common.buttons.save")}
+					</Button>
+				)}
 			</Stack>
 			<Dialog
 				open={isDeleteDialogOpen}

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -1366,6 +1366,7 @@ const CreateMonitorPage = () => {
 				)}
 				{isWizard && currentStep < TOTAL_STEPS - 1 ? (
 					<Button
+						key="wizard-next"
 						type="button"
 						variant="contained"
 						color="primary"
@@ -1375,6 +1376,7 @@ const CreateMonitorPage = () => {
 					</Button>
 				) : (
 					<Button
+						key="wizard-save"
 						loading={isSubmitting}
 						type="submit"
 						variant="contained"

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -47,7 +47,11 @@ import {
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
 import type { Tag } from "@/Types/Tag";
-import { stepFieldsFor, type MonitorFormData } from "@/Validation/monitor";
+import {
+	stepFieldsFor,
+	monitorStepCount,
+	type MonitorFormData,
+} from "@/Validation/monitor";
 
 interface GeneralSettingsConfig {
 	urlLabel: string;
@@ -213,11 +217,6 @@ const getGeneralSettingsConfig = (
 	return configs[type] || configs.http;
 };
 
-// Whether the wizard's "Advanced" step (TLS / matching / geo) has any content
-// for this monitor type. Types without it skip the step entirely.
-const hasAdvancedStep = (type: MonitorType): boolean =>
-	type === "http" || type === "grpc" || type === "websocket" || supportsGeoCheck(type);
-
 const CreateMonitorPage = () => {
 	const theme = useTheme();
 	const { t } = useTranslation();
@@ -276,7 +275,7 @@ const CreateMonitorPage = () => {
 	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
 
 	// Steps without an advanced section drop it, so the last step is the form's.
-	const totalSteps = hasAdvancedStep(watchedType) ? 3 : 2;
+	const totalSteps = monitorStepCount(watchedType);
 
 	const handleNext = async () => {
 		const isValid = await trigger(

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/Components/inputs";
 import { SPACING, LAYOUT } from "@/Utils/Theme/constants";
 import { useGet, usePost, usePatch, useDelete } from "@/Hooks/UseApi";
-import { useMonitorForm } from "@/Hooks/useMonitorForm";
+import { useMonitorForm, getMonitorDefaults } from "@/Hooks/useMonitorForm";
 import {
 	type Monitor,
 	type MonitorType,
@@ -213,7 +213,10 @@ const getGeneralSettingsConfig = (
 	return configs[type] || configs.http;
 };
 
-const TOTAL_STEPS = 3;
+// Whether the wizard's "Advanced" step (TLS / matching / geo) has any content
+// for this monitor type. Types without it skip the step entirely.
+const hasAdvancedStep = (type: MonitorType): boolean =>
+	type === "http" || type === "grpc" || type === "websocket" || supportsGeoCheck(type);
 
 // Fields validated before advancing past each wizard step (uptime create only).
 const STEP_FIELDS: FieldPath<MonitorFormData>[][] = [
@@ -282,33 +285,41 @@ const CreateMonitorPage = () => {
 		resolver: zodResolver(schema),
 		defaultValues: defaults,
 	});
-	const { control, watch, handleSubmit, clearErrors, trigger } = form;
+	const { control, watch, handleSubmit, clearErrors, trigger, reset } = form;
 
 	useEffect(() => {
-		form.reset(defaults);
-	}, [defaults, form]);
+		reset(defaults);
+	}, [defaults, reset]);
 
-	// Multi-step wizard (uptime create only). Other flows keep the flat form.
-	const isWizard = showTypeSelector;
+	// Multi-step wizard, uptime create only (showTypeSelector). Other flows
+	// keep the flat form, where showStep() is always true.
 	const [currentStep, setCurrentStep] = useState(0);
-	const showStep = (step: number) => !isWizard || currentStep === step;
+	const showStep = (step: number) => !showTypeSelector || currentStep === step;
+
+	const watchedType = watch("type") as MonitorType;
+	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
+	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
+
+	// Steps without an advanced section drop it, so the last step is the form's.
+	const totalSteps = hasAdvancedStep(watchedType) ? 3 : 2;
 
 	const handleNext = async () => {
 		const isValid = await trigger(STEP_FIELDS[currentStep]);
 		if (isValid) {
-			setCurrentStep((step) => Math.min(step + 1, TOTAL_STEPS - 1));
+			setCurrentStep((step) => step + 1);
 		}
 	};
-	const handleBack = () => setCurrentStep((step) => Math.max(step - 1, 0));
+	const handleBack = () => setCurrentStep((step) => step - 1);
 
-	const watchedType = watch("type") as MonitorType;
-
-	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
-	const watchGeoCheckEnabled = watch("geoCheckEnabled") as boolean;
-
+	// Reset the form when the monitor type changes so stale type-specific fields
+	// can't produce an invalid monitor. Type can only be changed on step 0.
 	useEffect(() => {
-		clearErrors();
-	}, [watchedType, clearErrors]);
+		if (showTypeSelector) {
+			reset(getMonitorDefaults(watchedType));
+		} else {
+			clearErrors();
+		}
+	}, [watchedType, showTypeSelector, reset, clearErrors]);
 
 	const generalSettingsConfig = useMemo(
 		() => getGeneralSettingsConfig(watchedType, t),
@@ -378,9 +389,9 @@ const CreateMonitorPage = () => {
 				refetch={refetchMonitor}
 				onDelete={handleDeleteClick}
 			/>
-			{isWizard && (
+			{showTypeSelector && (
 				<StepProgress
-					steps={TOTAL_STEPS}
+					steps={totalSteps}
 					current={currentStep}
 				/>
 			)}
@@ -1351,9 +1362,9 @@ const CreateMonitorPage = () => {
 
 			<Stack
 				direction="row"
-				justifyContent={isWizard ? "space-between" : "flex-end"}
+				justifyContent={showTypeSelector ? "space-between" : "flex-end"}
 			>
-				{isWizard && (
+				{showTypeSelector && (
 					<Button
 						type="button"
 						variant="outlined"
@@ -1364,7 +1375,7 @@ const CreateMonitorPage = () => {
 						{t("common.buttons.back")}
 					</Button>
 				)}
-				{isWizard && currentStep < TOTAL_STEPS - 1 ? (
+				{showTypeSelector && currentStep < totalSteps - 1 ? (
 					<Button
 						key="wizard-next"
 						type="button"

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
 import type { Tag } from "@/Types/Tag";
-import type { MonitorFormData } from "@/Validation/monitor";
+import { monitorFieldsByType, type MonitorFormData } from "@/Validation/monitor";
 
 interface GeneralSettingsConfig {
 	urlLabel: string;
@@ -218,30 +218,31 @@ const getGeneralSettingsConfig = (
 const hasAdvancedStep = (type: MonitorType): boolean =>
 	type === "http" || type === "grpc" || type === "websocket" || supportsGeoCheck(type);
 
-// Fields validated before advancing past each wizard step (uptime create only).
-const STEP_FIELDS: FieldPath<MonitorFormData>[][] = [
-	[
-		"type",
-		"url",
-		"name",
-		"port",
-		"gameId",
-		"grpcServiceName",
-		"dnsServer",
-		"dnsRecordType",
-	],
-	["interval", "statusWindowSize", "statusWindowThreshold", "notifications", "tags"],
-	[
-		"ignoreTlsErrors",
-		"useAdvancedMatching",
-		"matchMethod",
-		"expectedValue",
-		"jsonPath",
-		"geoCheckEnabled",
-		"geoCheckLocations",
-		"geoCheckInterval",
-	],
-];
+// The wizard step on which each field is validated. Fields not listed default
+// to step 0, so a field added to the schema is validated by default rather than
+// silently skipped. Step membership is the only thing hardcoded here; the field
+// set itself is derived from the schema via `monitorFieldsByType`.
+const FIELD_STEP: Record<string, number> = {
+	interval: 1,
+	statusWindowSize: 1,
+	statusWindowThreshold: 1,
+	notifications: 1,
+	tags: 1,
+	ignoreTlsErrors: 2,
+	useAdvancedMatching: 2,
+	matchMethod: 2,
+	expectedValue: 2,
+	jsonPath: 2,
+	geoCheckEnabled: 2,
+	geoCheckLocations: 2,
+	geoCheckInterval: 2,
+};
+
+// Exactly the selected type's fields that belong to the given step.
+const stepFieldsFor = (type: MonitorType, step: number): FieldPath<MonitorFormData>[] =>
+	(monitorFieldsByType[type] ?? []).filter(
+		(field) => (FIELD_STEP[field] ?? 0) === step
+	) as FieldPath<MonitorFormData>[];
 
 const CreateMonitorPage = () => {
 	const theme = useTheme();
@@ -304,7 +305,7 @@ const CreateMonitorPage = () => {
 	const totalSteps = hasAdvancedStep(watchedType) ? 3 : 2;
 
 	const handleNext = async () => {
-		const isValid = await trigger(STEP_FIELDS[currentStep]);
+		const isValid = await trigger(stepFieldsFor(watchedType, currentStep));
 		if (isValid) {
 			setCurrentStep((step) => step + 1);
 		}

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -47,7 +47,7 @@ import {
 } from "@/Types/Monitor";
 import type { Notification } from "@/Types/Notification";
 import type { Tag } from "@/Types/Tag";
-import { monitorFieldsByType, type MonitorFormData } from "@/Validation/monitor";
+import { stepFieldsFor, type MonitorFormData } from "@/Validation/monitor";
 
 interface GeneralSettingsConfig {
 	urlLabel: string;
@@ -218,32 +218,6 @@ const getGeneralSettingsConfig = (
 const hasAdvancedStep = (type: MonitorType): boolean =>
 	type === "http" || type === "grpc" || type === "websocket" || supportsGeoCheck(type);
 
-// The wizard step on which each field is validated. Fields not listed default
-// to step 0, so a field added to the schema is validated by default rather than
-// silently skipped. Step membership is the only thing hardcoded here; the field
-// set itself is derived from the schema via `monitorFieldsByType`.
-const FIELD_STEP: Record<string, number> = {
-	interval: 1,
-	statusWindowSize: 1,
-	statusWindowThreshold: 1,
-	notifications: 1,
-	tags: 1,
-	ignoreTlsErrors: 2,
-	useAdvancedMatching: 2,
-	matchMethod: 2,
-	expectedValue: 2,
-	jsonPath: 2,
-	geoCheckEnabled: 2,
-	geoCheckLocations: 2,
-	geoCheckInterval: 2,
-};
-
-// Exactly the selected type's fields that belong to the given step.
-const stepFieldsFor = (type: MonitorType, step: number): FieldPath<MonitorFormData>[] =>
-	(monitorFieldsByType[type] ?? []).filter(
-		(field) => (FIELD_STEP[field] ?? 0) === step
-	) as FieldPath<MonitorFormData>[];
-
 const CreateMonitorPage = () => {
 	const theme = useTheme();
 	const { t } = useTranslation();
@@ -305,7 +279,9 @@ const CreateMonitorPage = () => {
 	const totalSteps = hasAdvancedStep(watchedType) ? 3 : 2;
 
 	const handleNext = async () => {
-		const isValid = await trigger(stepFieldsFor(watchedType, currentStep));
+		const isValid = await trigger(
+			stepFieldsFor(watchedType, currentStep) as FieldPath<MonitorFormData>[]
+		);
 		if (isValid) {
 			setCurrentStep((step) => step + 1);
 		}

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -3,7 +3,6 @@ import { useEffect } from "react";
 import { logger } from "@/Utils/logger";
 import { useParams, useLocation, useNavigate } from "react-router";
 import { useForm, Controller } from "react-hook-form";
-import type { FieldPath } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useTheme } from "@mui/material";
 import Stack from "@mui/material/Stack";
@@ -278,9 +277,7 @@ const CreateMonitorPage = () => {
 	const totalSteps = monitorStepCount(watchedType);
 
 	const handleNext = async () => {
-		const isValid = await trigger(
-			stepFieldsFor(watchedType, currentStep) as FieldPath<MonitorFormData>[]
-		);
+		const isValid = await trigger(stepFieldsFor(watchedType, currentStep));
 		if (isValid) {
 			setCurrentStep((step) => step + 1);
 		}

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -2,6 +2,11 @@ import { z } from "zod";
 import { GeoContinents } from "@/Types/GeoCheck";
 import { DnsRecordTypes, PageSpeedStrategies, type MonitorType } from "@/Types/Monitor";
 
+// Wizard step a field is validated on. Attached inline to each field below so
+// the grouping lives next to the field definition; unannotated fields default
+// to step 0. Read via `stepFieldsFor`.
+export const monitorStepRegistry = z.registry<{ step: number }>();
+
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
 
@@ -12,34 +17,46 @@ const baseSchema = z.object({
 		.min(1, "Monitor name is required")
 		.max(50, "Monitor name must be at most 50 characters"),
 	description: z.string().optional(),
-	interval: z.number().min(15000, "Interval must be at least 15 seconds"),
-	notifications: z.array(z.string()),
-	tags: z.array(z.string()),
+	interval: z
+		.number()
+		.min(15000, "Interval must be at least 15 seconds")
+		.register(monitorStepRegistry, { step: 1 }),
+	notifications: z.array(z.string()).register(monitorStepRegistry, { step: 1 }),
+	tags: z.array(z.string()).register(monitorStepRegistry, { step: 1 }),
 	statusWindowSize: z
 		.number({ message: "Status window size is required" })
 		.min(1, "Status window size must be at least 1")
-		.max(25, "Status window size must be at most 25"),
+		.max(25, "Status window size must be at most 25")
+		.register(monitorStepRegistry, { step: 1 }),
 	statusWindowThreshold: z
 		.number({ message: "Threshold percentage is required" })
 		.min(1, "Incident percentage must be at least 1")
-		.max(100, "Incident percentage must be at most 100"),
-	geoCheckEnabled: z.boolean().optional(),
-	geoCheckLocations: z.array(z.enum(GeoContinents)).optional(),
+		.max(100, "Incident percentage must be at most 100")
+		.register(monitorStepRegistry, { step: 1 }),
+	geoCheckEnabled: z.boolean().optional().register(monitorStepRegistry, { step: 2 }),
+	geoCheckLocations: z
+		.array(z.enum(GeoContinents))
+		.optional()
+		.register(monitorStepRegistry, { step: 2 }),
 	geoCheckInterval: z
 		.number()
 		.min(300000, "Interval must be at least 5 minutes")
-		.optional(),
+		.optional()
+		.register(monitorStepRegistry, { step: 2 }),
 });
 
 // HTTP monitor schema
 const httpSchema = baseSchema.extend({
 	type: z.literal("http"),
 	url: urlSchema,
-	ignoreTlsErrors: z.boolean(),
-	useAdvancedMatching: z.boolean(),
-	matchMethod: z.enum(["equal", "include", "regex", ""]).optional(),
-	expectedValue: z.string().optional(),
-	jsonPath: z.string().optional(),
+	ignoreTlsErrors: z.boolean().register(monitorStepRegistry, { step: 2 }),
+	useAdvancedMatching: z.boolean().register(monitorStepRegistry, { step: 2 }),
+	matchMethod: z
+		.enum(["equal", "include", "regex", ""])
+		.optional()
+		.register(monitorStepRegistry, { step: 2 }),
+	expectedValue: z.string().optional().register(monitorStepRegistry, { step: 2 }),
+	jsonPath: z.string().optional().register(monitorStepRegistry, { step: 2 }),
 });
 
 // Ping monitor schema
@@ -84,7 +101,7 @@ const grpcSchema = baseSchema.extend({
 		.min(1, "Port must be at least 1")
 		.max(65535, "Port must be at most 65535"),
 	grpcServiceName: z.string().optional(),
-	ignoreTlsErrors: z.boolean(),
+	ignoreTlsErrors: z.boolean().register(monitorStepRegistry, { step: 2 }),
 });
 
 // PageSpeed monitor schema
@@ -122,7 +139,7 @@ const hardwareSchema = baseSchema.extend({
 const websocketSchema = baseSchema.extend({
 	type: z.literal("websocket"),
 	url: z.string().min(1, "WebSocket URL is required"),
-	ignoreTlsErrors: z.boolean(),
+	ignoreTlsErrors: z.boolean().register(monitorStepRegistry, { step: 2 }),
 });
 
 // Hostname (FQDN) — labels of 1-63 alphanumerics/hyphens separated by dots,
@@ -164,15 +181,16 @@ export const monitorSchema = z.discriminatedUnion("type", [
 
 export type MonitorFormData = z.infer<typeof monitorSchema>;
 
-// Field names present in each monitor type's schema, derived from the schema
-// itself. Consumers (e.g. the create wizard's per-step validation) should read
-// this rather than hardcoding field lists, so renames/additions stay in sync.
-export const monitorFieldsByType = Object.fromEntries(
-	monitorSchema.options.map((option) => [
-		option.shape.type.value,
-		Object.keys(option.shape),
-	])
-) as Record<MonitorType, string[]>;
+// The selected type's fields that belong to a given wizard step, read from the
+// per-field `monitorStepRegistry` metadata (unannotated fields default to step
+// 0). Derived from the schema so it can't drift from the field definitions.
+export const stepFieldsFor = (type: MonitorType, step: number): string[] => {
+	const option = monitorSchema.options.find((o) => o.shape.type.value === type);
+	if (!option) return [];
+	return Object.entries(option.shape)
+		.filter(([, field]) => (monitorStepRegistry.get(field)?.step ?? 0) === step)
+		.map(([name]) => name);
+};
 
 // Type-specific schemas exported for individual use
 export {

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -33,6 +33,12 @@ const baseSchema = z.object({
 		.min(1, "Incident percentage must be at least 1")
 		.max(100, "Incident percentage must be at most 100")
 		.register(monitorStepRegistry, { step: 1 }),
+});
+
+// Geo-distributed check fields. Only http and ping support geo checks
+// (GeoCheckSupportedTypes), so these live on those schemas rather than the base
+// — that way each type's step count is exactly what its own fields declare.
+const geoCheckFields = {
 	geoCheckEnabled: z.boolean().optional().register(monitorStepRegistry, { step: 2 }),
 	geoCheckLocations: z
 		.array(z.enum(GeoContinents))
@@ -43,7 +49,7 @@ const baseSchema = z.object({
 		.min(300000, "Interval must be at least 5 minutes")
 		.optional()
 		.register(monitorStepRegistry, { step: 2 }),
-});
+};
 
 // HTTP monitor schema
 const httpSchema = baseSchema.extend({
@@ -57,12 +63,14 @@ const httpSchema = baseSchema.extend({
 		.register(monitorStepRegistry, { step: 2 }),
 	expectedValue: z.string().optional().register(monitorStepRegistry, { step: 2 }),
 	jsonPath: z.string().optional().register(monitorStepRegistry, { step: 2 }),
+	...geoCheckFields,
 });
 
 // Ping monitor schema
 const pingSchema = baseSchema.extend({
 	type: z.literal("ping"),
 	url: z.string().min(1, "Host is required"),
+	...geoCheckFields,
 });
 
 // Port monitor schema
@@ -181,16 +189,28 @@ export const monitorSchema = z.discriminatedUnion("type", [
 
 export type MonitorFormData = z.infer<typeof monitorSchema>;
 
-// The selected type's fields that belong to a given wizard step, read from the
-// per-field `monitorStepRegistry` metadata (unannotated fields default to step
-// 0). Derived from the schema so it can't drift from the field definitions.
-export const stepFieldsFor = (type: MonitorType, step: number): string[] => {
-	const option = monitorSchema.options.find((o) => o.shape.type.value === type);
-	if (!option) return [];
-	return Object.entries(option.shape)
-		.filter(([, field]) => (monitorStepRegistry.get(field)?.step ?? 0) === step)
+const optionForType = (type: MonitorType) =>
+	monitorSchema.options.find((o) => o.shape.type.value === type);
+
+// The step each field of a type is validated on, from the per-field
+// `monitorStepRegistry` metadata (unannotated fields default to step 0).
+const fieldStepsFor = (type: MonitorType): [name: string, step: number][] =>
+	Object.entries(optionForType(type)?.shape ?? {}).map(([name, field]) => [
+		name,
+		monitorStepRegistry.get(field)?.step ?? 0,
+	]);
+
+// The selected type's fields that belong to a given wizard step. Derived from
+// the schema so it can't drift from the field definitions.
+export const stepFieldsFor = (type: MonitorType, step: number): string[] =>
+	fieldStepsFor(type)
+		.filter(([, fieldStep]) => fieldStep === step)
 		.map(([name]) => name);
-};
+
+// Number of wizard steps a type has, derived from the highest step its fields
+// declare. A type with no step-2 fields is a 2-step form, and so on.
+export const monitorStepCount = (type: MonitorType): number =>
+	Math.max(0, ...fieldStepsFor(type).map(([, step]) => step)) + 1;
 
 // Type-specific schemas exported for individual use
 export {

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { GeoContinents } from "@/Types/GeoCheck";
-import { DnsRecordTypes, PageSpeedStrategies } from "@/Types/Monitor";
+import { DnsRecordTypes, PageSpeedStrategies, type MonitorType } from "@/Types/Monitor";
 
 // URL schema with custom error message
 const urlSchema = z.url({ message: "Please enter a valid URL" });
@@ -163,6 +163,16 @@ export const monitorSchema = z.discriminatedUnion("type", [
 ]);
 
 export type MonitorFormData = z.infer<typeof monitorSchema>;
+
+// Field names present in each monitor type's schema, derived from the schema
+// itself. Consumers (e.g. the create wizard's per-step validation) should read
+// this rather than hardcoding field lists, so renames/additions stay in sync.
+export const monitorFieldsByType = Object.fromEntries(
+	monitorSchema.options.map((option) => [
+		option.shape.type.value,
+		Object.keys(option.shape),
+	])
+) as Record<MonitorType, string[]>;
 
 // Type-specific schemas exported for individual use
 export {

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { FieldPath } from "react-hook-form";
 import { GeoContinents } from "@/Types/GeoCheck";
 import { DnsRecordTypes, PageSpeedStrategies, type MonitorType } from "@/Types/Monitor";
 
@@ -194,15 +195,20 @@ const optionForType = (type: MonitorType) =>
 
 // The step each field of a type is validated on, from the per-field
 // `monitorStepRegistry` metadata (unannotated fields default to step 0).
-const fieldStepsFor = (type: MonitorType): [name: string, step: number][] =>
+const fieldStepsFor = (
+	type: MonitorType
+): [name: FieldPath<MonitorFormData>, step: number][] =>
 	Object.entries(optionForType(type)?.shape ?? {}).map(([name, field]) => [
-		name,
+		name as FieldPath<MonitorFormData>,
 		monitorStepRegistry.get(field)?.step ?? 0,
 	]);
 
 // The selected type's fields that belong to a given wizard step. Derived from
 // the schema so it can't drift from the field definitions.
-export const stepFieldsFor = (type: MonitorType, step: number): string[] =>
+export const stepFieldsFor = (
+	type: MonitorType,
+	step: number
+): FieldPath<MonitorFormData>[] =>
 	fieldStepsFor(type)
 		.filter(([, fieldStep]) => fieldStep === step)
 		.map(([name]) => name);

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -43,6 +43,8 @@
 			"pause": "Pause",
 			"resume": "Resume",
 			"save": "Save",
+			"next": "Next",
+			"back": "Back",
 			"sendInvite": "Send invite",
 			"test": "Test",
 			"testNotifications": "Test notifications",


### PR DESCRIPTION
## Describe your changes

Splits the overwhelming single-page "Create Uptime Monitor" form into a focused 3-step wizard (Basics → Monitoring → Advanced) with a slim segmented progress bar in Checkmate's green palette, validating each step before advancing. Scoped to uptime create only — edit/configure, pagespeed, and hardware flows keep the existing flat form unchanged.

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [ ] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1174" height="758" alt="Screenshot 2026-05-25 at 23 36 22" src="https://github.com/user-attachments/assets/daa3562b-bf31-4b6e-9a04-d18aca6b4e33" />
<img width="1169" height="743" alt="Screenshot 2026-05-25 at 23 36 51" src="https://github.com/user-attachments/assets/689492fb-abfe-4336-81fb-2150bcf72ef7" />
<img width="1189" height="561" alt="Screenshot 2026-05-25 at 23 40 35" src="https://github.com/user-attachments/assets/3e28b23d-cf49-4f4c-a4a8-3bee91cdfd7e" />
