### PR TITLE
fix: (diagnostics) derive Mongo totalSize when dbStats omits it (Atlas shared tier)

### DIFF
--- a/server/src/service/business/diagnosticService.ts
+++ b/server/src/service/business/diagnosticService.ts
@@ -87,9 +87,9 @@ export class DiagnosticService implements IDiagnosticService {
 					const entry: CollectionDiagnostics = {
 						name: collection.collectionName,
 						documentCount,
-						storageSize: stats.storageSize,
-						totalIndexSize: stats.totalIndexSize,
-						totalSize: stats.totalSize,
+						storageSize: stats.storageSize ?? 0,
+						totalIndexSize: stats.totalIndexSize ?? 0,
+						totalSize: stats.totalSize ?? (stats.storageSize ?? 0) + (stats.totalIndexSize ?? 0),
 					};
 					if (stats.timeseries?.bucketCount !== undefined) {
 						entry.bucketCount = stats.timeseries.bucketCount;
@@ -103,7 +103,7 @@ export class DiagnosticService implements IDiagnosticService {
 			host: mongo.connection.host,
 			port: mongo.connection.port,
 			dbName: mongo.connection.name,
-			totalSize: dbStats.totalSize,
+			totalSize: dbStats.totalSize ?? (dbStats.storageSize ?? 0) + (dbStats.indexSize ?? 0),
 			collections,
 		};
 	};

--- a/server/test/unit/services/diagnosticService.test.ts
+++ b/server/test/unit/services/diagnosticService.test.ts
@@ -147,6 +147,42 @@ describe("DiagnosticService", () => {
 			});
 		});
 
+		it("derives mongoStats.totalSize from storageSize + indexSize when the server omits it (e.g. Atlas shared tier)", async () => {
+			const db = makeDb({
+				collections: [{ collectionName: "monitors" }],
+				dbStats: { storageSize: 376832, indexSize: 1155072 },
+			});
+			const service = new DiagnosticService(db);
+			const promise = service.getSystemStats();
+			jest.advanceTimersByTime(1000);
+			await jest.advanceTimersByTimeAsync(10);
+			const result = await promise;
+
+			expect(result.mongoStats.totalSize).toBe(376832 + 1155072);
+			expect(Number.isFinite(result.mongoStats.totalSize)).toBe(true);
+		});
+
+		it("derives collection totalSize and defaults missing size fields to 0 when collStats omits them", async () => {
+			const db = makeDb({
+				collections: [{ collectionName: "checks" }],
+				collStats: { storageSize: 200 },
+			});
+			const service = new DiagnosticService(db);
+			const promise = service.getSystemStats();
+			jest.advanceTimersByTime(1000);
+			await jest.advanceTimersByTimeAsync(10);
+			const result = await promise;
+
+			const coll = result.mongoStats.collections[0];
+			expect(coll).toMatchObject({
+				name: "checks",
+				storageSize: 200,
+				totalIndexSize: 0,
+				totalSize: 200, // storageSize (200) + totalIndexSize (0)
+			});
+			expect(Number.isFinite(coll?.totalSize)).toBe(true);
+		});
+
 		it("includes bucketCount on timeseries collections, omits it elsewhere", async () => {
 			const db = makeDb({
 				collections: [{ collectionName: "checks" }],


### PR DESCRIPTION
## Summary

The **Diagnostics** tab crashes with `TypeError: Expected a finite number, got undefined` when Checkmate runs against a MongoDB whose `dbStats` does not include `totalSize` — most notably **MongoDB Atlas shared/free tiers (M0/Flex)**.

`diagnosticService.getMongoDBStats()` passed `dbStats.totalSize` straight through to the API response. `MongoDiagnostics.totalSize` is typed as a non-optional `number`, but on these tiers it comes back `undefined`, which propagates to the client and throws in a number formatter / chart.

## Root cause (verified)

Against an Atlas shared-tier cluster, `db.stats()` returns a legacy shape **without** `totalSize`:

```
keys: db,collections,views,objects,avgObjSize,dataSize,storageSize,
      totalFreeStorageSize,numExtents,indexes,indexSize,indexFreeStorageSize,
      fileSize,nsSizeMB,ok          # note: legacy fields, no `totalSize`
totalSize = undefined
```

Ruled out the alternatives:
- **Not a MongoDB version removal** — a stock `mongo:8` returns `totalSize` with the modern key set (`scaleFactor`, `fsUsedSize`, `fsTotalSize`) and no legacy fields.
- **Not permissions** — `dbStats` succeeds (`ok:1`) and `totalSize` is absent even with an `atlasAdmin` user. A permissions error would deny the whole command.

It's purely the Atlas shared-tier `dbStats` compatibility format.

## Fix

Derive `totalSize` (`storageSize + indexSize`) at both the DB and per-collection level when the server omits it, and default the other size fields to `0`, so the response always satisfies the non-optional `number` types.

## Tests

Added unit tests in `diagnosticService.test.ts`:
- derives `mongoStats.totalSize` from `storageSize + indexSize` when `dbStats` omits it
- derives collection `totalSize` and defaults missing size fields to `0`

All `diagnosticService` tests pass (12/12).

## Reproduce

1. Run Checkmate with `DB_CONNECTION_STRING` pointing at an Atlas M0/shared cluster
2. Log in as superadmin → Settings → Diagnostics
3. Before: page crashes (`Expected a finite number`). After: renders with a derived total size.
