### PR TITLE
feat: add SSL certificate expiry notifications

### DIFF
--- a/server/src/api/controllers/controllerUtils.ts
+++ b/server/src/api/controllers/controllerUtils.ts
@@ -1,18 +1,7 @@
 import { AppError } from "@/utils/AppError.js";
-import { Monitor, MonitorTypes, type MonitorType } from "@/domain/monitors/monitor.types.js";
+import { MonitorTypes, type MonitorType } from "@/domain/monitors/monitor.types.js";
 import { UserRole } from "@/domain/users/user.type.js";
-import sslChecker, { SSLDetails } from "ssl-checker";
-type SSLCheckerType = typeof sslChecker;
 
-export const fetchMonitorCertificate = async (checker: SSLCheckerType, monitor: Monitor): Promise<SSLDetails> => {
-	const monitorUrl = new URL(monitor.url);
-	const hostname = monitorUrl.hostname;
-	const cert = await checker(hostname);
-	if (cert?.validTo === null || cert?.validTo === undefined) {
-		throw new Error("Certificate not found");
-	}
-	return cert;
-};
 export const requireString = (value: unknown, fieldName: string): string => {
 	if (typeof value === "string" && value.trim().length > 0) {
 		return value;

--- a/server/src/api/controllers/monitorController.ts
+++ b/server/src/api/controllers/monitorController.ts
@@ -17,7 +17,8 @@ import {
 	bulkPauseMonitorBodyValidation,
 } from "@/api/validation/monitorValidation.js";
 import sslChecker from "ssl-checker";
-import { fetchMonitorCertificate, requireTeamId, requireUserId } from "@/api/controllers/controllerUtils.js";
+import { requireTeamId, requireUserId } from "@/api/controllers/controllerUtils.js";
+import { fetchMonitorCertificate } from "@/utils/ssl.js";
 import { AppError } from "@/utils/AppError.js";
 import { IMonitorService } from "@/domain/monitors/monitor.service.js";
 import { INotificationsService } from "@/domain/notifications/notification.service.js";

--- a/server/src/config/services.ts
+++ b/server/src/config/services.ts
@@ -107,6 +107,7 @@ import { NotificationReactor } from "@/worker/reactors/reactor.notification.js";
 import { ReactorDispatcher } from "@/worker/reactors/reactor.dispatcher.js";
 import { IncidentReactor } from "@/worker/reactors/reactor.incident.js";
 import { CheckPipeline, GeoChecksPipeline } from "@/worker/worker.check-pipeline.js";
+import { SslCertificateExpiryReactor } from "@/worker/reactors/reactor.ssl-certificate-expiry.js";
 
 export type InitializedServices = {
 	settingsService: ISettingsService;
@@ -318,7 +319,9 @@ export const initializeServices = async ({
 	// reactors and dispatcher
 	const notificationReactor = new NotificationReactor(notificationsService);
 	const incidentReactor = new IncidentReactor(incidentService);
-	const reactorDispatcher = new ReactorDispatcher(logger, [notificationReactor, incidentReactor]);
+	const sslCertificateExpiryReactor = new SslCertificateExpiryReactor(notificationsService, logger);
+
+	const reactorDispatcher = new ReactorDispatcher(logger, [notificationReactor, incidentReactor, sslCertificateExpiryReactor]);
 
 	// pipelines
 	const checkPipeline = new CheckPipeline(

--- a/server/src/domain/notifications/notification.service.ts
+++ b/server/src/domain/notifications/notification.service.ts
@@ -20,6 +20,7 @@ export interface INotificationsService {
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
+	handleCertificateExpiryNotification: (monitor: Monitor, expiryDate: Date, daysRemaining: number) => Promise<boolean>;
 }
 
 const SERVICE_NAME = "NotificationsService";
@@ -162,6 +163,75 @@ export class NotificationsService implements INotificationsService {
 
 		// Send notifications based on decision
 		return await this.sendNotifications(monitor, monitorStatusResponse, decision);
+	};
+
+	handleCertificateExpiryNotification = async (monitor: Monitor, expiryDate: Date, daysRemaining: number): Promise<boolean> => {
+		const notificationIds = monitor.notifications ?? [];
+
+		if (notificationIds.length === 0) {
+			return false;
+		}
+
+		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds);
+
+		if (notifications.length === 0) {
+			return false;
+		}
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+
+		const monitorName = monitor.name || monitor.url || monitor.id;
+		const monitorUrl = monitor.url || "";
+		const expiryDateText = expiryDate.toUTCString();
+
+		const title = "TLS certificate expiry warning";
+		const message = `TLS certificate for ${monitorName} will expire in ${daysRemaining} day${daysRemaining === 1 ? "" : "s"} on ${expiryDateText}.`;
+
+		const notificationMessage: NotificationMessage = {
+			type: "ssl_certificate_expiry",
+			severity: "warning",
+			monitor: {
+				id: monitor.id,
+				name: monitorName,
+				url: monitorUrl,
+				type: monitor.type,
+				status: monitor.status,
+			},
+			content: {
+				title,
+				summary: message,
+				details: [`Certificate expiry date: ${expiryDateText}`, `Days remaining: ${daysRemaining}`],
+				timestamp: new Date(),
+			},
+			clientHost,
+			metadata: {
+				teamId: monitor.teamId,
+				notificationReason: "certificate_expiry",
+			},
+		};
+
+		const monitorStatusResponse = {
+			status: "warning",
+			code: 200,
+			message,
+			responseTime: 0,
+		} as unknown as MonitorStatusResponse;
+
+		const decision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: true,
+			incidentReason: null,
+			notificationReason: "status_change",
+		} as MonitorActionDecision;
+
+		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage));
+		const outcomes = await Promise.all(tasks);
+
+		const succeeded = outcomes.filter(Boolean).length;
+
+		return succeeded > 0;
 	};
 
 	sendTestNotification = async (notification: Partial<Notification>) => {

--- a/server/src/domain/notifications/notification.type.ts
+++ b/server/src/domain/notifications/notification.type.ts
@@ -62,7 +62,7 @@ export interface AlertDiscordPayload {
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "ssl_certificate_expiry" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/utils/ssl.ts
+++ b/server/src/utils/ssl.ts
@@ -1,0 +1,36 @@
+import { Monitor } from "@/domain/monitors/monitor.types.js";
+
+type SSLDetails = {
+	validTo: string | Date;
+	daysRemaining?: number;
+};
+
+type SSLCheckerType = (hostname: string) => Promise<SSLDetails>;
+
+export const fetchMonitorCertificate = async (checker: SSLCheckerType, monitor: Monitor): Promise<SSLDetails> => {
+	if (!monitor.url) {
+		throw new Error("Monitor URL not found");
+	}
+
+	const monitorUrl = new URL(monitor.url);
+	const hostname = monitorUrl.hostname;
+
+	const cert = await checker(hostname);
+
+	if (cert?.validTo === null || cert?.validTo === undefined) {
+		throw new Error("Certificate not found");
+	}
+
+	return cert;
+};
+
+export const getCertificateDaysRemaining = (validTo: string | Date): number => {
+	const expiryDate = new Date(validTo);
+
+	if (Number.isNaN(expiryDate.getTime())) {
+		throw new Error("Invalid certificate expiry date");
+	}
+
+	const msInDay = 1000 * 60 * 60 * 24;
+	return Math.ceil((expiryDate.getTime() - Date.now()) / msInDay);
+};

--- a/server/src/worker/reactors/reactor.ssl-certificate-expiry.ts
+++ b/server/src/worker/reactors/reactor.ssl-certificate-expiry.ts
@@ -1,0 +1,77 @@
+import sslChecker from "ssl-checker";
+import { INotificationsService } from "@/domain/notifications/notification.service.js";
+import { Monitor } from "@/domain/monitors/monitor.types.js";
+import { ILogger } from "@/utils/logger.js";
+import { fetchMonitorCertificate, getCertificateDaysRemaining } from "@/utils/ssl.js";
+import { IMonitorReactor } from "@/worker/reactors/reactor.interface.js";
+import { MonitorEvaluation } from "@/worker/worker.interface.js";
+
+const SERVICE_NAME = "SslCertificateExpiryReactor";
+
+const SSL_EXPIRY_WARNING_DAYS = [14, 7, 1] as const;
+type SslExpiryWarningDay = (typeof SSL_EXPIRY_WARNING_DAYS)[number];
+
+export class SslCertificateExpiryReactor implements IMonitorReactor {
+	readonly name = "ssl-certificate-expiry";
+	readonly blocking = false;
+
+	private sentWarnings = new Set<string>();
+
+	constructor(
+		private notificationService: INotificationsService,
+		private logger: ILogger
+	) {}
+
+	private isHttpsMonitor(monitor: Monitor) {
+		if (!monitor.url) return false;
+
+		try {
+			return new URL(monitor.url).protocol === "https:";
+		} catch {
+			return false;
+		}
+	}
+
+	private getWarningDay(daysRemaining: number): SslExpiryWarningDay | null {
+		return SSL_EXPIRY_WARNING_DAYS.find((day) => day === daysRemaining) ?? null;
+	}
+
+	private getDedupeKey(monitor: Monitor, expiryDate: Date, warningDay: SslExpiryWarningDay) {
+		return `${monitor.id}:${expiryDate.toISOString()}:${warningDay}`;
+	}
+
+	react = async (evaluation: MonitorEvaluation) => {
+		const monitor = evaluation.monitor;
+
+		if (!monitor.id) return;
+		if (!this.isHttpsMonitor(monitor)) return;
+
+		try {
+			const certificate = await fetchMonitorCertificate(sslChecker, monitor);
+
+			const expiryDate = new Date(certificate.validTo);
+			const daysRemaining = getCertificateDaysRemaining(certificate.validTo);
+
+			const warningDay = this.getWarningDay(daysRemaining);
+
+			if (!warningDay) return;
+
+			const dedupeKey = this.getDedupeKey(monitor, expiryDate, warningDay);
+
+			if (this.sentWarnings.has(dedupeKey)) return;
+
+			const sent = await this.notificationService.handleCertificateExpiryNotification(monitor, expiryDate, warningDay);
+
+			if (sent) {
+				this.sentWarnings.add(dedupeKey);
+			}
+		} catch (error: unknown) {
+			this.logger.warn({
+				service: SERVICE_NAME,
+				method: "react",
+				message: `Failed to check SSL certificate expiry for monitor ${monitor.id}: ${error instanceof Error ? error.message : String(error)}`,
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+		}
+	};
+}


### PR DESCRIPTION
## Describe your changes

This PR adds early SSL/TLS certificate expiry notifications for HTTPS monitors.

Changes include:
- Added a new SSL certificate expiry reactor that runs after monitor heartbeat checks.
- Sends expiry warning notifications when a certificate has 14, 7, or 1 day remaining.
- Reuses the monitor's existing configured notification channels.
- Added shared SSL utility helpers for fetching certificate details and calculating days remaining.
- Updated the monitor certificate controller to use the shared SSL utility.

The warning thresholds are fixed at 14, 7, and 1 day as requested in the issue.

## Write your issue number after "Fixes "

Fixes #3634

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed.
- [x] I didn't use any hardcoded values beyond the 14, 7, and 1 day thresholds requested in the issue.
- [x] I made sure font sizes, color choices etc. are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.

No UI changes were made.
