### PR TITLE
fix(server): raise express.json body limit to 10mb

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -54,7 +54,8 @@ export const createApp = ({
 
 	app.use(express.static(frontendPath));
 
-	app.use(express.json({ limit: "10mb" }));
+	app.use("/api/v1/monitors/import/json", express.json({ limit: "10mb" }));
+	app.use(express.json());
 	app.use(cookieParser());
 
 	app.use(sanitizeBody());

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -54,7 +54,7 @@ export const createApp = ({
 
 	app.use(express.static(frontendPath));
 
-	app.use(express.json());
+	app.use(express.json({ limit: "10mb" }));
 	app.use(cookieParser());
 
 	app.use(sanitizeBody());


### PR DESCRIPTION
## Summary

Express's default JSON body limit is 100 KB, which is too small for the monitor-import route (\`POST /api/v1/monitors/import/json\`). A backup containing more than a handful of monitors and their config quickly exceeds 100 KB and the server responds \`413 request entity too large\`.

Raise the parser cap to 10 MB:

\`\`\`ts
app.use(express.json({ limit: "10mb" }));
\`\`\`

## Rationale for 10 MB

- Fits realistic backups (thousands of monitors with full config).
- 100× the default, but bounded — keeps the DoS surface finite.
- Applies globally; every endpoint gets the same cap. That is fine for now because all POST bodies (auth, settings, monitor CRUD) are well under 10 MB.

## Follow-up (not this PR)

The right long-term shape for imports is a streaming multipart file upload via the existing \`upload\` middleware (\`server/src/api/middleware/upload.ts\`), so the global JSON cap can stay tight and imports can be hundreds of MB. Worth a separate issue.

## Test plan

- [ ] Import a backup JSON around 5 MB — succeeds.
- [ ] Import a backup JSON around 15 MB — fails with 413 (bound holds).
- [ ] Regular API calls (login, monitor create, settings edit) unaffected.