### PR TITLE
Fix SSL cert check on non-standard ports and login user enumeration

### DIFF
--- a/server/src/api/controllers/controllerUtils.ts
+++ b/server/src/api/controllers/controllerUtils.ts
@@ -7,7 +7,8 @@ type SSLCheckerType = typeof sslChecker;
 export const fetchMonitorCertificate = async (checker: SSLCheckerType, monitor: Monitor): Promise<SSLDetails> => {
 	const monitorUrl = new URL(monitor.url);
 	const hostname = monitorUrl.hostname;
-	const cert = await checker(hostname);
+	const port = monitorUrl.port ? parseInt(monitorUrl.port, 10) : undefined;
+	const cert = await checker(hostname, { ...(port ? { port } : {}) });
 	if (cert?.validTo === null || cert?.validTo === undefined) {
 		throw new Error("Certificate not found");
 	}

--- a/server/src/domain/users/user.service.ts
+++ b/server/src/domain/users/user.service.ts
@@ -220,12 +220,17 @@ export class UserService implements IUserService {
 
 	loginUser = async (email: string, password: string) => {
 		// Check if user exists
-		const user = await this.usersRepository.findByEmail(email);
+		let user;
+		try {
+			user = await this.usersRepository.findByEmail(email);
+		} catch {
+			throw new AppError({ message: "Incorrect email or password", service: SERVICE_NAME, status: 401 });
+		}
 		// Compare password
 		const match = await bcrypt.compare(password, user.password);
 
 		if (match !== true) {
-			throw new AppError({ message: "Incorrect password", service: SERVICE_NAME, status: 401 });
+			throw new AppError({ message: "Incorrect email or password", service: SERVICE_NAME, status: 401 });
 		}
 
 		// Remove password from user object.  Should this be abstracted to DB layer?

--- a/server/test/unit/services/userService.test.ts
+++ b/server/test/unit/services/userService.test.ts
@@ -328,7 +328,7 @@ describe("UserService", () => {
 			const hashed = bcrypt.hashSync("correct-password", 10);
 			(usersRepository.findByEmail as jest.Mock).mockResolvedValue(makeUser({ password: hashed }));
 
-			await expect(service.loginUser("test@example.com", "wrong-password")).rejects.toThrow("Incorrect password");
+			await expect(service.loginUser("test@example.com", "wrong-password")).rejects.toThrow("Incorrect email or password");
 		});
 	});
 


### PR DESCRIPTION
## Summary

Two small fixes for confirmed open issues:

### 1. SSL/TLS certificate expiry on non-standard HTTPS ports (#3646)

`fetchMonitorCertificate` was only passing the hostname to `ssl-checker`, ignoring the port specified in the monitor URL. This meant certificates on non-standard HTTPS ports (e.g., `https://example.com:8443`) were never checked and always showed "N/A".

**Fix:** Extract port from the monitor URL and pass it to the ssl-checker via the `SSLOptions.port` parameter (already supported by the library).

### 2. Login error handling / user enumeration (#2768)

The login flow returned different error messages and status codes depending on whether the email existed:
- Non-existent email → "User not found" (404)
- Wrong password → "Incorrect password" (401)

This leaks information about which emails are registered.

**Fix:** Catch the "user not found" case and return the same generic "Incorrect email or password" (401) message for both scenarios.

Fixes #3646
Fixes #2768