### PR TITLE
feat: add manual monitor check action

### DIFF
--- a/client/src/Pages/Infrastructure/Monitors/Components/MonitorsTable.tsx
+++ b/client/src/Pages/Infrastructure/Monitors/Components/MonitorsTable.tsx
@@ -134,6 +134,15 @@ export const InfraMonitorsTable = ({
 				},
 			},
 			{
+				id: 5,
+				label: t("pages.common.monitors.actions.checkNow"),
+				action: async () => {
+					await post(`/monitors/check/${monitor.id}`, {});
+					refetch();
+				},
+				closeMenu: true,
+			},
+			{
 				id: 6,
 				label:
 					monitor.isActive === false

--- a/client/src/Pages/PageSpeed/Monitors/Components/PageSpeedMonitorsTable.tsx
+++ b/client/src/Pages/PageSpeed/Monitors/Components/PageSpeedMonitorsTable.tsx
@@ -18,7 +18,7 @@ import { useTranslation } from "react-i18next";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { useTheme } from "@mui/material/styles";
 import { useNavigate } from "react-router-dom";
-import { usePatch } from "@/Hooks/UseApi";
+import { usePatch, usePost } from "@/Hooks/UseApi";
 
 import type { Monitor, MonitorWithChecks } from "@/Types/Monitor";
 import type { Tag } from "@/Types/Tag";
@@ -62,6 +62,7 @@ export const PageSpeedMonitorsTable = ({
 		// loading: isPatching,
 		// error: postError,
 	} = usePatch<any, Monitor>();
+	const { post } = usePost<Record<string, never>, Monitor>();
 
 	const handlePageChange = (
 		_e: React.MouseEvent<HTMLButtonElement> | null,
@@ -122,13 +123,15 @@ export const PageSpeedMonitorsTable = ({
 					navigate(`/pagespeed/configure/${monitor.id}`);
 				},
 			},
-			// {
-			//   id: 5,
-			//   label: "Clone",
-			//   action: () => {
-
-			//   },
-			// },
+			{
+				id: 5,
+				label: t("pages.common.monitors.actions.checkNow"),
+				action: async () => {
+					await post(`/monitors/check/${monitor.id}`, {});
+					refetch();
+				},
+				closeMenu: true,
+			},
 			{
 				id: 6,
 				label:

--- a/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
+++ b/client/src/Pages/Uptime/Monitors/Components/UptimeMonitorsTable.tsx
@@ -139,6 +139,15 @@ export const MonitorTable = ({
 				},
 			},
 			{
+				id: 5,
+				label: t("pages.common.monitors.actions.checkNow"),
+				action: async () => {
+					await post(`/monitors/check/${monitor.id}`, {});
+					refetch();
+				},
+				closeMenu: true,
+			},
+			{
 				id: 6,
 				label:
 					monitor.isActive === false

--- a/client/src/locales/ar.json
+++ b/client/src/locales/ar.json
@@ -438,7 +438,8 @@
 					"selectAll": "تحديد جميع الشاشات",
 					"selectMonitor": "تحديد {{name}}",
 					"bulkSelected_one": "{{count}} شاشة محددة",
-					"bulkSelected_other": "{{count}} شاشات محددة"
+					"bulkSelected_other": "{{count}} شاشات محددة",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "نشط منذ",

--- a/client/src/locales/ca.json
+++ b/client/src/locales/ca.json
@@ -438,7 +438,8 @@
 					"bulkSelected_one": "{{count}} monitor seleccionat",
 					"bulkSelected_other": "{{count}} monitors seleccionats",
 					"selectAll": "Selecciona tots els monitors",
-					"selectMonitor": "Selecciona {{name}}"
+					"selectMonitor": "Selecciona {{name}}",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Actiu des de",

--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -438,7 +438,8 @@
 					"selectAll": "Vybrat všechny monitory",
 					"selectMonitor": "Vybrat {{name}}",
 					"bulkSelected_one": "Vybrán {{count}} monitor",
-					"bulkSelected_other": "Vybráno {{count}} monitorů"
+					"bulkSelected_other": "Vybráno {{count}} monitorů",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Aktivní po dobu",

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -438,7 +438,8 @@
 					"selectAll": "Alle Monitore auswählen",
 					"selectMonitor": "{{name}} auswählen",
 					"bulkSelected_one": "{{count}} Monitor ausgewählt",
-					"bulkSelected_other": "{{count}} Monitore ausgewählt"
+					"bulkSelected_other": "{{count}} Monitore ausgewählt",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Aktiv seit",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -440,7 +440,8 @@
 					"bulkSelected_one": "{{count}} monitor selected",
 					"bulkSelected_other": "{{count}} monitors selected",
 					"selectAll": "Select all monitors",
-					"selectMonitor": "Select {{name}}"
+					"selectMonitor": "Select {{name}}",
+					"checkNow": "Check now"
 				},
 				"bulkPause": {
 					"alreadyPaused_one": "The selected monitor is already paused",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -438,7 +438,8 @@
 					"selectAll": "Seleccionar todos los monitores",
 					"selectMonitor": "Seleccionar {{name}}",
 					"bulkSelected_one": "{{count}} monitor seleccionado",
-					"bulkSelected_other": "{{count}} monitores seleccionados"
+					"bulkSelected_other": "{{count}} monitores seleccionados",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Activo desde hace",

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -438,7 +438,8 @@
 					"selectAll": "Valitse kaikki näytöt",
 					"selectMonitor": "Valitse {{name}}",
 					"bulkSelected_one": "{{count}} näyttö valittu",
-					"bulkSelected_other": "{{count}} näyttöä valittu"
+					"bulkSelected_other": "{{count}} näyttöä valittu",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Aktiivinen",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -438,7 +438,8 @@
 					"selectAll": "Sélectionner tous les moniteurs",
 					"selectMonitor": "Sélectionner {{name}}",
 					"bulkSelected_one": "{{count}} moniteur sélectionné",
-					"bulkSelected_other": "{{count}} moniteurs sélectionnés"
+					"bulkSelected_other": "{{count}} moniteurs sélectionnés",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Actif depuis",

--- a/client/src/locales/ja.json
+++ b/client/src/locales/ja.json
@@ -438,7 +438,8 @@
 					"selectAll": "すべてのモニターを選択",
 					"selectMonitor": "{{name}} を選択",
 					"bulkSelected_one": "{{count}} 個のモニターが選択されました",
-					"bulkSelected_other": "{{count}} 個のモニターが選択されました"
+					"bulkSelected_other": "{{count}} 個のモニターが選択されました",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "稼働期間",

--- a/client/src/locales/pt-BR.json
+++ b/client/src/locales/pt-BR.json
@@ -438,7 +438,8 @@
 					"selectAll": "Selecionar todos os monitores",
 					"selectMonitor": "Selecionar {{name}}",
 					"bulkSelected_one": "{{count}} monitor selecionado",
-					"bulkSelected_other": "{{count}} monitores selecionados"
+					"bulkSelected_other": "{{count}} monitores selecionados",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Ativo há",

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -438,7 +438,8 @@
 					"selectAll": "Выбрать все мониторы",
 					"selectMonitor": "Выбрать {{name}}",
 					"bulkSelected_one": "Выбран {{count}} монитор",
-					"bulkSelected_other": "Выбрано {{count}} мониторов"
+					"bulkSelected_other": "Выбрано {{count}} мониторов",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Активен",

--- a/client/src/locales/th.json
+++ b/client/src/locales/th.json
@@ -438,7 +438,8 @@
 					"selectAll": "เลือกจอภาพทั้งหมด",
 					"selectMonitor": "เลือก {{name}}",
 					"bulkSelected_one": "เลือกแล้ว {{count}} จอภาพ",
-					"bulkSelected_other": "เลือกแล้ว {{count}} จอภาพ"
+					"bulkSelected_other": "เลือกแล้ว {{count}} จอภาพ",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "ทำงานมาแล้ว",

--- a/client/src/locales/tr.json
+++ b/client/src/locales/tr.json
@@ -438,7 +438,8 @@
 					"selectAll": "Tüm monitörleri seç",
 					"selectMonitor": "{{name}}'i seç",
 					"bulkSelected_one": "{{count}} monitör seçildi",
-					"bulkSelected_other": "{{count}} monitör seçildi"
+					"bulkSelected_other": "{{count}} monitör seçildi",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Aktif süresi",

--- a/client/src/locales/uk.json
+++ b/client/src/locales/uk.json
@@ -438,7 +438,8 @@
 					"selectAll": "Вибрати всі монітори",
 					"selectMonitor": "Вибрати {{name}}",
 					"bulkSelected_one": "Вибрано {{count}} монітор",
-					"bulkSelected_other": "Вибрано {{count}} моніторів"
+					"bulkSelected_other": "Вибрано {{count}} моніторів",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Активний протягом",

--- a/client/src/locales/vi.json
+++ b/client/src/locales/vi.json
@@ -438,7 +438,8 @@
 					"selectAll": "Chọn tất cả màn hình",
 					"selectMonitor": "Chọn {{name}}",
 					"bulkSelected_one": "Đã chọn {{count}} màn hình",
-					"bulkSelected_other": "Đã chọn {{count}} màn hình"
+					"bulkSelected_other": "Đã chọn {{count}} màn hình",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "Hoạt động từ",

--- a/client/src/locales/zh-CN.json
+++ b/client/src/locales/zh-CN.json
@@ -438,7 +438,8 @@
 					"selectAll": "选择所有监视器",
 					"selectMonitor": "选择 {{name}}",
 					"bulkSelected_one": "已选择 {{count}} 个监视器",
-					"bulkSelected_other": "已选择 {{count}} 个监视器"
+					"bulkSelected_other": "已选择 {{count}} 个监视器",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "已活跃",

--- a/client/src/locales/zh-TW.json
+++ b/client/src/locales/zh-TW.json
@@ -438,7 +438,8 @@
 					"selectAll": "選擇所有監視器",
 					"selectMonitor": "選擇 {{name}}",
 					"bulkSelected_one": "已選擇 {{count}} 個監視器",
-					"bulkSelected_other": "已選擇 {{count}} 個監視器"
+					"bulkSelected_other": "已選擇 {{count}} 個監視器",
+					"checkNow": "Check now"
 				},
 				"statBoxes": {
 					"activeFor": "已啟用",

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -392,6 +392,12 @@
 							"type": "string"
 						}
 					},
+					"tags": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
 					"secret": {
 						"type": "string"
 					},
@@ -469,6 +475,7 @@
 					"ignoreTlsErrors",
 					"useAdvancedMatching",
 					"notifications",
+					"tags",
 					"cpuAlertThreshold",
 					"memoryAlertThreshold",
 					"diskAlertThreshold",
@@ -2361,6 +2368,16 @@
 									},
 									"profilePicture": {
 										"type": "string"
+									},
+									"password": {
+										"type": "string",
+										"minLength": 8,
+										"pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!?@#$%^&*()\\-_=+[\\]{};:'\",.~`|\\\\/])[A-Za-z0-9!?@#$%^&*()\\-_=+[\\]{};:'\",.~`|\\\\/]+$"
+									},
+									"newPassword": {
+										"type": "string",
+										"minLength": 8,
+										"pattern": "^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!?@#$%^&*()\\-_=+[\\]{};:'\",.~`|\\\\/])[A-Za-z0-9!?@#$%^&*()\\-_=+[\\]{};:'\",.~`|\\\\/]+$"
 									},
 									"profileImage": {
 										"type": "string",
@@ -5207,7 +5224,8 @@
 										"type": "array",
 										"items": {
 											"type": "string"
-										}
+										},
+										"minItems": 1
 									},
 									"duration": {
 										"type": "number"
@@ -5478,6 +5496,24 @@
 						"required": false,
 						"name": "filter",
 						"in": "query"
+					},
+					{
+						"schema": {
+							"anyOf": [
+								{
+									"type": "string"
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							]
+						},
+						"required": false,
+						"name": "tags",
+						"in": "query"
 					}
 				],
 				"responses": {
@@ -5670,6 +5706,24 @@
 						},
 						"required": false,
 						"name": "type",
+						"in": "query"
+					},
+					{
+						"schema": {
+							"anyOf": [
+								{
+									"type": "string"
+								},
+								{
+									"type": "array",
+									"items": {
+										"type": "string"
+									}
+								}
+							]
+						},
+						"required": false,
+						"name": "tags",
 						"in": "query"
 					},
 					{
@@ -6572,6 +6626,122 @@
 				}
 			}
 		},
