### PR TITLE
add img.shields.io to csp directive

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -76,6 +76,7 @@ export const createApp = ({
 				directives: {
 					upgradeInsecureRequests: null,
 					"script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+					"img-src": ["'self'", "data:", "https://img.shields.io"],
 					"object-src": ["'none'"],
 					"base-uri": ["'self'"],
 				},


### PR DESCRIPTION
Updated CSP blocks img.shields.io which breaks the star banner.  This PR adds img.shields.io to the directives