### PR TITLE
feat: Add bearer/basic auth option to webhooks

### DIFF
--- a/client/src/Hooks/useNotificationForm.ts
+++ b/client/src/Hooks/useNotificationForm.ts
@@ -44,6 +44,10 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 			type: "webhook",
 			notificationName: data.notificationName || "",
 			address: data.address || "",
+			webhookAuthType: data.webhookAuthType || "none",
+			webhookUsername: data.webhookUsername || "",
+			webhookPassword: data.webhookPassword || "",
+			webhookToken: data.webhookToken || "",
 		};
 	}
 	if (data?.type === "pager_duty") {

--- a/client/src/Pages/Notifications/create/index.tsx
+++ b/client/src/Pages/Notifications/create/index.tsx
@@ -175,6 +175,92 @@ const NotificationsCreatePage = () => {
 						}
 					/>
 				)}
+			{watchedType === "webhook" && (
+				<ConfigBox
+					title={t("pages.notifications.form.webhookAuth.title")}
+					subtitle={t("pages.notifications.form.webhookAuth.description")}
+					rightContent={
+						<Stack spacing={theme.spacing(8)}>
+							<Controller
+								name="webhookAuthType"
+								control={control}
+								defaultValue={"webhookAuthType" in defaults ? defaults.webhookAuthType : "none"}
+								render={({ field }) => (
+									<Select
+										value={field.value}
+										fieldLabel={t("pages.notifications.form.webhookAuth.optionAuthType")}
+										onChange={field.onChange}
+									>
+										<MenuItem value="none">
+											<Typography>{t("pages.notifications.form.webhookAuth.authNone")}</Typography>
+										</MenuItem>
+										<MenuItem value="basic">
+											<Typography>{t("pages.notifications.form.webhookAuth.authBasic")}</Typography>
+										</MenuItem>
+										<MenuItem value="bearer">
+											<Typography>{t("pages.notifications.form.webhookAuth.authBearer")}</Typography>
+										</MenuItem>
+									</Select>
+								)}
+							/>
+							{watch("webhookAuthType") === "basic" && (
+								<>
+									<Controller
+										name="webhookUsername"
+										control={control}
+										defaultValue={"webhookUsername" in defaults ? defaults.webhookUsername : ""}
+										render={({ field, fieldState }) => (
+											<TextField
+												{...field}
+												type="text"
+												fieldLabel={t("pages.notifications.form.webhookAuth.optionUsername")}
+												placeholder={t("pages.notifications.form.webhookAuth.placeholderUsername")}
+												fullWidth
+												error={!!fieldState.error}
+												helperText={fieldState.error?.message ?? ""}
+											/>
+										)}
+									/>
+									<Controller
+										name="webhookPassword"
+										control={control}
+										defaultValue={"webhookPassword" in defaults ? defaults.webhookPassword : ""}
+										render={({ field, fieldState }) => (
+											<TextField
+												{...field}
+												type="password"
+												fieldLabel={t("pages.notifications.form.webhookAuth.optionPassword")}
+												placeholder={t("pages.notifications.form.webhookAuth.placeholderPassword")}
+												fullWidth
+												error={!!fieldState.error}
+												helperText={fieldState.error?.message ?? ""}
+											/>
+										)}
+									/>
+								</>
+							)}
+							{watch("webhookAuthType") === "bearer" && (
+								<Controller
+									name="webhookToken"
+									control={control}
+									defaultValue={"webhookToken" in defaults ? defaults.webhookToken : ""}
+									render={({ field, fieldState }) => (
+										<TextField
+											{...field}
+											type="text"
+											fieldLabel={t("pages.notifications.form.webhookAuth.optionToken")}
+											placeholder={t("pages.notifications.form.webhookAuth.placeholderToken")}
+											fullWidth
+											error={!!fieldState.error}
+											helperText={fieldState.error?.message ?? ""}
+										/>
+									)}
+								/>
+							)}
+						</Stack>
+					}
+				/>
+			)}
 			{watchedType === "ntfy" && (
 				<ConfigBox
 					title={t("pages.notifications.form.ntfy.title")}

--- a/client/src/Types/Notification.ts
+++ b/client/src/Types/Notification.ts
@@ -27,6 +27,10 @@ export interface Notification {
 	accountSid?: string;
 	twilioPhoneNumber?: string;
 	topic?: string;
+	webhookAuthType?: 'none' | 'basic' | 'bearer';
+	webhookUsername?: string;
+	webhookPassword?: string;
+	webhookToken?: string;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/client/src/Validation/notifications.ts
+++ b/client/src/Validation/notifications.ts
@@ -28,6 +28,10 @@ const discordSchema = baseSchema.extend({
 const webhookSchema = baseSchema.extend({
 	type: z.literal("webhook"),
 	address: z.string().min(1, "Webhook URL is required").url("Please enter a valid URL"),
+	webhookAuthType: z.enum(["none", "basic", "bearer"]).optional(),
+	webhookUsername: z.string().optional(),
+	webhookPassword: z.string().optional(),
+	webhookToken: z.string().optional(),
 });
 
 const pagerDutySchema = baseSchema.extend({

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1188,6 +1188,20 @@
 					"placeholderServerUrl": "https://ntfy.sh",
 					"optionTopic": "Topic",
 					"placeholderTopic": "checkmate-alerts"
+				},
+				"webhookAuth": {
+					"title": "Webhook authentication",
+					"description": "Optionally configure authentication for your webhook requests.",
+					"optionAuthType": "Authentication type",
+					"authNone": "None",
+					"authBasic": "Basic Auth",
+					"authBearer": "Bearer Token",
+					"optionUsername": "Username",
+					"placeholderUsername": "Enter username",
+					"optionPassword": "Password",
+					"placeholderPassword": "Enter password",
+					"optionToken": "Token",
+					"placeholderToken": "Enter bearer token"
 				}
 			},
 			"table": {

--- a/server/src/api/validation/notificationValidation.ts
+++ b/server/src/api/validation/notificationValidation.ts
@@ -22,6 +22,10 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
 		roomId: z.union([z.string(), z.literal("")]).optional(),
 		accessToken: z.union([z.string(), z.literal("")]).optional(),
+		webhookAuthType: z.enum(["none", "basic", "bearer"]).optional(),
+		webhookUsername: z.union([z.string(), z.literal("")]).optional(),
+		webhookPassword: z.union([z.string(), z.literal("")]).optional(),
+		webhookToken: z.union([z.string(), z.literal("")]).optional(),
 	}),
 	// Slack notification
 	z.object({

--- a/server/src/domain/notifications/notification.model.ts
+++ b/server/src/domain/notifications/notification.model.ts
@@ -52,6 +52,10 @@ const NotificationSchema = new Schema<NotificationDocument>(
 		accountSid: { type: String },
 		twilioPhoneNumber: { type: String },
 		topic: { type: String },
+		webhookAuthType: { type: String, enum: ['none', 'basic', 'bearer'] },
+		webhookUsername: { type: String },
+		webhookPassword: { type: String },
+		webhookToken: { type: String },
 	},
 	{
 		timestamps: true,

--- a/server/src/domain/notifications/notification.type.ts
+++ b/server/src/domain/notifications/notification.type.ts
@@ -27,6 +27,10 @@ export interface Notification {
 	accountSid?: string;
 	twilioPhoneNumber?: string;
 	topic?: string;
+	webhookAuthType?: 'none' | 'basic' | 'bearer';
+	webhookUsername?: string;
+	webhookPassword?: string;
+	webhookToken?: string;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/domain/notifications/providers/webhook.ts
+++ b/server/src/domain/notifications/providers/webhook.ts
@@ -6,6 +6,25 @@ import { getTestMessage } from "@/domain/notifications/providers/utils.js";
 import got from "got";
 
 export class WebhookProvider extends NotificationProvider {
+	/**
+	 * Build authorization header based on webhook auth configuration
+	 */
+	private buildAuthHeaders = (notification: Notification): Record<string, string> => {
+		const headers: Record<string, string> = {};
+
+		if (notification.webhookAuthType === "basic") {
+			const username = notification.webhookUsername || "";
+			const password = notification.webhookPassword || "";
+			const encoded = Buffer.from(username + ":" + password).toString("base64");
+			headers["Authorization"] = "Basic " + encoded;
+		} else if (notification.webhookAuthType === "bearer") {
+			const token = notification.webhookToken || "";
+			headers["Authorization"] = "Bearer " + token;
+		}
+
+		return headers;
+	};
+
 	sendMessage = async (notification: Notification, message: NotificationMessage): Promise<boolean> => {
 		if (!notification.address) {
 			return false;
@@ -19,6 +38,7 @@ export class WebhookProvider extends NotificationProvider {
 				json: payload,
 				headers: {
 					"Content-Type": "application/json",
+					...this.buildAuthHeaders(notification),
 				},
 				...this.gotRequestOptions(),
 			});
@@ -101,6 +121,7 @@ export class WebhookProvider extends NotificationProvider {
 				json: { text: getTestMessage() },
 				headers: {
 					"Content-Type": "application/json",
+					...this.buildAuthHeaders(notification as Notification),
 				},
 				...this.gotRequestOptions(),
 			});


### PR DESCRIPTION
## Description

Closes #2369

This PR adds optional authentication support for webhook notifications. Users can now select an authentication type when configuring a webhook:

- **None** (default) - No authentication
- **Basic Auth** - Provides username and password fields, sends Authorization: Basic <base64> header
- **Bearer Token** - Provides a token field, sends Authorization: Bearer <token> header

## Changes

### Backend
- Added webhookAuthType, webhookUsername, webhookPassword, webhookToken fields to the Notification interface
- Added corresponding Mongoose schema fields
- Added optional validation fields for the webhook discriminated union
- Implemented buildAuthHeaders method in WebhookProvider to send the appropriate Authorization header based on auth type

### Frontend
- Added webhook auth UI section (auth type dropdown + conditional fields) to the notification create/edit page
- Updated Notification type, Zod validation schema, form hook defaults, and English translations

## Testing
- The auth fields are optional; existing webhook configurations continue to work without changes
- Tested in both sendMessage and sendTestAlert code paths