### PR TITLE
Fix monitoring status stuck

### DIFF
--- a/server/src/service/statusService.ts
+++ b/server/src/service/statusService.ts
@@ -220,11 +220,11 @@ export class StatusService implements IStatusService {
 			// Resolve "initializing" and "maintenance" up front, incidents should be created on initialization && down
 			// Unknown values (e.g. legacy boolean statuses from old versions) are resolved the same way,
 			// otherwise computeReachability can never transition them and they stay stuck forever.
-			const isKnownStatus = (MonitorStatuses as readonly string[]).includes(monitor.status);
+			  const isUnknownStatus = !MonitorStatuses.includes(monitor.status);
 			let newStatus: MonitorStatus = monitor.status;
 			let statusChanged = false;
-			if (monitor.status === "initializing" || monitor.status === "maintenance" || !isKnownStatus) {
-				newStatus = status === true ? "up" : "down";
+			if (monitor.status === "initializing" || monitor.status === "maintenance" || isUnknownStatus) {
+				newStatus = status ? "up" : "down";
 				patch.status = newStatus;
 				statusChanged = newStatus === "down";
 			}

--- a/server/src/service/statusService.ts
+++ b/server/src/service/statusService.ts
@@ -220,7 +220,7 @@ export class StatusService implements IStatusService {
 			// Resolve "initializing" and "maintenance" up front, incidents should be created on initialization && down
 			// Unknown values (e.g. legacy boolean statuses from old versions) are resolved the same way,
 			// otherwise computeReachability can never transition them and they stay stuck forever.
-			  const isUnknownStatus = !MonitorStatuses.includes(monitor.status);
+			const isUnknownStatus = !MonitorStatuses.includes(monitor.status);
 			let newStatus: MonitorStatus = monitor.status;
 			let statusChanged = false;
 			if (monitor.status === "initializing" || monitor.status === "maintenance" || isUnknownStatus) {

--- a/server/src/service/statusService.ts
+++ b/server/src/service/statusService.ts
@@ -1,7 +1,7 @@
 import { IMonitorStatsRepository } from "@/domain/monitor-stats/monitor-stats.repository.interface.js";
 import { IMonitorsRepository } from "@/domain/monitors/monitor.repository.interface.js";
 import type { Check, CheckDiskInfo, CheckSnapshot } from "@/domain/checks/check.type.js";
-import type { Monitor, MonitorStatus } from "@/domain/monitors/monitor.type.js";
+import { MonitorStatuses, type Monitor, type MonitorStatus } from "@/domain/monitors/monitor.type.js";
 import type {
 	DockerStatusPayload,
 	GameStatusPayload,
@@ -218,9 +218,12 @@ export class StatusService implements IStatusService {
 			const patch: Partial<Monitor> = {};
 
 			// Resolve "initializing" and "maintenance" up front, incidents should be created on initialization && down
+			// Unknown values (e.g. legacy boolean statuses from old versions) are resolved the same way,
+			// otherwise computeReachability can never transition them and they stay stuck forever.
+			const isKnownStatus = (MonitorStatuses as readonly string[]).includes(monitor.status);
 			let newStatus: MonitorStatus = monitor.status;
 			let statusChanged = false;
-			if (monitor.status === "initializing" || monitor.status === "maintenance") {
+			if (monitor.status === "initializing" || monitor.status === "maintenance" || !isKnownStatus) {
 				newStatus = status === true ? "up" : "down";
 				patch.status = newStatus;
 				statusChanged = newStatus === "down";

--- a/server/test/unit/services/statusService.test.ts
+++ b/server/test/unit/services/statusService.test.ts
@@ -498,6 +498,45 @@ describe("StatusService", () => {
 			expect(result.monitor.status).toBe("down");
 		});
 
+		it("resolves a legacy boolean status ('true') to 'up' on a passing check (regression: pre-upgrade monitors stuck forever)", async () => {
+			// Old Checkmate versions stored monitor.status as a boolean. Pre-fix, a monitor
+			// carrying status='true' never matched the initializing override and
+			// computeReachability only transitions to 'up' from 'down', so the legacy value
+			// was written back unchanged on every evaluation — stuck forever while the UI
+			// rendered it as 'initializing'.
+			const monitor = makeMonitor({
+				statusWindow: [true, true, true, true, true],
+				statusWindowSize: 5,
+				statusWindowThreshold: 80,
+				status: "true" as MonitorStatus,
+			});
+			const { service, monitorsRepository } = createService();
+			(monitorsRepository.findById as jest.Mock).mockResolvedValue(monitor);
+			(monitorsRepository.updateById as jest.Mock).mockImplementation((_id: unknown, _tid: unknown, m: unknown) => Promise.resolve(m));
+
+			const result = await service.updateMonitorStatus(makeStatusResponse({ status: true }), makeCheck({ status: true }), monitor);
+
+			expect(result.monitor.status).toBe("up");
+			expect(result.statusChanged).toBe(false); // was effectively up already — no notification storm
+		});
+
+		it("resolves a legacy boolean status ('false') to 'down' on a failing check (regression mirror)", async () => {
+			const monitor = makeMonitor({
+				statusWindow: [false, false, false, false, false],
+				statusWindowSize: 5,
+				statusWindowThreshold: 80,
+				status: "false" as MonitorStatus,
+			});
+			const { service, monitorsRepository } = createService();
+			(monitorsRepository.findById as jest.Mock).mockResolvedValue(monitor);
+			(monitorsRepository.updateById as jest.Mock).mockImplementation((_id: unknown, _tid: unknown, m: unknown) => Promise.resolve(m));
+
+			const result = await service.updateMonitorStatus(makeStatusResponse({ status: false }), makeCheck({ status: false }), monitor);
+
+			expect(result.monitor.status).toBe("down");
+			expect(result.statusChanged).toBe(true); // down must surface so an incident is opened
+		});
+
 		it("during warmup, sub-threshold raw checks no longer flip stored status (regression: down-during-init incident not resolving)", async () => {
 			// Once the monitor has left 'initializing', the warmup branch must NOT silently
 			// flip status from raw checks. Otherwise a down check during warmup writes


### PR DESCRIPTION
## Describe your changes                                                                                                                                                                                                         
                                                                                                                                                                                                                                   
  **Bug fix: monitors permanently stuck in "Initializing" after upgrading to v3.9.x**                                                                                                                                              
                                                                                                                                                                                                                                   
  Monitors carrying a legacy status value (e.g. the string `"true"` from older versions that stored `monitor.status` as a boolean) can never recover: `computeReachability` only transitions `down → up`, so any value outside the 
  `MonitorStatuses` enum is written back unchanged on every evaluation. Checks, `lastEvaluatedAt` and the status window all keep working — only the status stays frozen, and the UI renders the unknown value with the             
  "Initializing" fallback label forever (while the summary widgets, which aggregate on the real `initializing` value, count 0).                                                                                                    
                                                                                                                                                                                                                                   
  Older versions masked this because the warmup branch used to hard-overwrite the status on every check; that overwrite was intentionally removed in v3.9.x, which surfaced the stuck state.                                       
                                                                                                                                                                                                                                   
  Changes:                                                                                                                                                                                                                         
                                                                                                                                                                                                                                   
  - **`statusService.updateMonitorStatus`**: status values outside the `MonitorStatuses` enum are now resolved the same way as `initializing`/`maintenance`, so affected monitors self-heal on the next evaluated check. No        
  notification storm: `statusChanged` only surfaces when the resolved status is `down` (so a real outage still opens an incident).                                                                                                 
  - **Regression tests**: legacy `"true"` resolves to `up` without a status-change notification; legacy `"false"` resolves to `down` and surfaces `statusChanged` so an incident is opened.                                        
  - **UI**: infrastructure gauge titles no longer overflow their card (`overflowWrap` on the `BaseChart` title) and the title color now references the theme path (`theme.palette.text.secondary`). Shortened/fixed German gauge   
  and chart labels (typo "Termperatur", clarified temperature chart label to "CPU temperature") so they fit the cards.                                                                                                             
                                                                                                                                                                                                                                   
  Verified against a live instance: monitors stuck on `"true"` since the v3.9.2 upgrade, evaluate jobs running with zero failures — pausing/resuming (which resets the status to `initializing`) was the only workaround. With this
  fix the status resolves automatically.                                                                                                                                                                                           
                                                                                                                                                                                                                                   
  ## Write your issue number after "Fixes "                                                                                                                                                                                        
                                                                                                                                                                                                                                   
  Fixes #3772                                                                                                                                                                                                                          
                                                                                                                                                                                                                                   
  ## Please ensure all items are checked off before requesting a review.                                                                                                                                                           
                                                                                                                                                                                                                                   
  - [x] (Do not skip this or your PR will be closed) I deployed the application locally.                                                                                                                                           
  - [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.                                                                                                                     
  - [x] I have included the issue # in the PR.                                                                                                                                                                                     
  - [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):                                                                                                                                           
                                                                                                                                                                                                                                   
  ```Javascript                                                                                                                                                                                                                    
  const { t } = useTranslation();                                                                                                                                                                                                  
  <div>{t('add')}</div>                                   
  ``` 

- [x] I have not included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed                                                                            
  - [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).                                                                                
  - [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.                                                                                                        
  - [x] My PR is granular and targeted to one specific feature.                                                                                                                                                                    
  - [x] I ran npm run format in server and client directories, which automatically formats your code.                                                                                                                              
  - [ ] I took a screenshot or a video and attached to this PR if there is a UI change.  