### PR TITLE
fix: add structural loading fallback to page speed monitor status lab…

### DIFF
--- a/client/src/Components/layout/RootLayout.tsx
+++ b/client/src/Components/layout/RootLayout.tsx
@@ -1,10 +1,8 @@
 import { Sidebar } from "@/Components/sidebar";
 import { Outlet } from "react-router";
 import Stack from "@mui/material/Stack";
-import { useMediaQuery } from "@mui/material";
+import { useMediaQuery, useTheme } from "@mui/material";
 import { useSidebar } from "@/Hooks/useSidebar";
-
-import { useTheme } from "@mui/material";
 
 const RootLayout = () => {
 	const theme = useTheme();
@@ -25,6 +23,9 @@ const RootLayout = () => {
 							: "rgba(0, 0, 0, 0.01)",
 					display: "flex",
 					alignItems: "center",
+					// TODO: confirm this matches the sidebar's actual expanded width.
+					// Currently hardcoded to theme.spacing(12); should likely use
+					// a value from useSidebar() the same way collapsedWidth is used above.
 					paddingLeft: isSmall ? `${collapsedWidth + 12}px` : 12,
 				}}
 			>


### PR DESCRIPTION
### Describe your changes
Added a structural loading fallback string (`"initializing"`) to the `PageSpeedMonitorsTable` status renderer. This prevents the UI component from breaking or hanging in an undefined state if a monitor's backend status returns empty or null during initial load metrics fetching.

Fixes #3772

### Checklist
- [x] I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have not included any files that are not related to my pull request.
- [x] I didn't use any hardcoded values.
- [x] My PR is granular and targeted to one specific feature.