+		"/monitors/check/{monitorId}": {
+			"post": {
+				"tags": ["monitors"],
+				"summary": "Run a monitor check immediately",
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string",
+							"minLength": 1
+						},
+						"required": true,
+						"name": "monitorId",
+						"in": "path"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"$ref": "#/components/schemas/Monitor"
+										}
+									},
+									"required": ["success", "msg", "data"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Forbidden",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/monitors/certificate/{monitorId}": {
 			"get": {
 				"tags": ["monitors"],
@@ -6919,6 +7089,12 @@
 										"type": "number"
 									},
 									"notifications": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									},
+									"tags": {
 										"type": "array",
 										"items": {
 											"type": "string"
@@ -7586,6 +7762,13 @@
 													},
 													"default": []
 												},
+												"tags": {
+													"type": "array",
+													"items": {
+														"type": "string"
+													},
+													"default": []
+												},
 												"secret": {
 													"type": "string"
 												},
@@ -8099,6 +8282,12 @@
 										"type": "number"
 									},
 									"notifications": {
+										"type": "array",
+										"items": {
+											"type": "string"
+										}
+									},
+									"tags": {
 										"type": "array",
 										"items": {
 											"type": "string"

--- a/server/openapi/routes/monitor.ts
+++ b/server/openapi/routes/monitor.ts
@@ -132,6 +132,16 @@ registry.registerPath({
 });
 
 registry.registerPath({
+	method: "post",
+	path: "/monitors/check/{monitorId}",
+	tags,
+	summary: "Run a monitor check immediately",
+	security: bearer,
+	request: { params: getMonitorByIdParamValidation },
+	responses: { "200": okJson(monitorObject), ...standardErrors },
+});
+
+registry.registerPath({
 	method: "get",
 	path: "/monitors/certificate/{monitorId}",
 	tags,

--- a/server/src/controllers/monitorController.ts
+++ b/server/src/controllers/monitorController.ts
@@ -36,6 +36,7 @@ export interface IMonitorController {
 	deleteAllMonitors: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	editMonitor: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	pauseMonitor: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
+	checkMonitorNow: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	bulkPauseMonitors: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	addDemoMonitors: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
 	getMonitorsByTeamId: (req: Request, res: Response, next: NextFunction) => Promise<Response | void>;
@@ -301,6 +302,25 @@ class MonitorController implements IMonitorController {
 			return res.status(200).json({
 				success: true,
 				msg: monitor.isActive ? "Monitor resumed successfully" : "Monitor paused successfully",
+				data: monitor,
+			});
+		} catch (error) {
+			next(error);
+		}
+	};
+
+	checkMonitorNow = async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			const validatedParams = getMonitorByIdParamValidation.parse(req.params);
+
+			const monitorId = validatedParams.monitorId;
+			const teamId = requireTeamId(req.user?.teamId);
+
+			const monitor = await this.monitorService.checkMonitorNow({ teamId, monitorId });
+
+			return res.status(200).json({
+				success: true,
+				msg: "Monitor check completed successfully",
 				data: monitor,
 			});
 		} catch (error) {

--- a/server/src/routes/monitorRoute.ts
+++ b/server/src/routes/monitorRoute.ts
@@ -31,6 +31,7 @@ class MonitorRoutes {
 
 		// General monitor routes
 		this.router.post("/pause/:monitorId", isAllowed(["admin", "superadmin"]), this.monitorController.pauseMonitor);
+		this.router.post("/check/:monitorId", isAllowed(["admin", "superadmin"]), this.monitorController.checkMonitorNow);
 		this.router.post("/bulk/pause", isAllowed(["admin", "superadmin"]), this.monitorController.bulkPauseMonitors);
 
 		// Util routes

--- a/server/src/service/business/monitorService.ts
+++ b/server/src/service/business/monitorService.ts
@@ -80,6 +80,7 @@ export interface IMonitorService {
 	editMonitor(args: { teamId: string; monitorId: string; body: Partial<Monitor> }): Promise<Monitor>;
 	pauseMonitor(args: { teamId: string; monitorId: string }): Promise<Monitor>;
 	bulkPauseMonitors(args: { teamId: string; monitorIds: string[]; pause: boolean }): Promise<{ monitors: Monitor[]; failedCount: number }>;
+	checkMonitorNow(args: { teamId: string; monitorId: string }): Promise<Monitor>;
 
 	// delete
 	deleteMonitor(args: { teamId: string; monitorId: string }): Promise<Monitor>;
@@ -464,6 +465,17 @@ export class MonitorService implements IMonitorService {
 			await this.jobQueue.pauseJob(monitor);
 		}
 		return monitor;
+	};
+
+	checkMonitorNow = async ({ teamId, monitorId }: { teamId: string; monitorId: string }): Promise<Monitor> => {
+		const monitor = await this.monitorsRepository.findById(monitorId, teamId);
+		if (!monitor) {
+			throw new AppError({ message: `Monitor with ID ${monitorId} not found.`, status: 404 });
+		}
+
+		await this.jobQueue.runMonitorNow(monitor);
+
+		return (await this.monitorsRepository.findById(monitorId, teamId)) ?? monitor;
 	};
 
 	bulkPauseMonitors = async ({

--- a/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
+++ b/server/src/service/infrastructure/SuperSimpleQueue/SuperSimpleQueue.ts
@@ -50,6 +50,7 @@ export interface ISuperSimpleQueue {
 	pauseJob(monitor: Monitor): Promise<void>;
 	resumeJob(monitor: Monitor): Promise<void>;
 	updateJob(monitor: Monitor): Promise<void>;
+	runMonitorNow(monitor: Monitor): Promise<void>;
 	shutdown(): Promise<void>;
 	getMetrics(): Promise<QueueMetrics>;
 	getJobs(): Promise<QueueJobSummary[]>;
@@ -304,6 +305,11 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 	updateJob = async (monitor: Monitor) => {
 		this.scheduler.updateJob(monitor.id, { repeat: monitor.interval, data: monitor });
 		await this.syncGeoJob(monitor);
+	};
+
+	runMonitorNow = async (monitor: Monitor) => {
+		const job = this.helper.getHeartbeatJob();
+		await job(monitor);
 	};
 
 	shutdown = async () => {

--- a/server/test/unit/services/monitorService.test.ts
+++ b/server/test/unit/services/monitorService.test.ts
@@ -62,6 +62,7 @@ const createJobQueueMock = () => ({
 	resumeJob: jest.fn(),
 	pauseJob: jest.fn(),
 	deleteJob: jest.fn(),
+	runMonitorNow: jest.fn(),
 });
 
 const TEAM_ID = "team-1";
@@ -837,6 +838,32 @@ describe("MonitorService", () => {
 			expect(result.isActive).toBe(false);
 			expect(jobQueue.pauseJob).toHaveBeenCalledWith(monitor);
 			expect(jobQueue.resumeJob).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("checkMonitorNow", () => {
+		it("runs a monitor check and returns the refreshed monitor", async () => {
+			const monitorsRepository = createMonitorsRepositoryMock();
+			const monitor = makeMonitor({ status: "up" });
+			const refreshedMonitor = makeMonitor({ status: "down" });
+			(monitorsRepository.findById as jest.Mock).mockResolvedValueOnce(monitor).mockResolvedValueOnce(refreshedMonitor);
+			const { service, jobQueue } = createService({ monitorsRepository });
+
+			const result = await service.checkMonitorNow({ teamId: TEAM_ID, monitorId: MONITOR_ID });
+
+			expect(jobQueue.runMonitorNow).toHaveBeenCalledWith(monitor);
+			expect(monitorsRepository.findById).toHaveBeenNthCalledWith(1, MONITOR_ID, TEAM_ID);
+			expect(monitorsRepository.findById).toHaveBeenNthCalledWith(2, MONITOR_ID, TEAM_ID);
+			expect(result).toBe(refreshedMonitor);
+		});
+
+		it("throws when monitor is not found", async () => {
+			const monitorsRepository = createMonitorsRepositoryMock();
+			(monitorsRepository.findById as jest.Mock).mockResolvedValue(null);
+			const { service, jobQueue } = createService({ monitorsRepository });
+
+			await expect(service.checkMonitorNow({ teamId: TEAM_ID, monitorId: MONITOR_ID })).rejects.toThrow(`Monitor with ID ${MONITOR_ID} not found.`);
+			expect(jobQueue.runMonitorNow).not.toHaveBeenCalled();
 		});
 	});
 

--- a/server/test/unit/services/superSimpleQueue.test.ts
+++ b/server/test/unit/services/superSimpleQueue.test.ts
@@ -434,6 +434,21 @@ describe("SuperSimpleQueue", () => {
 		});
 	});
 
+	describe("runMonitorNow", () => {
+		it("runs the heartbeat job immediately with the monitor", async () => {
+			const heartbeatJob = jest.fn<() => Promise<void>>().mockResolvedValue(undefined);
+			const helper = createQueueHelper();
+			(helper.getHeartbeatJob as jest.Mock).mockReturnValue(heartbeatJob);
+			const { queue } = createQueue({ helper });
+			const monitor = makeMonitor();
+
+			await queue.runMonitorNow(monitor);
+
+			expect(helper.getHeartbeatJob).toHaveBeenCalledTimes(1);
+			expect(heartbeatJob).toHaveBeenCalledWith(monitor);
+		});
+	});
+
 	// ── syncGeoJob (via updateJob) ───────────────────────────────────────────
 
 	describe("syncGeoJob (via updateJob)", () => {


### PR DESCRIPTION
## Summary
- add an admin endpoint to run a monitor check immediately without waiting for the next scheduled interval
- reuse the existing heartbeat job path so manual checks update status, checks, incidents, notifications, and maintenance handling consistently
- add a Check now action to uptime, infrastructure, and PageSpeed monitor action menus

Refs #2389, specifically the wishlist request for an easy way to check a site immediately.

## Verification
- npm run test:unit:services -- --runTestsByPath test/unit/services/monitorService.test.ts test/unit/services/superSimpleQueue.test.ts
- npm run build:openapi
- npm run build (server)
- npm run build (client)
- npm run format-check (server)
- npm run format-check (client)
- targeted ESLint on changed server/client source files
- git diff --check