### PR TITLE
fix: diagnostic stats

### DIFF
--- a/client/src/Pages/Logs/components/TableJobs.tsx
+++ b/client/src/Pages/Logs/components/TableJobs.tsx
@@ -42,12 +42,15 @@ export const TableJobs = ({
 		maxWidth: 220,
 	};
 
+	const isRunning = (row: QueueJobWithId) =>
+		row.lockedBy !== null && row.lockedUntil !== null && row.lockedUntil > Date.now();
+
 	const headers: Header<QueueJobWithId>[] = [
 		{
 			id: "state",
 			content: t("pages.logs.table.headers.state"),
 			render: (row) => {
-				if (row.lockedAt) {
+				if (isRunning(row)) {
 					return t("common.labels.running");
 				}
 				if (row.monitorActive === true) {
@@ -73,18 +76,6 @@ export const TableJobs = ({
 			),
 		},
 		{
-			id: "url",
-			content: t("common.table.headers.url"),
-			render: (row) => (
-				<Typography
-					title={row.monitorUrl ?? ""}
-					sx={cellSx}
-				>
-					{row.monitorUrl}
-				</Typography>
-			),
-		},
-		{
 			id: "type",
 			content: t("common.table.headers.type"),
 			render: (row) => <Typography sx={cellSx}>{row.monitorType}</Typography>,
@@ -92,50 +83,36 @@ export const TableJobs = ({
 		{
 			id: "interval",
 			content: t("common.table.headers.interval"),
-			render: (row) => {
-				let interval;
-				if (row.monitorId.toString().includes("geo")) {
-					interval = row.monitorGeoInterval ?? 0;
-				} else {
-					interval = row.repeat ?? 0;
-				}
-				return <Typography sx={cellSx}>{prettyMilliseconds(interval)}</Typography>;
-			},
+			render: (row) => (
+				<Typography sx={cellSx}>{prettyMilliseconds(row.monitorInterval ?? 0)}</Typography>
+			),
 		},
 		{
-			id: "lastRun",
-			content: t("pages.logs.table.headers.lastRunAt"),
+			id: "lastFinishedAt",
+			content: t("pages.logs.table.headers.lastFinishedAt"),
 			render: (row) => {
-				const v = formatTimestamp(row.lastRunAt) ?? "-";
+				const lastFinishedAt = formatTimestamp(row.lastFinishedAt) ?? "-";
 				return (
 					<Typography
-						title={v}
+						title={lastFinishedAt}
 						sx={cellSx}
 					>
-						{v}
+						{lastFinishedAt}
 					</Typography>
 				);
 			},
 		},
 		{
-			id: "lastRunTook",
-			content: t("pages.logs.table.headers.lastRunTook"),
+			id: "nextScheduledAt",
+			content: t("pages.logs.table.headers.nextScheduledAt"),
 			render: (row) => {
-				const value = row.lastRunTook ? prettyMilliseconds(row.lastRunTook) : "-";
-				return <Typography sx={cellSx}>{value}</Typography>;
-			},
-		},
-		{
-			id: "lockedAt",
-			content: t("pages.logs.table.headers.lockedAt"),
-			render: (row) => {
-				const v = formatTimestamp(row.lockedAt) ?? "-";
+				const nextScheduledAt = formatTimestamp(row.nextScheduledAt) ?? "-";
 				return (
 					<Typography
-						title={v}
+						title={nextScheduledAt}
 						sx={cellSx}
 					>
-						{v}
+						{nextScheduledAt}
 					</Typography>
 				);
 			},
@@ -169,7 +146,7 @@ export const TableJobs = ({
 				headers={headers}
 				data={jobsWithId}
 				getRowSx={(row) => ({
-					...(row.lockedAt && {
+					...(isRunning(row) && {
 						"& td": { backgroundColor: theme.palette.rowStatus.running },
 					}),
 					...(row.monitorActive === false && {

--- a/client/src/Types/Queue.ts
+++ b/client/src/Types/Queue.ts
@@ -30,23 +30,16 @@ export type QueueMetrics = {
 
 export type QueueJobSummary = {
 	monitorId: string | number;
-	monitorUrl: string | null;
 	monitorType: string | null;
 	monitorInterval: number | null;
-	monitorGeoInterval: number | null;
 	monitorActive: boolean | null;
-	active: boolean;
 	lockedBy: string | null;
 	lockedUntil: number | null;
-	lockedAt: number | null;
+	nextScheduledAt: number;
 	runCount: number;
 	failCount: number;
 	failReason: string | null;
-	lastRunAt: number | null;
 	lastFinishedAt: number | null;
-	lastRunTook: number | null;
-	lastFailedAt: number | null;
-	repeat: number | null;
 };
 
 export interface QueueData {

--- a/client/src/locales/ar.json
+++ b/client/src/locales/ar.json
@@ -941,10 +941,7 @@
 					"monitorId": "معرّف المراقب",
 					"runCount": "عدد التشغيلات",
 					"failCount": "عدد حالات الفشل",
-					"lastRunAt": "آخر تشغيل في",
-					"lockedAt": "مقفل في",
 					"lastFinishedAt": "آخر انتهاء في",
-					"lastRunTook": "مدة آخر تشغيل",
 					"lastFailedAt": "آخر فشل في",
 					"failReason": "سبب الفشل",
 					"state": "الحالة"

--- a/client/src/locales/ca.json
+++ b/client/src/locales/ca.json
@@ -945,10 +945,7 @@
 					"monitorId": "ID del monitor",
 					"runCount": "Recompte d'execucions",
 					"failCount": "Recompte",
-					"lastRunAt": "Darrera execució",
-					"lockedAt": "Bloquejat el",
 					"lastFinishedAt": "Darrera finalització",
-					"lastRunTook": "Durada de la darrera execució",
 					"lastFailedAt": "Darrera fallada",
 					"failReason": "Motiu de la fallada",
 					"state": "Estat"

--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -941,10 +941,7 @@
 					"monitorId": "ID monitoru",
 					"runCount": "Počet spuštění",
 					"failCount": "Počet selhání",
-					"lastRunAt": "Poslední spuštění",
-					"lockedAt": "Uzamčeno v",
 					"lastFinishedAt": "Naposledy dokončeno",
-					"lastRunTook": "Poslední běh trval",
 					"lastFailedAt": "Poslední selhání",
 					"failReason": "Důvod selhání",
 					"state": "Stav"

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -941,10 +941,7 @@
 					"monitorId": "Monitor-ID",
 					"runCount": "Ausführungen",
 					"failCount": "Fehlerzahl",
-					"lastRunAt": "Letzter Lauf am",
-					"lockedAt": "Gesperrt am",
 					"lastFinishedAt": "Zuletzt abgeschlossen am",
-					"lastRunTook": "Letzter Lauf dauerte",
 					"lastFailedAt": "Letzter Fehler am",
 					"failReason": "Fehlergrund",
 					"state": "Status"

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1025,11 +1025,9 @@
 					"monitorId": "Monitor ID",
 					"runCount": "Run count",
 					"failCount": "Count",
-					"lastRunAt": "Last run at",
-					"lockedAt": "Locked at",
+					"nextScheduledAt": "Next run at",
 					"lockedBy": "Locked by",
 					"lastFinishedAt": "Last finished at",
-					"lastRunTook": "Last run took",
 					"lastFailedAt": "Last failed",
 					"failReason": "Fail reason"
 				}

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -941,10 +941,7 @@
 					"monitorId": "ID de monitor",
 					"runCount": "Conteo de ejecuciones",
 					"failCount": "Conteo de fallas",
-					"lastRunAt": "Última ejecución",
-					"lockedAt": "Bloqueado a las",
 					"lastFinishedAt": "Última finalización",
-					"lastRunTook": "Última ejecución tomó",
 					"lastFailedAt": "Última falla",
 					"failReason": "Razón de falla",
 					"state": "Estado"

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -941,10 +941,7 @@
 					"monitorId": "Monitorin tunnus",
 					"runCount": "Suorituskerrat",
 					"failCount": "Epäonnistumiskerrat",
-					"lastRunAt": "Viimeisin suoritus",
-					"lockedAt": "Lukittu",
 					"lastFinishedAt": "Viimeisin valmistuminen",
-					"lastRunTook": "Viimeisin suoritus kesti",
 					"lastFailedAt": "Viimeisin epäonnistuminen",
 					"failReason": "Epäonnistumisen syy",
 					"state": "Tila"

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -941,10 +941,7 @@
 					"monitorId": "ID du moniteur",
 					"runCount": "Nombre d'exécutions",
 					"failCount": "Nombre d'échecs",
-					"lastRunAt": "Dernière exécution",
-					"lockedAt": "Verrouillé le",
 					"lastFinishedAt": "Dernière fin",
-					"lastRunTook": "Durée dernière exécution",
 					"lastFailedAt": "Dernier échec",
 					"failReason": "Raison de l'échec",
 					"state": "État"

--- a/client/src/locales/ja.json
+++ b/client/src/locales/ja.json
@@ -941,10 +941,7 @@
 					"monitorId": "モニターID",
 					"runCount": "実行回数",
 					"failCount": "失敗回数",
-					"lastRunAt": "最終実行日時",
-					"lockedAt": "ロック日時",
 					"lastFinishedAt": "最終完了日時",
-					"lastRunTook": "最終実行時間",
 					"lastFailedAt": "最終失敗日時",
 					"failReason": "失敗理由",
 					"state": "状態"

--- a/client/src/locales/pt-BR.json
+++ b/client/src/locales/pt-BR.json
@@ -941,10 +941,7 @@
 					"monitorId": "ID do monitor",
 					"runCount": "Contagem de execuções",
 					"failCount": "Contagem de falhas",
-					"lastRunAt": "Última execução em",
-					"lockedAt": "Bloqueado em",
 					"lastFinishedAt": "Última conclusão em",
-					"lastRunTook": "Última execução durou",
 					"lastFailedAt": "Última falha em",
 					"failReason": "Motivo da falha",
 					"state": "Estado"

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -941,10 +941,7 @@
 					"monitorId": "ID монитора",
 					"runCount": "Кол-во запусков",
 					"failCount": "Кол-во ошибок",
-					"lastRunAt": "Последний запуск",
-					"lockedAt": "Заблокировано в",
 					"lastFinishedAt": "Последнее завершение",
-					"lastRunTook": "Последний запуск занял",
 					"lastFailedAt": "Последняя ошибка",
 					"failReason": "Причина ошибки",
 					"state": "Состояние"

--- a/client/src/locales/th.json
+++ b/client/src/locales/th.json
@@ -941,10 +941,7 @@
 					"monitorId": "รหัสมอนิเตอร์",
 					"runCount": "จำนวนรัน",
 					"failCount": "จำนวนล้มเหลว",
-					"lastRunAt": "รันล่าสุดเมื่อ",
-					"lockedAt": "ล็อกเมื่อ",
 					"lastFinishedAt": "เสร็จสิ้นล่าสุดเมื่อ",
-					"lastRunTook": "รันล่าสุดใช้เวลา",
 					"lastFailedAt": "ล้มเหลวล่าสุดเมื่อ",
 					"failReason": "สาเหตุที่ล้มเหลว",
 					"state": "สถานะ"

--- a/client/src/locales/tr.json
+++ b/client/src/locales/tr.json
@@ -941,10 +941,7 @@
 					"monitorId": "Monitör ID",
 					"runCount": "Çalışma sayısı",
 					"failCount": "Başarısızlık sayısı",
-					"lastRunAt": "Son çalışma zamanı",
-					"lockedAt": "Kilitlenme zamanı",
 					"lastFinishedAt": "Son tamamlanma zamanı",
-					"lastRunTook": "Son çalışma süresi",
 					"lastFailedAt": "Son başarısızlık zamanı",
 					"failReason": "Başarısızlık nedeni",
 					"state": "Durum"

--- a/client/src/locales/uk.json
+++ b/client/src/locales/uk.json
@@ -941,10 +941,7 @@
 					"monitorId": "ID монітора",
 					"runCount": "Кількість запусків",
 					"failCount": "Кількість помилок",
-					"lastRunAt": "Останній запуск",
-					"lockedAt": "Заблоковано о",
 					"lastFinishedAt": "Останнє завершення",
-					"lastRunTook": "Останній запуск тривав",
 					"lastFailedAt": "Остання помилка",
 					"failReason": "Причина помилки",
 					"state": "Стан"

--- a/client/src/locales/vi.json
+++ b/client/src/locales/vi.json
@@ -941,10 +941,7 @@
 					"monitorId": "ID trình giám sát",
 					"runCount": "Số lần chạy",
 					"failCount": "Số lần lỗi",
-					"lastRunAt": "Chạy lần cuối lúc",
-					"lockedAt": "Khóa lúc",
 					"lastFinishedAt": "Hoàn thành lần cuối lúc",
-					"lastRunTook": "Lần chạy cuối mất",
 					"lastFailedAt": "Lỗi lần cuối lúc",
 					"failReason": "Lý do lỗi",
 					"state": "Trạng thái"

--- a/client/src/locales/zh-CN.json
+++ b/client/src/locales/zh-CN.json
@@ -941,10 +941,7 @@
 					"monitorId": "监控 ID",
 					"runCount": "运行次数",
 					"failCount": "失败次数",
-					"lastRunAt": "上次运行于",
-					"lockedAt": "锁定于",
 					"lastFinishedAt": "上次完成于",
-					"lastRunTook": "上次运行耗时",
 					"lastFailedAt": "上次失败于",
 					"failReason": "失败原因",
 					"state": "状态"

--- a/client/src/locales/zh-TW.json
+++ b/client/src/locales/zh-TW.json
@@ -941,10 +941,7 @@
 					"monitorId": "監控 ID",
 					"runCount": "執行次數",
 					"failCount": "失敗次數",
-					"lastRunAt": "最後執行於",
-					"lockedAt": "鎖定於",
 					"lastFinishedAt": "最後完成於",
-					"lastRunTook": "最後執行耗時",
 					"lastFailedAt": "最後失敗於",
 					"failReason": "失敗原因",
 					"state": "狀態"

--- a/server/src/domain/jobs/job.repository.mongo.ts
+++ b/server/src/domain/jobs/job.repository.mongo.ts
@@ -127,6 +127,7 @@ class MongoJobsRepository implements IJobsRepository {
 					nextScheduledAt: now + BACKOFF_MS,
 					lockedBy: null, // Remove lock
 					lockedUntil: null,
+					lastFinishedAt: now, // a failed run still finished used in getMetrics for failedAt timestamp
 					lastFailReason: error instanceof Error ? error.message : String(error),
 				},
 				$inc: {

--- a/server/src/worker/worker.db-queue.ts
+++ b/server/src/worker/worker.db-queue.ts
@@ -137,23 +137,16 @@ export class DBQueueWorker implements IWorker {
 
 	private toSummary = (job: Job): WorkerJobSummary => ({
 		monitorId: job.refId ?? job.id,
-		monitorUrl: null, // Jobs don't have URL
 		monitorType: job.type,
 		monitorInterval: job.intervalMs,
-		monitorGeoInterval: null,
 		monitorActive: job.isActive,
-		active: job.isActive,
 		lockedBy: job.lockedBy,
 		lockedUntil: job.lockedUntil,
-		lockedAt: null, // no lockedAt
+		nextScheduledAt: job.nextScheduledAt,
 		runCount: job.runCount,
 		failCount: job.failCount,
 		failReason: job.lastFailReason,
-		lastRunAt: null, // not tracked
 		lastFinishedAt: job.lastFinishedAt,
-		lastRunTook: null, // not tracked
-		lastFailedAt: null, // not tracked
-		repeat: job.intervalMs,
 	});
 
 	// ********************

--- a/server/src/worker/worker.interface.ts
+++ b/server/src/worker/worker.interface.ts
@@ -34,23 +34,16 @@ export type WorkerMetrics = {
 
 export type WorkerJobSummary = {
 	monitorId: string | number;
-	monitorUrl: string | null;
 	monitorType: string | null;
 	monitorInterval: number | null;
-	monitorGeoInterval: number | null;
 	monitorActive: boolean | null;
-	active: boolean;
 	lockedBy: string | null;
 	lockedUntil: number | null;
-	lockedAt: number | null;
+	nextScheduledAt: number;
 	runCount: number;
 	failCount: number;
 	failReason: string | null;
-	lastRunAt: number | null;
 	lastFinishedAt: number | null;
-	lastRunTook: number | null;
-	lastFailedAt: number | null;
-	repeat: number | null;
 };
 
 export type WorkerJobsPagination = {

--- a/server/test/integration/jobsRepository.test.ts
+++ b/server/test/integration/jobsRepository.test.ts
@@ -258,6 +258,7 @@ describe("MongoJobsRepository", () => {
 			const row = await readRow("check:mon-1");
 			expect(row?.nextScheduledAt).toBe(NOW + BACKOFF_MS);
 			expect(row?.lastFailReason).toBe("connection refused");
+			expect(row?.lastFinishedAt).toBe(NOW);
 			expect(row?.failCount).toBe(3);
 			expect(row?.lockedBy).toBeNull();
 			expect(row?.lockedUntil).toBeNull();

--- a/server/test/unit/services/dbQueueWorker.test.ts
+++ b/server/test/unit/services/dbQueueWorker.test.ts
@@ -680,7 +680,7 @@ describe("DBQueueWorker", () => {
 
 			expect(page.count).toBe(1);
 			expect(page.jobs).toHaveLength(1);
-			expect(page.jobs[0]).toEqual(expect.objectContaining({ monitorId: "m1", monitorType: "check", monitorInterval: 60000, repeat: 60000 }));
+			expect(page.jobs[0]).toEqual(expect.objectContaining({ monitorId: "m1", monitorType: "check", monitorInterval: 60000 }));
 		});
 
 		it("falls back to the job id for monitorId when refId is null (global jobs)", async () => {


### PR DESCRIPTION
This PR removes dead fields from the `WorkerSummary` and associated jobs table/types.

This PR also fixes a bug whereby a `lastFinishedAt` timestamp was not recorded for failed jobs.