### PR TITLE
Fix missing "Poor" label on the average response-time gauge

### DIFF
--- a/client/src/Components/monitors/charts/RadialAvgResponse.tsx
+++ b/client/src/Components/monitors/charts/RadialAvgResponse.tsx
@@ -20,7 +20,7 @@ export const RadialAvgResponse = ({ avg, max }: { avg: number; max: number }) =>
 	const msg: Record<string, string> = {
 		success: "Excellent",
 		warning: "Average",
-		danger: "Poor",
+		error: "Poor",
 	};
 
 	return (


### PR DESCRIPTION
## Problem

`RadialAvgResponse` (`client/src/Components/monitors/charts/RadialAvgResponse.tsx`) shows a qualitative word under the average response-time gauge, keyed by the response-time palette:

```ts
const palette = getResponseTimeColor(avg);
const msg: Record<string, string> = {
    success: "Excellent",
    warning: "Average",
    danger: "Poor",
};
...
{msg[palette]}
```

But `getResponseTimeColor` (`client/src/Utils/MonitorUtils.ts`) only ever returns `"success" | "warning" | "error"` — never `"danger"`:

```ts
export const getResponseTimeColor = (responseTime: number): PaletteKey => {
    if (responseTime < 200) return "success";
    else if (responseTime < 300) return "warning";
    else return "error";
};
```

So for the slow case `palette === "error"`, and `msg["error"]` is `undefined` — no label renders.

## Evidence (intent)

The same component does `theme.palette[palette].main`, which only works because `palette` is a real MUI key (`error`). Every other palette helper in `MonitorUtils.ts` (`getStatusPalette`, `getUptimePercentageColor`, `getInfraGaugeColor`) uses `"error"`, and `"danger"` appears nowhere else in the client — so the `msg` key is simply mistyped.

## Impact

`RadialAvgResponse` is rendered on the Uptime monitor details page. Any monitor whose average response time is ≥ 300 ms (very common) shows an **empty** label instead of "Poor" — exactly the worst-performance case where the signal matters most. "Excellent"/"Average" render fine.

## Reproduction

| avg (ms) | palette | before | after |
|---|---|---|---|
| 120 | success | Excellent | Excellent |
| 250 | warning | Average | Average |
| 350 | error | *(empty)* ❌ | Poor ✅ |

## Fix

```ts
error: "Poor",
```
