### PR TITLE
fix(infrastructure): trigger network 'no traffic' notice on interface name only

### DIFF
--- a/client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx
+++ b/client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx
@@ -92,14 +92,14 @@ export const InfraNetworkCharts = ({
 		() => getChartConfigs(theme, checks, t),
 		[theme, checks, t]
 	);
-	const showNoTrafficNotice =
+	const showLoopbackOnlyNotice =
 		chartConfigs.length > 0 && onlyContainerVisibleInterfaces(checks);
 
 	return (
 		<Stack gap={theme.spacing(LAYOUT.XS)}>
-			{showNoTrafficNotice && (
+			{showLoopbackOnlyNotice && (
 				<NoticeBanner severity="warning">
-					{t("pages.infrastructure.charts.labels.netNoTraffic")}
+					{t("pages.infrastructure.charts.labels.loopbackOnlyNotice")}
 				</NoticeBanner>
 			)}
 			<Grid

--- a/client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx
+++ b/client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx
@@ -63,10 +63,20 @@ const getChartConfigs = (
 	return configs;
 };
 
-const hasAnyNetworkTraffic = (checks: HardwareCheckStats[]): boolean =>
-	checks.some((c) =>
-		c.net?.some((iface) => iface.bytesSentPerSecond > 0 || iface.deltaBytesRecv > 0)
-	);
+// Loopback / bridge names Capture sees when it can only observe the container's
+// own network namespace. When ALL reported interfaces match this set we assume
+// the "no real interfaces visible" case and surface the notice.
+const CONTAINER_ONLY_IFACE_NAMES = new Set(["lo", "lo0", "docker0"]);
+
+const onlyContainerVisibleInterfaces = (checks: HardwareCheckStats[]): boolean => {
+	const named = new Set<string>();
+	checks.forEach((c) => c.net?.forEach((iface) => named.add(iface.name)));
+	if (named.size === 0) return false;
+	for (const name of named) {
+		if (!CONTAINER_ONLY_IFACE_NAMES.has(name)) return false;
+	}
+	return true;
+};
 
 export const InfraNetworkCharts = ({
 	checks,
@@ -82,7 +92,8 @@ export const InfraNetworkCharts = ({
 		() => getChartConfigs(theme, checks, t),
 		[theme, checks, t]
 	);
-	const showNoTrafficNotice = chartConfigs.length > 0 && !hasAnyNetworkTraffic(checks);
+	const showNoTrafficNotice =
+		chartConfigs.length > 0 && onlyContainerVisibleInterfaces(checks);
 
 	return (
 		<Stack gap={theme.spacing(LAYOUT.XS)}>

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -844,7 +844,7 @@
 					"memory": "Memory usage",
 					"netBytesRecv": "{{name}} - Bytes Received",
 					"netBytesSent": "{{name}} - Bytes Sent",
-					"netNoTraffic": "Capture is reporting zero traffic on every interface. This is normal when Capture runs inside a container that can only see loopback interfaces — run Capture directly on the host to see real network activity.",
+					"loopbackOnlyNotice": "Capture is only reporting loopback or container-bridge interfaces (lo, lo0, docker0). This is normal when Capture runs inside a container that can only see its own network namespace — run Capture directly on the host to see real network activity.",
 					"temp": "Temp"
 				}
 			},


### PR DESCRIPTION
## Summary

Related to #3765.

The Infrastructure > Network tab was firing a "Capture is reporting zero traffic on every interface … container … loopback interfaces" notice whenever the aggregated per-second delta was zero across every interface. That is a **false positive** on real hosts whenever the monitor interval is ≥ the aggregation bucket size (default: 60 s interval, 1-minute bucket). Single-sample buckets always produce zero per-second deltas even though the underlying interface has plenty of real traffic — see #3765 for the root cause.

## Fix

Base the notice on **interface names**, not on delta values.

- Only show the notice when the *only* interfaces Capture reports are loopback / container-bridge names (\`lo\`, \`lo0\`, \`docker0\`).
- Real NICs (\`enp0s6\`, \`eth0\`, \`wlan0\`, \`tunN\`, \`vethN\`, \`brN\`, …) → notice hidden, even if the current buckets read zero.
- Empty checks array → notice hidden (already gated by \`chartConfigs.length > 0\`).

The underlying zero-throughput bug (single-sample buckets) is tracked in #3765 as a separate, larger fix.

## Diff

- \`client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx\`
- +16 / -5

## Test plan

- [ ] Host running Capture directly, real NIC present → notice hidden.
- [ ] Container-only run reporting only \`lo\` → notice shown.
- [ ] Container with \`lo\` + \`docker0\` and no real NIC → notice shown.
- [ ] Empty checks / no data → notice hidden.
- [ ] TypeScript, ESLint, Prettier pass.