### PR TITLE
Feat: Progress indicator infra & pagespeed

### DIFF
--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -234,6 +234,9 @@ const CreateMonitorPage = () => {
 	}, [location.pathname]);
 
 	const showTypeSelector = pageType === "uptime" && !isEditMode;
+	// The multi-step wizard applies to every create flow; only the monitor-type
+	// radio is uptime-specific. Edit mode keeps the flat form.
+	const isWizard = !isEditMode;
 	const defaultType: MonitorType =
 		pageType === "pagespeed"
 			? "pagespeed"
@@ -267,7 +270,7 @@ const CreateMonitorPage = () => {
 	// Multi-step wizard, uptime create only (showTypeSelector). Other flows
 	// keep the flat form, where showStep() is always true.
 	const [currentStep, setCurrentStep] = useState(0);
-	const showStep = (step: number) => !showTypeSelector || currentStep === step;
+	const showStep = (step: number) => !isWizard || currentStep === step;
 
 	const watchedType = watch("type") as MonitorType;
 	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
@@ -362,7 +365,7 @@ const CreateMonitorPage = () => {
 				refetch={refetchMonitor}
 				onDelete={handleDeleteClick}
 			/>
-			{showTypeSelector && (
+			{isWizard && (
 				<StepProgress
 					steps={totalSteps}
 					current={currentStep}
@@ -1335,9 +1338,9 @@ const CreateMonitorPage = () => {
 
 			<Stack
 				direction="row"
-				justifyContent={showTypeSelector ? "space-between" : "flex-end"}
+				justifyContent={isWizard ? "space-between" : "flex-end"}
 			>
-				{showTypeSelector && (
+				{isWizard && (
 					<Button
 						type="button"
 						variant="outlined"
@@ -1348,7 +1351,7 @@ const CreateMonitorPage = () => {
 						{t("common.buttons.back")}
 					</Button>
 				)}
-				{showTypeSelector && currentStep < totalSteps - 1 ? (
+				{isWizard && currentStep < totalSteps - 1 ? (
 					<Button
 						key="wizard-next"
 						type="button"

--- a/client/src/Pages/CreateMonitor/index.tsx
+++ b/client/src/Pages/CreateMonitor/index.tsx
@@ -234,9 +234,6 @@ const CreateMonitorPage = () => {
 	}, [location.pathname]);
 
 	const showTypeSelector = pageType === "uptime" && !isEditMode;
-	// The multi-step wizard applies to every create flow; only the monitor-type
-	// radio is uptime-specific. Edit mode keeps the flat form.
-	const isWizard = !isEditMode;
 	const defaultType: MonitorType =
 		pageType === "pagespeed"
 			? "pagespeed"
@@ -267,10 +264,10 @@ const CreateMonitorPage = () => {
 		reset(defaults);
 	}, [defaults, reset]);
 
-	// Multi-step wizard, uptime create only (showTypeSelector). Other flows
-	// keep the flat form, where showStep() is always true.
+	// Multi-step wizard on every create flow; edit mode keeps the flat form
+	// where showStep() is always true.
 	const [currentStep, setCurrentStep] = useState(0);
-	const showStep = (step: number) => !isWizard || currentStep === step;
+	const showStep = (step: number) => isEditMode || currentStep === step;
 
 	const watchedType = watch("type") as MonitorType;
 	const watchedUseAdvancedMatching = watch("useAdvancedMatching") as boolean;
@@ -365,7 +362,7 @@ const CreateMonitorPage = () => {
 				refetch={refetchMonitor}
 				onDelete={handleDeleteClick}
 			/>
-			{isWizard && (
+			{!isEditMode && (
 				<StepProgress
 					steps={totalSteps}
 					current={currentStep}
@@ -1338,9 +1335,9 @@ const CreateMonitorPage = () => {
 
 			<Stack
 				direction="row"
-				justifyContent={isWizard ? "space-between" : "flex-end"}
+				justifyContent={!isEditMode ? "space-between" : "flex-end"}
 			>
-				{isWizard && (
+				{!isEditMode && (
 					<Button
 						type="button"
 						variant="outlined"
@@ -1351,7 +1348,7 @@ const CreateMonitorPage = () => {
 						{t("common.buttons.back")}
 					</Button>
 				)}
-				{isWizard && currentStep < totalSteps - 1 ? (
+				{!isEditMode && currentStep < totalSteps - 1 ? (
 					<Button
 						key="wizard-next"
 						type="button"

--- a/client/src/Validation/monitor.ts
+++ b/client/src/Validation/monitor.ts
@@ -128,19 +128,23 @@ const hardwareSchema = baseSchema.extend({
 	cpuAlertThreshold: z
 		.number()
 		.min(0, "CPU threshold must be at least 0")
-		.max(100, "CPU threshold must be at most 100"),
+		.max(100, "CPU threshold must be at most 100")
+		.register(monitorStepRegistry, { step: 1 }),
 	memoryAlertThreshold: z
 		.number()
 		.min(0, "Memory threshold must be at least 0")
-		.max(100, "Memory threshold must be at most 100"),
+		.max(100, "Memory threshold must be at most 100")
+		.register(monitorStepRegistry, { step: 1 }),
 	diskAlertThreshold: z
 		.number()
 		.min(0, "Disk threshold must be at least 0")
-		.max(100, "Disk threshold must be at most 100"),
+		.max(100, "Disk threshold must be at most 100")
+		.register(monitorStepRegistry, { step: 1 }),
 	tempAlertThreshold: z
 		.number()
 		.min(0, "Temperature threshold must be at least 0")
-		.max(150, "Temperature threshold must be at most 150"),
+		.max(150, "Temperature threshold must be at most 150")
+		.register(monitorStepRegistry, { step: 1 }),
 	selectedDisks: z.array(z.string()),
 });
 


### PR DESCRIPTION
## Describe your changes

Decoupled the multi-step wizard from the uptime-only type selector via a new `isWizard` flag, so infrastructure and pagespeed creation now show the segmented progress bar and Back/Next stepping (edit mode stays a flat form). Also moved hardware's four alert-threshold fields to wizard step 2 in the Zod schema so they validate on the step where they're actually shown.

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [ ] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1919" height="711" alt="Screenshot 2026-06-03 201900" src="https://github.com/user-attachments/assets/b4f6f3b1-cb14-4332-a54b-6c4906e10a89" />
<img width="1917" height="626" alt="Screenshot 2026-06-03 201917" src="https://github.com/user-attachments/assets/de11e7cd-4d44-4810-8c90-a379aecae59d" />
