### PR TITLE
fix(status-page): inject sanitized customCSS on the public page

### DIFF
--- a/client/src/Pages/StatusPage/Status/index.tsx
+++ b/client/src/Pages/StatusPage/Status/index.tsx
@@ -21,6 +21,7 @@ import {
 	getStatusPagePublicUrl,
 	isCustomDomainHost,
 } from "@/Utils/statusPageUrl";
+import { cssReferencesExternalResource } from "@/Utils/customCss";
 import { HeaderStatusPageControls } from "@/Pages/StatusPage/Status/Components/HeaderStatusPageControls";
 import { StatusPageThemeProvider } from "@/Pages/StatusPage/Status/themes/StatusPageThemeProvider";
 import {
@@ -132,6 +133,10 @@ const StatusPageView = () => {
 	// Public route: render directly on the viewport, themed background covers everything.
 	if (isPublic) {
 		const themeConfig = THEME_CONFIGS[resolveStatusPageTheme(statusPage.theme)];
+		const customCss =
+			statusPage.customCSS && !cssReferencesExternalResource(statusPage.customCSS)
+				? statusPage.customCSS
+				: "";
 		return (
 			<StatusPageThemeProvider
 				theme={statusPage.theme}
@@ -139,6 +144,7 @@ const StatusPageView = () => {
 				timezone={statusPage.timezone}
 				paintBody
 			>
+				{customCss && <style>{customCss}</style>}
 				<BaseStatusPage
 					statusPage={statusPage}
 					monitors={monitors}


### PR DESCRIPTION
## Summary

Closes #3762. The \`customCSS\` field on status pages was persisted and validated end-to-end but never rendered on the public page, so operator-supplied styles had no effect.

## Root cause

Grep verified: no \`<style>\` tag, no \`customCSS\` reference, and no \`dangerouslySetInnerHTML\` anywhere under \`client/src/Pages/StatusPage/**\`. Data was flowing all the way to \`statusPage.customCSS\` on the client but nothing was rendering it.

## Fix

- In \`client/src/Pages/StatusPage/Status/index.tsx\`, on the public branch, render \`<style>{statusPage.customCSS}</style>\` inside the \`StatusPageThemeProvider\`.
- Reuse the existing \`cssReferencesExternalResource\` check from \`client/src/Utils/customCss.ts\` (uses \`@csstools/css-tokenizer\`) so CSS containing \`@import\`, \`url(http…)\`, \`url(//…)\`, or similar external references is dropped defensively on the client, matching the server-side check.
- The admin preview iframe already points at the public URL, so this single insertion covers both the live page and the in-app preview — no separate render path needed.

## Out of scope

Adding stable selectors (\`data-checkmate-*\` or non-hashed class names) so operators have something reliable to target. That is the second half of #3762 and will be a separate, larger PR.

## Test plan

- [ ] Save a status page with \`customCSS: "body { background: papayawhip; }"\` — public page background turns papayawhip.
- [ ] Save \`customCSS: "@import url(https://evil.example/x.css);"\` — CSS is dropped, no \`<style>\` tag rendered.
- [ ] Save \`customCSS: ""\` or leave unset — no \`<style>\` tag rendered.
- [ ] Admin preview iframe reflects the applied CSS (since it points at the public URL).
- [ ] TypeScript, ESLint, and Prettier all pass.