### PR TITLE
fix: move listener registration to constructor

### DIFF
--- a/server/src/service/infrastructure/JobQueues/LessSimpleQueue.ts
+++ b/server/src/service/infrastructure/JobQueues/LessSimpleQueue.ts
@@ -25,6 +25,7 @@ export class LessSimpleQueue implements IJobQueue {
 		this.helper = helper;
 		this.monitorsRepository = monitorsRepository;
 		this.scheduler = scheduler;
+		this.registerListeners();
 	}
 
 	get serviceName() {
@@ -121,7 +122,6 @@ export class LessSimpleQueue implements IJobQueue {
 
 	init = async () => {
 		try {
-			this.registerListeners();
 			await this.scheduler.start();
 			this.scheduler.addTemplate("monitor-job", this.helper.getHeartbeatJob());
 			this.scheduler.addTemplate("geo-check-job", this.helper.getHeartbeatGeoJob());

--- a/server/src/service/infrastructure/JobQueues/SuperSimpleQueue.ts
+++ b/server/src/service/infrastructure/JobQueues/SuperSimpleQueue.ts
@@ -69,6 +69,7 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 		this.helper = helper;
 		this.monitorsRepository = monitorsRepository;
 		this.scheduler = scheduler;
+		this.registerListeners();
 	}
 
 	get serviceName() {
@@ -158,8 +159,6 @@ export class SuperSimpleQueue implements ISuperSimpleQueue {
 
 	init = async () => {
 		try {
-			this.registerListeners();
-
 			this.scheduler.start();
 			this.scheduler.addTemplate("monitor-job", this.helper.getHeartbeatJob());
 			this.scheduler.addTemplate("geo-check-job", this.helper.getHeartbeatGeoJob());


### PR DESCRIPTION
Job queues currently register event listeners in the `init()` function.  This function is called internally when the queue is flushed, leading to leaked listeners.

This PR moves listener registration to the constructor so it is only called once.