### PR TITLE
fix: stop returning notification credentials to the client

### DIFF
--- a/client/src/Hooks/useNotificationForm.ts
+++ b/client/src/Hooks/useNotificationForm.ts
@@ -1,10 +1,14 @@
 import { useMemo } from "react";
-import { notificationSchema } from "@/Validation/notifications";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { Resolver } from "react-hook-form";
+import { notificationEditSchema, notificationSchema } from "@/Validation/notifications";
 import type { NotificationFormData } from "@/Validation/notifications";
 import type { Notification } from "@/Types/Notification";
 
 interface UseNotificationFormOptions {
 	data?: Notification | null;
+	/** True once the user has asked to replace the stored credential, which reveals its field. */
+	isCredentialReset?: boolean;
 }
 
 function buildDefaults(data: Notification | null): NotificationFormData {
@@ -12,7 +16,9 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 		type: data?.type ?? "email",
 		notificationName: data?.notificationName || "",
 		address: data?.address || "",
-		accessToken: data?.accessToken || "",
+		// Never seeded from the API: credentials are not returned, and an unchanged one is kept by
+		// leaving it out of the payload.
+		accessToken: "",
 		accountSid: data?.accountSid || "",
 		phone: data?.phone || "",
 		twilioPhoneNumber: data?.twilioPhoneNumber || "",
@@ -22,9 +28,30 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 	};
 }
 
-export const useNotificationForm = ({ data = null }: UseNotificationFormOptions = {}) => {
-	return useMemo(() => {
-		const defaults = buildDefaults(data);
-		return { schema: notificationSchema, defaults };
-	}, [data]);
+export const useNotificationForm = ({
+	data = null,
+	isCredentialReset = false,
+}: UseNotificationFormOptions = {}) => {
+	// Only the fetched notification may rebuild the defaults. Asking to replace a credential swaps
+	// the schema but must not hand the form a new defaults object, which would reset it and discard
+	// whatever the user has already typed.
+	const defaults = useMemo(() => buildDefaults(data), [data]);
+
+	/**
+	 * Whether the stored credential is being kept, meaning its field stays hidden and it is left out
+	 * of the payload. It is kept only while the user has not asked to replace it *and* the selected
+	 * channel type still matches the one it was stored against: a credential belongs to the provider
+	 * it was issued by, so switching type has to ask for a new one rather than carry the old one over.
+	 */
+	const isCredentialKept = (type: NotificationFormData["type"]) =>
+		Boolean(data?.accessTokenSet) && !isCredentialReset && type === data?.type;
+
+	// The schema depends on the type currently selected in the form, so it is resolved per validation
+	// run rather than fixed at render time.
+	const resolver: Resolver<NotificationFormData> = (values, context, options) =>
+		zodResolver(
+			isCredentialKept(values.type) ? notificationEditSchema : notificationSchema
+		)(values, context, options);
+
+	return { resolver, defaults, isCredentialKept };
 };

--- a/client/src/Pages/Notifications/create/CredentialField.tsx
+++ b/client/src/Pages/Notifications/create/CredentialField.tsx
@@ -1,0 +1,51 @@
+import Box from "@mui/material/Box";
+import { Button, FieldLabel } from "@/Components/inputs";
+import { FormTextField } from "@/Components/inputs/forms/FormTextField";
+
+interface CredentialFieldProps {
+	fieldLabel: string;
+	placeholder: string;
+	storedLabel: string;
+	resetLabel: string;
+	isEditable: boolean;
+	onReset: () => void;
+}
+
+/**
+ * Input for a stored credential. The API never returns the credential itself, so an existing one
+ * cannot be prefilled: the field is replaced by a Reset button until the user chooses to change it,
+ * the same flow the PageSpeed API key uses on the settings page.
+ */
+export const CredentialField = ({
+	fieldLabel,
+	placeholder,
+	storedLabel,
+	resetLabel,
+	isEditable,
+	onReset,
+}: CredentialFieldProps) => {
+	if (!isEditable) {
+		return (
+			<Box>
+				<FieldLabel>{storedLabel}</FieldLabel>
+				<Button
+					onClick={onReset}
+					variant="contained"
+					color="error"
+				>
+					{resetLabel}
+				</Button>
+			</Box>
+		);
+	}
+
+	return (
+		<FormTextField
+			name="accessToken"
+			type="password"
+			autoComplete="new-password"
+			fieldLabel={fieldLabel}
+			placeholder={placeholder}
+		/>
+	);
+};

--- a/client/src/Pages/Notifications/create/index.tsx
+++ b/client/src/Pages/Notifications/create/index.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/Components/inputs";
 import Stack from "@mui/material/Stack";
 import { useTheme } from "@mui/material/styles";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";
@@ -44,17 +44,27 @@ const NotificationsCreatePage = () => {
 		defaultValues: defaults,
 	});
 
-	const { watch, reset, handleSubmit, clearErrors, trigger, getValues } = form;
+	const { watch, reset, handleSubmit, clearErrors, trigger, getValues, setValue } = form;
 
 	useEffect(() => {
 		reset(defaults);
 	}, [defaults, reset]);
 
 	const watchedType = watch("type");
+	const previousType = useRef(watchedType);
 
 	useEffect(() => {
 		clearErrors();
-	}, [watchedType, clearErrors]);
+
+		if (previousType.current === watchedType) return;
+		previousType.current = watchedType;
+
+		// A credential belongs to the provider it was issued by. The field is shared across providers,
+		// and react-hook-form keeps a value when its input unmounts, so without this the credential
+		// typed for one provider silently becomes the next one's, hidden behind a masked field.
+		setValue("accessToken", "");
+		setCredentialHasBeenReset(false);
+	}, [watchedType, clearErrors, setValue]);
 
 	const addressConfig = useMemo(() => {
 		if (watchedType === "pager_duty") {

--- a/client/src/Pages/Notifications/create/index.tsx
+++ b/client/src/Pages/Notifications/create/index.tsx
@@ -3,11 +3,10 @@ import { Button } from "@/Components/inputs";
 import Stack from "@mui/material/Stack";
 import { useTheme } from "@mui/material/styles";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useNavigate } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { useGet, usePost, usePatch } from "@/Hooks/UseApi";
 import { useNotificationForm } from "@/Hooks/useNotificationForm";
 import type { NotificationFormData } from "@/Validation/notifications";
@@ -16,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { NotificationChannels } from "@/Types/Notification";
 import { FormTextField } from "@/Components/inputs/forms/FormTextField";
 import { FormSelectField } from "@/Components/inputs/forms/FormSelectField";
+import { CredentialField } from "./CredentialField";
 
 const NotificationsCreatePage = () => {
 	const { t } = useTranslation();
@@ -32,10 +32,15 @@ const NotificationsCreatePage = () => {
 	const { patch, loading: isPatching } = usePatch<NotificationFormData, Notification>();
 	const { post: testPost, loading: isTesting } = usePost<NotificationFormData, void>();
 
-	const { schema, defaults } = useNotificationForm({ data: existingNotification });
+	const [credentialHasBeenReset, setCredentialHasBeenReset] = useState(false);
+
+	const { resolver, defaults, isCredentialKept } = useNotificationForm({
+		data: existingNotification,
+		isCredentialReset: credentialHasBeenReset,
+	});
 
 	const form = useForm<NotificationFormData>({
-		resolver: zodResolver(schema),
+		resolver,
 		defaultValues: defaults,
 	});
 
@@ -76,10 +81,22 @@ const NotificationsCreatePage = () => {
 		};
 	}, [watchedType, t]);
 
+	// A credential the user has not chosen to replace is left out of the payload entirely, which the
+	// server reads as "keep the stored value".
+	const buildPayload = (data: NotificationFormData): NotificationFormData => {
+		if (!isCredentialKept(data.type)) {
+			return data;
+		}
+		const payload = { ...data };
+		Reflect.deleteProperty(payload, "accessToken");
+		return payload;
+	};
+
 	const onSubmit = async (data: NotificationFormData) => {
+		const payload = buildPayload(data);
 		const result = isEditMode
-			? await patch(`/notifications/${notificationId}`, data)
-			: await post("/notifications", data);
+			? await patch(`/notifications/${notificationId}`, payload)
+			: await post("/notifications", payload);
 		if (result) {
 			navigate("/notifications");
 		}
@@ -88,8 +105,19 @@ const NotificationsCreatePage = () => {
 	const handleTest = async () => {
 		const isValid = await trigger();
 		if (!isValid) return;
-		const data = getValues();
-		await testPost("/notifications/test", data);
+		const payload = buildPayload(getValues());
+		// Testing a saved channel goes through its own endpoint so the server can supply the stored
+		// credential. Anything else — an unsaved channel, or one being switched to another provider,
+		// whose stored credential no longer applies — carries what it needs in the body.
+		const isSavedChannel = isEditMode && watchedType === existingNotification?.type;
+		const endpoint = isSavedChannel
+			? `/notifications/${notificationId}/test`
+			: "/notifications/test";
+		await testPost(endpoint, payload);
+	};
+
+	const handleCredentialReset = () => {
+		setCredentialHasBeenReset(true);
 	};
 
 	return (
@@ -166,10 +194,13 @@ const NotificationsCreatePage = () => {
 						subtitle={t("pages.notifications.form.telegram.description")}
 						rightContent={
 							<Stack spacing={theme.spacing(8)}>
-								<FormTextField
-									name="accessToken"
+								<CredentialField
 									fieldLabel={t("pages.notifications.form.telegram.optionBotToken")}
 									placeholder={t("pages.notifications.form.telegram.placeholderBotToken")}
+									storedLabel={t("pages.notifications.form.credential.labelSet")}
+									resetLabel={t("common.buttons.reset")}
+									isEditable={!isCredentialKept(watchedType)}
+									onReset={handleCredentialReset}
 								/>
 								<FormTextField
 									name="address"
@@ -186,10 +217,13 @@ const NotificationsCreatePage = () => {
 						subtitle={t("pages.notifications.form.pushover.description")}
 						rightContent={
 							<Stack spacing={theme.spacing(8)}>
-								<FormTextField
-									name="accessToken"
+								<CredentialField
 									fieldLabel={t("pages.notifications.form.pushover.optionAppToken")}
 									placeholder={t("pages.notifications.form.pushover.placeholderAppToken")}
+									storedLabel={t("pages.notifications.form.credential.labelSet")}
+									resetLabel={t("common.buttons.reset")}
+									isEditable={!isCredentialKept(watchedType)}
+									onReset={handleCredentialReset}
 								/>
 
 								<FormTextField
@@ -212,10 +246,13 @@ const NotificationsCreatePage = () => {
 									fieldLabel={t("pages.notifications.form.twilio.optionAccountSid")}
 									placeholder={t("pages.notifications.form.twilio.placeholderAccountSid")}
 								/>
-								<FormTextField
-									name="accessToken"
+								<CredentialField
 									fieldLabel={t("pages.notifications.form.twilio.optionAuthToken")}
 									placeholder={t("pages.notifications.form.twilio.placeholderAuthToken")}
+									storedLabel={t("pages.notifications.form.credential.labelSet")}
+									resetLabel={t("common.buttons.reset")}
+									isEditable={!isCredentialKept(watchedType)}
+									onReset={handleCredentialReset}
 								/>
 
 								<FormTextField
@@ -249,10 +286,13 @@ const NotificationsCreatePage = () => {
 									fieldLabel={t("pages.notifications.form.roomId.optionRoomId")}
 									placeholder={t("pages.notifications.form.roomId.placeholder")}
 								/>
-								<FormTextField
-									name="accessToken"
+								<CredentialField
 									fieldLabel={t("pages.notifications.form.accessToken.optionAccessToken")}
 									placeholder={t("pages.notifications.form.accessToken.placeholder")}
+									storedLabel={t("pages.notifications.form.credential.labelSet")}
+									resetLabel={t("common.buttons.reset")}
+									isEditable={!isCredentialKept(watchedType)}
+									onReset={handleCredentialReset}
 								/>
 							</Stack>
 						}

--- a/client/src/Types/Notification.ts
+++ b/client/src/Types/Notification.ts
@@ -24,10 +24,11 @@ export interface Notification {
 	phone?: string;
 	homeserverUrl?: string;
 	roomId?: string;
-	accessToken?: string;
 	accountSid?: string;
 	twilioPhoneNumber?: string;
 	topic?: string;
 	createdAt: string;
 	updatedAt: string;
+	/** The API never returns the stored access token, only whether one is stored. */
+	accessTokenSet: boolean;
 }

--- a/client/src/Validation/notifications.ts
+++ b/client/src/Validation/notifications.ts
@@ -99,4 +99,39 @@ export const notificationSchema = z.discriminatedUnion("type", [
 	ntfySchema,
 ]);
 
+// Used while an existing credential is being kept. Its field is hidden, so it holds an empty string
+// that has to pass validation; the empty value is then stripped from the payload and the server
+// keeps the stored credential. Once the user asks to replace a credential the field is shown again
+// and notificationSchema applies, so an empty value is reported inline as usual.
+const keptCredential = z.string();
+
+export const notificationEditSchema = z.discriminatedUnion("type", [
+	emailSchema,
+	slackSchema,
+	discordSchema,
+	webhookSchema,
+	rocketChatSchema,
+	pagerDutySchema,
+	matrixSchema.extend({ accessToken: keptCredential }),
+	teamsSchema,
+	telegramSchema.extend({ accessToken: keptCredential }),
+	pushoverSchema.extend({ accessToken: keptCredential }),
+	twilioSchema.extend({ accessToken: keptCredential }),
+	ntfySchema,
+]);
+
+// Build-time drift detection, mirroring the server's EditUnionCoversEveryChannel: a channel added to
+// notificationSchema must also reach notificationEditSchema. Missing it makes that channel
+// impossible to edit, and zod reports the cause only as "Invalid input" on the type field.
+type Assert<T extends true> = T;
+type ChannelMissingFromEditSchema = Exclude<
+	z.infer<typeof notificationSchema>["type"],
+	z.infer<typeof notificationEditSchema>["type"]
+>;
+export type EditSchemaCoversEveryChannel = Assert<
+	[ChannelMissingFromEditSchema] extends [never]
+		? true
+		: { addToNotificationEditSchema: ChannelMissingFromEditSchema }
+>;
+
 export type NotificationFormData = z.infer<typeof notificationSchema>;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1122,6 +1122,9 @@
 					"optionAccessToken": "Access token",
 					"placeholder": "syt_YWxleF9ob2xsaWRheQ_VmtScmV0U2VjcmV0S2V5_abc123"
 				},
+				"credential": {
+					"labelSet": "Credential is set. Click Reset to change it."
+				},
 				"address": {
 					"description": "The address where notifications will be sent.",
 					"optionAddress": "Address",

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -871,6 +871,58 @@
 				},
 				"required": ["monitorData", "monitorStats"]
 			},
+			"Notification": {
+				"type": "object",
+				"properties": {
+					"id": {
+						"type": "string"
+					},
+					"userId": {
+						"type": "string"
+					},
+					"teamId": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string",
+						"enum": ["email", "slack", "discord", "webhook", "rocket_chat", "pager_duty", "matrix", "teams", "telegram", "pushover", "twilio", "ntfy"]
+					},
+					"notificationName": {
+						"type": "string"
+					},
+					"address": {
+						"type": "string"
+					},
+					"phone": {
+						"type": "string"
+					},
+					"homeserverUrl": {
+						"type": "string"
+					},
+					"roomId": {
+						"type": "string"
+					},
+					"accountSid": {
+						"type": "string"
+					},
+					"twilioPhoneNumber": {
+						"type": "string"
+					},
+					"topic": {
+						"type": "string"
+					},
+					"createdAt": {
+						"type": "string"
+					},
+					"updatedAt": {
+						"type": "string"
+					},
+					"accessTokenSet": {
+						"type": "boolean"
+					}
+				},
+				"required": ["id", "userId", "teamId", "type", "notificationName", "createdAt", "updatedAt", "accessTokenSet"]
+			},
 			"NotificationChannelBody": {
 				"oneOf": [
 					{
@@ -1419,6 +1471,434 @@
 					"address": "https://ntfy.sh",
 					"topic": "checkmate-alerts"
 				}
+			},
+			"NotificationChannelEditBody": {
+				"oneOf": [
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["email"]
+							},
+							"address": {
+								"type": "string",
+								"format": "email"
+							},
+							"homeserverUrl": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"roomId": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"accessToken": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["webhook"]
+							},
+							"address": {
+								"type": "string",
+								"format": "uri"
+							},
+							"homeserverUrl": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"roomId": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"accessToken": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["rocket_chat"]
+							},
+							"address": {
+								"type": "string",
+								"format": "uri"
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["slack"]
+							},
+							"address": {
+								"type": "string",
+								"format": "uri"
+							},
+							"homeserverUrl": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"roomId": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"accessToken": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["discord"]
+							},
+							"address": {
+								"type": "string",
+								"format": "uri"
+							},
+							"homeserverUrl": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"roomId": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"accessToken": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["pager_duty"]
+							},
+							"address": {
+								"type": "string",
+								"minLength": 1
+							},
+							"homeserverUrl": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"roomId": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"accessToken": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["matrix"]
+							},
+							"address": {
+								"anyOf": [
+									{
+										"type": "string"
+									},
+									{
+										"type": "string",
+										"enum": [""]
+									}
+								]
+							},
+							"homeserverUrl": {
+								"type": "string",
+								"format": "uri"
+							},
+							"roomId": {
+								"type": "string",
+								"minLength": 1
+							},
+							"accessToken": {
+								"type": "string",
+								"minLength": 1
+							}
+						},
+						"required": ["notificationName", "type", "homeserverUrl", "roomId"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["teams"]
+							},
+							"address": {
+								"type": "string",
+								"format": "uri"
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["telegram"]
+							},
+							"address": {
+								"type": "string",
+								"minLength": 1
+							},
+							"accessToken": {
+								"type": "string",
+								"minLength": 1
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["pushover"]
+							},
+							"address": {
+								"type": "string",
+								"minLength": 1
+							},
+							"accessToken": {
+								"type": "string",
+								"minLength": 1
+							}
+						},
+						"required": ["notificationName", "type", "address"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["twilio"]
+							},
+							"accountSid": {
+								"type": "string",
+								"minLength": 1
+							},
+							"accessToken": {
+								"type": "string",
+								"minLength": 1
+							},
+							"phone": {
+								"type": "string",
+								"minLength": 1
+							},
+							"twilioPhoneNumber": {
+								"type": "string",
+								"minLength": 1
+							}
+						},
+						"required": ["notificationName", "type", "accountSid", "phone", "twilioPhoneNumber"]
+					},
+					{
+						"type": "object",
+						"properties": {
+							"notificationName": {
+								"type": "string",
+								"minLength": 1
+							},
+							"type": {
+								"type": "string",
+								"enum": ["ntfy"]
+							},
+							"address": {
+								"type": "string",
+								"format": "uri"
+							},
+							"topic": {
+								"type": "string",
+								"minLength": 1
+							}
+						},
+						"required": ["notificationName", "type", "address", "topic"]
+					}
+				]
 			}
 		},
 		"parameters": {}
@@ -6791,14 +7271,6 @@
 					},
 					{
 						"schema": {
-							"type": "boolean"
-						},
-						"required": false,
-						"name": "normalize",
-						"in": "query"
-					},
-					{
-						"schema": {
 							"anyOf": [
 								{
 									"type": "string",
@@ -8962,7 +9434,7 @@
 			"post": {
 				"tags": ["notifications"],
 				"summary": "Create a notification channel",
-				"description": "Create a notification channel of any supported type. The `type` field discriminates the body shape.",
+				"description": "Create a notification channel of any supported type. The `type` field discriminates the body shape. Credentials are stored but never returned; the response reports `accessTokenSet` instead.",
 				"security": [
 					{
 						"bearerAuth": []
@@ -8993,10 +9465,10 @@
 											"type": "string"
 										},
 										"data": {
-											"nullable": true
+											"$ref": "#/components/schemas/Notification"
 										}
 									},
-									"required": ["success", "msg"]
+									"required": ["success", "msg", "data"]
 								}
 							}
 						}
@@ -9317,6 +9789,141 @@
 				}
 			}
 		},
+		"/notifications/{id}/test": {
+			"post": {
+				"tags": ["notifications"],
+				"summary": "Send a test alert through a saved notification channel",
+				"description": "Credentials omitted from the body are taken from the saved channel, so a channel can be tested without the client holding its secret. Omitting a credential while changing where the notification is delivered is rejected.",
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string",
+							"minLength": 1
+						},
+						"required": true,
+						"name": "id",
+						"in": "path"
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/NotificationChannelEditBody"
+							}
+						}
+					}
+				},
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"type": "object",
+											"properties": {
+												"success": {
+													"type": "boolean"
+												}
+											},
+											"required": ["success"],
+											"additionalProperties": {
+												"nullable": true
+											}
+										}
+									},
+									"required": ["success", "msg", "data"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Forbidden",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
 		"/notifications/team": {
 			"get": {
 				"tags": ["notifications"],
@@ -9342,10 +9949,13 @@
 											"type": "string"
 										},
 										"data": {
-											"nullable": true
+											"type": "array",
+											"items": {
+												"$ref": "#/components/schemas/Notification"
+											}
 										}
 									},
-									"required": ["success", "msg"]
+									"required": ["success", "msg", "data"]
 								}
 							}
 						}
@@ -9458,10 +10068,10 @@
 											"type": "string"
 										},
 										"data": {
-											"nullable": true
+											"$ref": "#/components/schemas/Notification"
 										}
 									},
-									"required": ["success", "msg"]
+									"required": ["success", "msg", "data"]
 								}
 							}
 						}
@@ -9655,6 +10265,7 @@
 			"patch": {
 				"tags": ["notifications"],
 				"summary": "Edit a notification channel",
+				"description": "Credentials may be omitted, which leaves the stored value unchanged. An empty credential is rejected, so a required one cannot be blanked out by mistake. Changing where the channel delivers, or which provider it uses, requires supplying the credential rather than relying on the stored one.",
 				"security": [
 					{
 						"bearerAuth": []
@@ -9675,7 +10286,7 @@
 					"content": {
 						"application/json": {
 							"schema": {
-								"$ref": "#/components/schemas/NotificationChannelBody"
+								"$ref": "#/components/schemas/NotificationChannelEditBody"
 							}
 						}
 					}
@@ -9696,10 +10307,10 @@
 											"type": "string"
 										},
 										"data": {
-											"nullable": true
+											"$ref": "#/components/schemas/Notification"
 										}
 									},
-									"required": ["success", "msg"]
+									"required": ["success", "msg", "data"]
 								}
 							}
 						}

--- a/server/openapi/routes/notification.ts
+++ b/server/openapi/routes/notification.ts
@@ -4,9 +4,12 @@ import { bearer, json, okJson, okJsonNoData, okUnknown, standardErrors } from ".
 import {
 	createNotificationBodyValidation,
 	deleteNotificationParamValidation,
+	editNotificationBodyValidation,
 	getNotificationByIdParamValidation,
 	editNotificationParamValidation,
+	notificationResponseSchema,
 	testAllNotificationsBodyValidation,
+	testSavedNotificationParamValidation,
 } from "@/api/validation/notificationValidation.js";
 
 const tags = ["notifications"];
@@ -96,15 +99,21 @@ const notificationBody = z
 	.discriminatedUnion("type", decoratedVariants as typeof createNotificationBodyValidation.options)
 	.openapi("NotificationChannelBody");
 
+// Same channels, but every credential may be omitted to keep the stored value.
+const notificationEditBody = editNotificationBodyValidation.openapi("NotificationChannelEditBody");
+
+const notificationObject = notificationResponseSchema.openapi("Notification");
+
 registry.registerPath({
 	method: "post",
 	path: "/notifications",
 	tags,
 	summary: "Create a notification channel",
-	description: "Create a notification channel of any supported type. The `type` field discriminates the body shape.",
+	description:
+		"Create a notification channel of any supported type. The `type` field discriminates the body shape. Credentials are stored but never returned; the response reports `accessTokenSet` instead.",
 	security: bearer,
 	request: { body: { content: json(notificationBody) } },
-	responses: { "200": okUnknown, ...standardErrors },
+	responses: { "200": okJson(notificationObject), ...standardErrors },
 });
 
 registry.registerPath({
@@ -128,12 +137,24 @@ registry.registerPath({
 });
 
 registry.registerPath({
+	method: "post",
+	path: "/notifications/{id}/test",
+	tags,
+	summary: "Send a test alert through a saved notification channel",
+	description:
+		"Credentials omitted from the body are taken from the saved channel, so a channel can be tested without the client holding its secret. Omitting a credential while changing where the notification is delivered is rejected.",
+	security: bearer,
+	request: { params: testSavedNotificationParamValidation, body: { content: json(notificationEditBody) } },
+	responses: { "200": okJson(z.object({ success: z.boolean() }).passthrough()), ...standardErrors },
+});
+
+registry.registerPath({
 	method: "get",
 	path: "/notifications/team",
 	tags,
 	summary: "List notification channels for the caller's team",
 	security: bearer,
-	responses: { "200": okUnknown, ...standardErrors },
+	responses: { "200": okJson(z.array(notificationObject)), ...standardErrors },
 });
 
 registry.registerPath({
@@ -143,7 +164,7 @@ registry.registerPath({
 	summary: "Get a notification channel by id",
 	security: bearer,
 	request: { params: getNotificationByIdParamValidation },
-	responses: { "200": okUnknown, ...standardErrors },
+	responses: { "200": okJson(notificationObject), ...standardErrors },
 });
 
 registry.registerPath({
@@ -161,7 +182,8 @@ registry.registerPath({
 	path: "/notifications/{id}",
 	tags,
 	summary: "Edit a notification channel",
+	description: "Credentials may be omitted, which leaves the stored value unchanged. Sending an empty credential is rejected.",
 	security: bearer,
-	request: { params: editNotificationParamValidation, body: { content: json(notificationBody) } },
-	responses: { "200": okUnknown, ...standardErrors },
+	request: { params: editNotificationParamValidation, body: { content: json(notificationEditBody) } },
+	responses: { "200": okJson(notificationObject), ...standardErrors },
 });

--- a/server/openapi/routes/notification.ts
+++ b/server/openapi/routes/notification.ts
@@ -182,7 +182,8 @@ registry.registerPath({
 	path: "/notifications/{id}",
 	tags,
 	summary: "Edit a notification channel",
-	description: "Credentials may be omitted, which leaves the stored value unchanged. Sending an empty credential is rejected.",
+	description:
+		"Credentials may be omitted, which leaves the stored value unchanged. An empty credential is rejected, so a required one cannot be blanked out by mistake. Changing where the channel delivers, or which provider it uses, requires supplying the credential rather than relying on the stored one.",
 	security: bearer,
 	request: { params: editNotificationParamValidation, body: { content: json(notificationEditBody) } },
 	responses: { "200": okJson(notificationObject), ...standardErrors },

--- a/server/src/api/controllers/notificationController.ts
+++ b/server/src/api/controllers/notificationController.ts
@@ -4,13 +4,17 @@ import { catchAsync } from "@/utils/catchAsync.js";
 import {
 	createNotificationBodyValidation,
 	deleteNotificationParamValidation,
+	editNotificationBodyValidation,
 	getNotificationByIdParamValidation,
 	testNotificationBodyValidation,
 	editNotificationParamValidation,
 	testAllNotificationsBodyValidation,
+	testSavedNotificationBodyValidation,
+	testSavedNotificationParamValidation,
 } from "@/api/validation/notificationValidation.js";
 import { AppError } from "@/utils/AppError.js";
 import { INotificationsService } from "@/domain/notifications/notification.service.js";
+import type { Notification, PublicNotification } from "@/domain/notifications/notification.type.js";
 import { requireTeamId, requireUserId } from "./controllerUtils.js";
 import { IMonitorsRepository } from "@/domain/monitors/monitor.repository.interface.js";
 
@@ -18,6 +22,7 @@ const SERVICE_NAME = "NotificationController";
 
 export interface INotificationController {
 	testNotification: RequestHandler;
+	testSavedNotification: RequestHandler;
 	createNotification: RequestHandler;
 	getNotificationsByTeamId: RequestHandler;
 	deleteNotification: RequestHandler;
@@ -33,9 +38,44 @@ class NotificationController implements INotificationController {
 		this.monitorsRepository = monitorsRepository;
 	}
 
+	// Builds the client-facing shape of a notification. Credentials are never part of it: each one
+	// is reported as a boolean saying whether a value is stored, the same way settingsController
+	// reports pagespeedKeySet and emailPasswordSet.
+	toPublicNotification = (notification: Notification): PublicNotification => ({
+		id: notification.id,
+		userId: notification.userId,
+		teamId: notification.teamId,
+		type: notification.type,
+		notificationName: notification.notificationName,
+		address: notification.address,
+		phone: notification.phone,
+		homeserverUrl: notification.homeserverUrl,
+		roomId: notification.roomId,
+		accountSid: notification.accountSid,
+		twilioPhoneNumber: notification.twilioPhoneNumber,
+		topic: notification.topic,
+		createdAt: notification.createdAt,
+		updatedAt: notification.updatedAt,
+		accessTokenSet: Boolean(notification.accessToken),
+	});
+
 	testNotification = catchAsync(async (req: Request, res: Response) => {
 		const notification = testNotificationBodyValidation.parse(req.body);
 		const success = await this.notificationsService.sendTestNotification(notification);
+
+		return res.status(200).json({
+			success,
+			msg: success ? "Notification sent successfully" : "Notification could not be sent — check the destination details.",
+			details: { service: SERVICE_NAME },
+		});
+	});
+
+	testSavedNotification = catchAsync(async (req: Request, res: Response) => {
+		const teamId = requireTeamId(req.user?.teamId);
+		const validatedParams = testSavedNotificationParamValidation.parse(req.params);
+		const validatedBody = testSavedNotificationBodyValidation.parse(req.body);
+
+		const success = await this.notificationsService.sendTestNotificationById(validatedParams.id, teamId, validatedBody);
 
 		return res.status(200).json({
 			success,
@@ -54,7 +94,7 @@ class NotificationController implements INotificationController {
 		return res.status(200).json({
 			success: true,
 			msg: "Notification created successfully",
-			data: notification,
+			data: this.toPublicNotification(notification),
 		});
 	});
 
@@ -65,7 +105,7 @@ class NotificationController implements INotificationController {
 		return res.status(200).json({
 			success: true,
 			msg: "Notifications fetched successfully",
-			data: notifications,
+			data: notifications.map(this.toPublicNotification),
 		});
 	});
 
@@ -89,12 +129,14 @@ class NotificationController implements INotificationController {
 		return res.status(200).json({
 			success: true,
 			msg: "Notification fetched successfully",
-			data: notification,
+			data: this.toPublicNotification(notification),
 		});
 	});
 
 	editNotification = catchAsync(async (req: Request, res: Response) => {
-		const validatedBody = createNotificationBodyValidation.parse(req.body);
+		// Credentials are not returned, so the client cannot send back the ones it never received.
+		// The edit schema lets them be omitted, which leaves the stored value untouched.
+		const validatedBody = editNotificationBodyValidation.parse(req.body);
 		const validatedParams = editNotificationParamValidation.parse(req.params);
 
 		const teamId = requireTeamId(req.user?.teamId);
@@ -104,7 +146,7 @@ class NotificationController implements INotificationController {
 		return res.status(200).json({
 			success: true,
 			msg: "Notification updated successfully",
-			data: editedNotification,
+			data: this.toPublicNotification(editedNotification),
 		});
 	});
 

--- a/server/src/api/routes/notificationRoutes.ts
+++ b/server/src/api/routes/notificationRoutes.ts
@@ -7,6 +7,7 @@ export const createNotificationRoutes = (notificationController: INotificationCo
 	router.post("/test/all", notificationController.testAllNotifications);
 	router.post("/test", notificationController.testNotification);
 	router.get("/team", notificationController.getNotificationsByTeamId);
+	router.post("/:id/test", notificationController.testSavedNotification);
 	router.get("/:id", notificationController.getNotificationById);
 	router.delete("/:id", notificationController.deleteNotification);
 	router.patch("/:id", notificationController.editNotification);

--- a/server/src/api/validation/notificationValidation.ts
+++ b/server/src/api/validation/notificationValidation.ts
@@ -1,112 +1,160 @@
 import { z } from "zod";
+import { NotificationChannels } from "@/domain/notifications/notification.type.js";
 
 //****************************************
 // Notification Validations
 //****************************************
 
+const notificationName = z.string().min(1, "Notification name is required");
+
+// Matrix fields that the simpler channels also accept but never use. Declared once and shared so
+// bodies posted by the existing form keep validating.
+const unusedMatrixFields = {
+	homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
+	roomId: z.union([z.string(), z.literal("")]).optional(),
+	accessToken: z.union([z.string(), z.literal("")]).optional(),
+};
+
+const emailSchema = z.object({
+	notificationName,
+	type: z.literal("email"),
+	address: z.email("Please enter a valid e-mail address"),
+	...unusedMatrixFields,
+});
+
+const webhookSchema = z.object({
+	notificationName,
+	type: z.literal("webhook"),
+	address: z.url({ message: "Please enter a valid Webhook URL" }),
+	...unusedMatrixFields,
+});
+
+// No unusedMatrixFields spread, unlike its webhook-shaped siblings: develop declared this channel
+// without them, and widening it here would let a credential be stored on a channel that has no field
+// to reset it from.
+const rocketChatSchema = z.object({
+	notificationName,
+	type: z.literal("rocket_chat"),
+	address: z.url({ protocol: /^https?$/, message: "Please enter a valid Rocket.Chat webhook URL" }),
+});
+
+const slackSchema = z.object({
+	notificationName,
+	type: z.literal("slack"),
+	address: z.url({ message: "Please enter a valid Webhook URL" }),
+	...unusedMatrixFields,
+});
+
+const discordSchema = z.object({
+	notificationName,
+	type: z.literal("discord"),
+	address: z.url({ message: "Please enter a valid Webhook URL" }),
+	...unusedMatrixFields,
+});
+
+const pagerDutySchema = z.object({
+	notificationName,
+	type: z.literal("pager_duty"),
+	address: z.string().min(1, "PagerDuty integration key is required"),
+	...unusedMatrixFields,
+});
+
+const matrixSchema = z.object({
+	notificationName,
+	type: z.literal("matrix"),
+	address: z.union([z.string(), z.literal("")]).optional(),
+	homeserverUrl: z.url({ message: "Please enter a valid Homeserver URL" }),
+	roomId: z.string().min(1, "Room ID is required"),
+	accessToken: z.string().min(1, "Access Token is required"),
+});
+
+const teamsSchema = z.object({
+	notificationName,
+	type: z.literal("teams"),
+	address: z.url({ message: "Please enter a valid Webhook URL" }),
+});
+
+const telegramSchema = z.object({
+	notificationName,
+	type: z.literal("telegram"),
+	address: z.string().min(1, "Chat ID is required"),
+	accessToken: z.string().min(1, "Bot token is required"),
+});
+
+const pushoverSchema = z.object({
+	notificationName,
+	type: z.literal("pushover"),
+	address: z.string().min(1, "User key is required"),
+	accessToken: z.string().min(1, "App token is required"),
+});
+
+const twilioSchema = z.object({
+	notificationName,
+	type: z.literal("twilio"),
+	accountSid: z.string().min(1, "Account SID is required"),
+	accessToken: z.string().min(1, "Auth token is required"),
+	phone: z.string().min(1, "Recipient phone number is required"),
+	twilioPhoneNumber: z.string().min(1, "Twilio phone number is required"),
+});
+
+const ntfySchema = z.object({
+	notificationName,
+	type: z.literal("ntfy"),
+	address: z.url({ message: "Please enter a valid ntfy server URL" }),
+	topic: z.string().min(1, "Topic is required"),
+});
+
 export const createNotificationBodyValidation = z.discriminatedUnion("type", [
-	// Email notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("email"),
-		address: z.email("Please enter a valid e-mail address"),
-		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
-		roomId: z.union([z.string(), z.literal("")]).optional(),
-		accessToken: z.union([z.string(), z.literal("")]).optional(),
-	}),
-	// Webhook notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("webhook"),
-		address: z.url({ message: "Please enter a valid Webhook URL" }),
-		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
-		roomId: z.union([z.string(), z.literal("")]).optional(),
-		accessToken: z.union([z.string(), z.literal("")]).optional(),
-	}),
-	// Rocket.Chat notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("rocket_chat"),
-		address: z.url({
-			protocol: /^https?$/,
-			message: "Please enter a valid Rocket.Chat webhook URL",
-		}),
-	}),
-	// Slack notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("slack"),
-		address: z.url({ message: "Please enter a valid Webhook URL" }),
-		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
-		roomId: z.union([z.string(), z.literal("")]).optional(),
-		accessToken: z.union([z.string(), z.literal("")]).optional(),
-	}),
-	// Discord notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("discord"),
-		address: z.url({ message: "Please enter a valid Webhook URL" }),
-		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
-		roomId: z.union([z.string(), z.literal("")]).optional(),
-		accessToken: z.union([z.string(), z.literal("")]).optional(),
-	}),
-	// PagerDuty notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("pager_duty"),
-		address: z.string().min(1, "PagerDuty integration key is required"),
-		homeserverUrl: z.union([z.string(), z.literal("")]).optional(),
-		roomId: z.union([z.string(), z.literal("")]).optional(),
-		accessToken: z.union([z.string(), z.literal("")]).optional(),
-	}),
-	// Matrix notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("matrix"),
-		address: z.union([z.string(), z.literal("")]).optional(),
-		homeserverUrl: z.url({ message: "Please enter a valid Homeserver URL" }),
-		roomId: z.string().min(1, "Room ID is required"),
-		accessToken: z.string().min(1, "Access Token is required"),
-	}),
-	// Teams notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("teams"),
-		address: z.url({ message: "Please enter a valid Webhook URL" }),
-	}),
-	// Telegram notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("telegram"),
-		address: z.string().min(1, "Chat ID is required"),
-		accessToken: z.string().min(1, "Bot token is required"),
-	}),
-	// Pushover notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("pushover"),
-		address: z.string().min(1, "User key is required"),
-		accessToken: z.string().min(1, "App token is required"),
-	}),
-	// Twilio SMS notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("twilio"),
-		accountSid: z.string().min(1, "Account SID is required"),
-		accessToken: z.string().min(1, "Auth token is required"),
-		phone: z.string().min(1, "Recipient phone number is required"),
-		twilioPhoneNumber: z.string().min(1, "Twilio phone number is required"),
-	}),
-	// ntfy notification
-	z.object({
-		notificationName: z.string().min(1, "Notification name is required"),
-		type: z.literal("ntfy"),
-		address: z.url({ message: "Please enter a valid ntfy server URL" }),
-		topic: z.string().min(1, "Topic is required"),
-	}),
+	emailSchema,
+	webhookSchema,
+	rocketChatSchema,
+	slackSchema,
+	discordSchema,
+	pagerDutySchema,
+	matrixSchema,
+	teamsSchema,
+	telegramSchema,
+	pushoverSchema,
+	twilioSchema,
+	ntfySchema,
 ]);
 
+// Editing an existing channel may omit its stored credential, which means "keep the stored value".
+// Derived from the create schemas so each channel stays declared once: only the credential becomes
+// optional, so an empty string is still rejected and a required credential cannot be blanked out.
+export const editNotificationBodyValidation = z.discriminatedUnion("type", [
+	emailSchema,
+	webhookSchema,
+	rocketChatSchema,
+	slackSchema,
+	discordSchema,
+	pagerDutySchema,
+	matrixSchema.partial({ accessToken: true }),
+	teamsSchema,
+	telegramSchema.partial({ accessToken: true }),
+	pushoverSchema.partial({ accessToken: true }),
+	twilioSchema.partial({ accessToken: true }),
+	ntfySchema,
+]);
+
+// Build-time drift detection, mirroring NotificationFieldsAreClassified in notification.type.ts: a
+// channel added to the create union must also reach the edit union. Missing it leaves that channel
+// impossible to edit, and a discriminated union reports the cause only as "Invalid input" on the
+// type field, which is a hard failure to trace back to this list.
+type Assert<T extends true> = T;
+type ChannelMissingFromEditUnion = Exclude<
+	z.infer<typeof createNotificationBodyValidation>["type"],
+	z.infer<typeof editNotificationBodyValidation>["type"]
+>;
+export type EditUnionCoversEveryChannel = Assert<
+	[ChannelMissingFromEditUnion] extends [never] ? true : { addToEditNotificationBodyValidation: ChannelMissingFromEditUnion }
+>;
+
+// Testing an unsaved channel carries every credential in the body, so it stays strict.
 export const testNotificationBodyValidation = createNotificationBodyValidation;
+
+// Testing a saved channel may omit credentials; the server fills them in from the stored record.
+export const testSavedNotificationBodyValidation = editNotificationBodyValidation;
 
 export const deleteNotificationParamValidation = z.object({
 	id: z.string().min(1, "Notification ID is required"),
@@ -116,6 +164,30 @@ export const getNotificationByIdParamValidation = z.object({
 });
 export const editNotificationParamValidation = z.object({
 	id: z.string().min(1, "Notification ID is required"),
+});
+export const testSavedNotificationParamValidation = z.object({
+	id: z.string().min(1, "Notification ID is required"),
+});
+
+// Canonical notification shape returned by /notifications endpoints. Credentials are absent by
+// design: each one is reported as a boolean "<field>Set" so a client can tell that a value is
+// stored without receiving it.
+export const notificationResponseSchema = z.object({
+	id: z.string(),
+	userId: z.string(),
+	teamId: z.string(),
+	type: z.enum(NotificationChannels),
+	notificationName: z.string(),
+	address: z.string().optional(),
+	phone: z.string().optional(),
+	homeserverUrl: z.string().optional(),
+	roomId: z.string().optional(),
+	accountSid: z.string().optional(),
+	twilioPhoneNumber: z.string().optional(),
+	topic: z.string().optional(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+	accessTokenSet: z.boolean(),
 });
 
 export const testAllNotificationsBodyValidation = z.object({

--- a/server/src/domain/notifications/notification.service.ts
+++ b/server/src/domain/notifications/notification.service.ts
@@ -1,6 +1,6 @@
 import type { Monitor } from "@/domain/monitors/monitor.type.js";
 import type { Notification } from "@/domain/notifications/notification.type.js";
-import { NotificationDestinationFields, NotificationSecretFields } from "@/domain/notifications/notification.type.js";
+import { NotificationCredentialFields, NotificationDestinationFields, NotificationSecretFields } from "@/domain/notifications/notification.type.js";
 import { AppError } from "@/utils/AppError.js";
 import type { MonitorStatusResponse } from "@/types/network.js";
 import type { NotificationMessage } from "@/domain/notifications/notification.type.js";
@@ -11,7 +11,7 @@ import type { MonitorActionDecision } from "@/worker/worker.helper.js";
 import type { ISettingsService } from "@/domain/app-settings/app-settings.service.js";
 import { ILogger } from "@/utils/logger.js";
 import type { INotificationMessageBuilder } from "@/domain/notifications/notification.message-builder.js";
-import type { NotificationChannel } from "@/domain/notifications/notification.type.js";
+import type { NotificationChannel, NotificationSecretField } from "@/domain/notifications/notification.type.js";
 
 export type NotificationProviderRegistry = Record<NotificationChannel, INotificationProvider>;
 
@@ -149,6 +149,62 @@ export class NotificationsService implements INotificationsService {
 		return await provider.sendTestAlert(notification);
 	};
 
+	// Secrets a channel's provider actually authenticates with. A credential stored against a channel
+	// whose provider never reads one is inert, so it must not constrain that channel: treating it as
+	// live left records with a leftover credential unable to change their address at all, and channels
+	// whose schema drops the field could not even clear it.
+	//
+	// The fallback is defensive only. Every request body is a discriminated union over the known
+	// channels, so an unrecognised type cannot arrive through the API; it exists so that a hand-edited
+	// document errs towards guarding the credential rather than skipping the check.
+	private credentialFieldsFor = (type: NotificationChannel): readonly NotificationSecretField[] =>
+		(NotificationCredentialFields[type] as readonly NotificationSecretField[] | undefined) ?? NotificationSecretFields;
+
+	// Secrets a request leaves to the stored record, by omitting them. A stored empty credential counts
+	// as no credential, the same way the API reports it.
+	private keptSecretFields = (notification: Partial<Notification>, storedNotification: Notification): readonly NotificationSecretField[] =>
+		this.credentialFieldsFor(storedNotification.type).filter((field) => notification[field] === undefined && Boolean(storedNotification[field]));
+
+	// A credential the server supplies on the caller's behalf may only ever reach the destination it is
+	// already stored against. A request that keeps a stored credential and repoints the channel at the
+	// same time has to supply that credential explicitly, otherwise the caller could name a host they
+	// control and have the server deliver the secret there. Applies to both testing and saving,
+	// because a saved change reaches the same place on the next alert.
+	private assertKeptCredentialStaysPut = (
+		notification: Partial<Notification>,
+		storedNotification: Notification,
+		keptSecrets: readonly NotificationSecretField[],
+		method: string
+	): void => {
+		if (keptSecrets.length === 0) return;
+
+		const destinationFields = NotificationDestinationFields[storedNotification.type] as readonly (keyof Notification)[] | undefined;
+		if (destinationFields === undefined) {
+			// Defensive, like the fallback above: unreachable through the API, since a stored type the
+			// validators do not know is always a type change, which sheds the credential before this runs.
+			throw new AppError({
+				message: "This channel's type is not recognised, so its stored credentials cannot be reused",
+				status: 400,
+				service: SERVICE_NAME,
+				method,
+			});
+		}
+
+		// An absent field counts as changed, which fails closed. That only stays comfortable while every
+		// destination field is required by its channel's schema: make one optional, and a patch that
+		// legitimately omits it starts being refused with an instruction the caller cannot act on.
+		const destinationChanged = destinationFields.some((field) => notification[field] !== storedNotification[field]);
+
+		if (destinationChanged) {
+			throw new AppError({
+				message: "Enter the credentials again to use this channel with a different destination",
+				status: 400,
+				service: SERVICE_NAME,
+				method,
+			});
+		}
+	};
+
 	// Tests a saved channel. Credentials the client left out are filled in from the stored record so
 	// that a channel can be tested without the client ever holding its secret. A backfilled secret is
 	// only ever allowed to travel to the destination it is already stored against: if the caller
@@ -165,22 +221,8 @@ export class NotificationsService implements INotificationsService {
 			});
 		}
 
-		// A stored empty credential counts as no credential, the same way the API reports it.
-		const backfilledFields = NotificationSecretFields.filter((field) => notification[field] === undefined && Boolean(storedNotification[field]));
-
-		if (backfilledFields.length > 0) {
-			const destinationFields: readonly (keyof Notification)[] = NotificationDestinationFields[storedNotification.type];
-			const destinationChanged = destinationFields.some((field) => notification[field] !== storedNotification[field]);
-
-			if (destinationChanged) {
-				throw new AppError({
-					message: "Enter the credentials again to test this channel with a different destination",
-					status: 400,
-					service: SERVICE_NAME,
-					method: "sendTestNotificationById",
-				});
-			}
-		}
+		const backfilledFields = this.keptSecretFields(notification, storedNotification);
+		this.assertKeptCredentialStaysPut(notification, storedNotification, backfilledFields, "sendTestNotificationById");
 
 		const testNotification: Partial<Notification> = { ...notification };
 		for (const field of backfilledFields) {
@@ -216,8 +258,49 @@ export class NotificationsService implements INotificationsService {
 		return await this.notificationsRepository.findByTeamId(teamId);
 	};
 
+	// An edit that omits a credential keeps the stored one, so it is subject to the same rule as a test:
+	// a kept credential may not be repointed. Without this, the guard on the test path could be walked
+	// around in two requests: save the new destination first, which leaves stored and incoming
+	// agreeing, then test. A saved change is also worse than a test, because every later alert carries
+	// the credential to the new destination too.
 	updateById = async (id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification> => {
-		return await this.notificationsRepository.updateById(id, teamId, updateData);
+		const storedNotification = await this.notificationsRepository.findById(id, teamId);
+		const patch: Partial<Notification> = { ...updateData };
+		const targetType = updateData.type;
+
+		if (targetType !== undefined && targetType !== storedNotification.type) {
+			// A credential is issued by one provider and means nothing to another, so it must not follow a
+			// channel to a different type. It is dropped rather than demanded back, because the target
+			// provider's schema need not accept the field at all, which would make a refusal impossible to
+			// satisfy. Every stored secret goes, not only the ones this channel could use, so a conversion
+			// never carries someone else's leftovers forward.
+			for (const field of NotificationSecretFields) {
+				if (patch[field] === undefined && Boolean(storedNotification[field])) {
+					patch[field] = "";
+				}
+			}
+
+			// The channel still has to be able to send afterwards. Leaving it credential-less would look
+			// configured and silently never deliver, which is the worst outcome for a monitoring tool, and
+			// creating the same channel from scratch is rejected. So ask for the new provider's credential
+			// instead of quietly producing a dead channel.
+			const missingCredentials = this.credentialFieldsFor(targetType).filter((field) => !patch[field]);
+			if (missingCredentials.length > 0) {
+				throw new AppError({
+					message: "Enter the credentials for the channel type you are switching to",
+					status: 400,
+					service: SERVICE_NAME,
+					method: "updateById",
+				});
+			}
+		}
+
+		// Runs on every path, including after a conversion. Clearing already left nothing kept, so this is
+		// a no-op there rather than skipped: clearing and guarding are not alternatives, and the guard must
+		// not depend on the cleared write actually landing.
+		this.assertKeptCredentialStaysPut(patch, storedNotification, this.keptSecretFields(patch, storedNotification), "updateById");
+
+		return await this.notificationsRepository.updateById(id, teamId, patch);
 	};
 
 	deleteById = async (id: string, teamId: string): Promise<Notification> => {

--- a/server/src/domain/notifications/notification.service.ts
+++ b/server/src/domain/notifications/notification.service.ts
@@ -1,5 +1,7 @@
 import type { Monitor } from "@/domain/monitors/monitor.type.js";
 import type { Notification } from "@/domain/notifications/notification.type.js";
+import { NotificationDestinationFields, NotificationSecretFields } from "@/domain/notifications/notification.type.js";
+import { AppError } from "@/utils/AppError.js";
 import type { MonitorStatusResponse } from "@/types/network.js";
 import type { NotificationMessage } from "@/domain/notifications/notification.type.js";
 import { IMonitorsRepository } from "@/domain/monitors/monitor.repository.interface.js";
@@ -22,6 +24,7 @@ export interface INotificationsService {
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
+	sendTestNotificationById: (id: string, teamId: string, notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
 }
 
@@ -144,6 +147,47 @@ export class NotificationsService implements INotificationsService {
 			return false;
 		}
 		return await provider.sendTestAlert(notification);
+	};
+
+	// Tests a saved channel. Credentials the client left out are filled in from the stored record so
+	// that a channel can be tested without the client ever holding its secret. A backfilled secret is
+	// only ever allowed to travel to the destination it is already stored against: if the caller
+	// changed where the notification is delivered, the credential has to be supplied explicitly.
+	sendTestNotificationById = async (id: string, teamId: string, notification: Partial<Notification>): Promise<boolean> => {
+		const storedNotification = await this.notificationsRepository.findById(id, teamId);
+
+		if (notification.type !== storedNotification.type) {
+			throw new AppError({
+				message: "Notification type does not match the saved channel",
+				status: 400,
+				service: SERVICE_NAME,
+				method: "sendTestNotificationById",
+			});
+		}
+
+		// A stored empty credential counts as no credential, the same way the API reports it.
+		const backfilledFields = NotificationSecretFields.filter((field) => notification[field] === undefined && Boolean(storedNotification[field]));
+
+		if (backfilledFields.length > 0) {
+			const destinationFields: readonly (keyof Notification)[] = NotificationDestinationFields[storedNotification.type];
+			const destinationChanged = destinationFields.some((field) => notification[field] !== storedNotification[field]);
+
+			if (destinationChanged) {
+				throw new AppError({
+					message: "Enter the credentials again to test this channel with a different destination",
+					status: 400,
+					service: SERVICE_NAME,
+					method: "sendTestNotificationById",
+				});
+			}
+		}
+
+		const testNotification: Partial<Notification> = { ...notification };
+		for (const field of backfilledFields) {
+			testNotification[field] = storedNotification[field];
+		}
+
+		return await this.sendTestNotification(testNotification);
 	};
 
 	testAllNotifications = async (notificationIds: string[]) => {

--- a/server/src/domain/notifications/notification.type.ts
+++ b/server/src/domain/notifications/notification.type.ts
@@ -40,6 +40,12 @@ export type NotificationSecretField = (typeof NotificationSecretFields)[number];
 // secret" so a newly added field stays invisible to clients until it is deliberately classified.
 // accountSid is public on purpose: it is Twilio's Basic-auth username and travels in the request
 // URL by design, so it identifies an account rather than authenticating one.
+//
+// address is public because it is the channel's destination and the form has always shown it, but
+// for the webhook-shaped channels the URL is itself the authorization, and for pager_duty it is the
+// routing key. Treating those as secret would change the API and the form for six channel types, so
+// it is left as it was rather than settled here. This list is not a claim that every entry is
+// harmless to expose; it is a claim that nothing reaches a client without being considered.
 export const NotificationPublicFields = [
 	"id",
 	"userId",
@@ -62,14 +68,37 @@ export type NotificationPublicField = (typeof NotificationPublicFields)[number];
 // mirroring pagespeedKeySet / emailPasswordSet in settingsController.
 export type NotificationSecretFlag = `${NotificationSecretField}Set`;
 
-// The notification shape returned by the API. Every public field is a required key (its value may
-// still be undefined) so a response cannot silently drop one.
-export type PublicNotification = { [K in NotificationPublicField]-?: Notification[K] | undefined } & Record<NotificationSecretFlag, boolean>;
+// The notification shape returned by the API. Every public field is a required key, so a response
+// cannot silently drop one; an optional field keeps its own optional value type.
+export type PublicNotification = { [K in NotificationPublicField]-?: Notification[K] } & Record<NotificationSecretFlag, boolean>;
 
-// Fields that decide which host a notification is delivered to, and therefore where a stored
+// Which stored secrets a channel's provider actually authenticates with. A secret stored against a
+// channel that does not use one is inert: it never reaches a request, so it must not restrict edits
+// to that channel either. Such records exist, because switching a channel's type used to leave the
+// previous provider's credential in the document.
+export const NotificationCredentialFields = {
+	email: [], // delivered by the configured SMTP server, which carries its own credentials
+	slack: [], // the webhook URL is the whole authorization
+	discord: [],
+	webhook: [],
+	rocket_chat: [],
+	pager_duty: [], // the routing key travels in the payload, not as a credential
+	matrix: ["accessToken"],
+	teams: [],
+	telegram: ["accessToken"],
+	pushover: ["accessToken"],
+	twilio: ["accessToken"],
+	ntfy: [], // until ntfy auth lands, see #3717
+} as const satisfies Record<NotificationChannel, readonly NotificationSecretField[]>;
+
+// Fields that decide which HOST a notification is delivered to, and therefore where a stored
 // credential would travel. Channels whose provider posts to a fixed host have no such field: their
 // credential can only ever reach that provider's own API. Exhaustive over NotificationChannel so a
 // new channel has to make this decision rather than inherit an unguarded default.
+//
+// Host, not recipient: a fixed-host channel's credential can still be repointed at another chat id,
+// user key or phone number without being re-entered. That discloses future alerts to whoever owns
+// the new recipient, but never the credential itself, which is why those entries stay empty.
 export const NotificationDestinationFields = {
 	email: [], // delivered by the configured SMTP server, not by the address
 	slack: ["address"],

--- a/server/src/domain/notifications/notification.type.ts
+++ b/server/src/domain/notifications/notification.type.ts
@@ -32,6 +32,68 @@ export interface Notification {
 	updatedAt: string;
 }
 
+// Credentials. Stored and used to send, never returned to the client.
+export const NotificationSecretFields = ["accessToken"] as const satisfies readonly (keyof Notification)[];
+export type NotificationSecretField = (typeof NotificationSecretFields)[number];
+
+// Fields the API may return. Listed explicitly rather than derived as "everything that is not a
+// secret" so a newly added field stays invisible to clients until it is deliberately classified.
+// accountSid is public on purpose: it is Twilio's Basic-auth username and travels in the request
+// URL by design, so it identifies an account rather than authenticating one.
+export const NotificationPublicFields = [
+	"id",
+	"userId",
+	"teamId",
+	"type",
+	"notificationName",
+	"address",
+	"phone",
+	"homeserverUrl",
+	"roomId",
+	"accountSid",
+	"twilioPhoneNumber",
+	"topic",
+	"createdAt",
+	"updatedAt",
+] as const satisfies readonly Exclude<keyof Notification, NotificationSecretField>[];
+export type NotificationPublicField = (typeof NotificationPublicFields)[number];
+
+// Each secret is replaced in responses by a boolean telling the client whether one is stored,
+// mirroring pagespeedKeySet / emailPasswordSet in settingsController.
+export type NotificationSecretFlag = `${NotificationSecretField}Set`;
+
+// The notification shape returned by the API. Every public field is a required key (its value may
+// still be undefined) so a response cannot silently drop one.
+export type PublicNotification = { [K in NotificationPublicField]-?: Notification[K] | undefined } & Record<NotificationSecretFlag, boolean>;
+
+// Fields that decide which host a notification is delivered to, and therefore where a stored
+// credential would travel. Channels whose provider posts to a fixed host have no such field: their
+// credential can only ever reach that provider's own API. Exhaustive over NotificationChannel so a
+// new channel has to make this decision rather than inherit an unguarded default.
+export const NotificationDestinationFields = {
+	email: [], // delivered by the configured SMTP server, not by the address
+	slack: ["address"],
+	discord: ["address"],
+	webhook: ["address"],
+	rocket_chat: ["address"],
+	pager_duty: [], // fixed host: events.pagerduty.com
+	matrix: ["homeserverUrl"],
+	teams: ["address"],
+	telegram: [], // fixed host: api.telegram.org
+	pushover: [], // fixed host: api.pushover.net
+	twilio: [], // fixed host: api.twilio.com
+	ntfy: ["address"],
+} as const satisfies Record<NotificationChannel, readonly (keyof Notification)[]>;
+
+// Build-time drift detection: every field of Notification must be classified above. Adding one
+// without classifying it fails the build, the same way openapi/routes/notification.ts fails when a
+// notification variant has no metadata entry.
+type Assert<T extends true> = T;
+type UnclassifiedNotificationField = Exclude<keyof Notification, NotificationPublicField | NotificationSecretField>;
+export type NotificationFieldsAreClassified = Assert<
+	[UnclassifiedNotificationField] extends [never] ? true : { classifyAsPublicOrSecret: UnclassifiedNotificationField }
+>;
+
 export interface AlertPagerDutyPayload {
 	routing_key?: string;
 	dedup_key?: string;

--- a/server/src/domain/notifications/providers/matrix.ts
+++ b/server/src/domain/notifications/providers/matrix.ts
@@ -39,7 +39,10 @@ export class MatrixProvider extends NotificationProvider {
 	private sendMessageWithBody = async (notification: Partial<Notification>, body: unknown): Promise<boolean> => {
 		const { homeserverUrl, accessToken, roomId } = notification;
 		const txnId = randomUUID();
-		const url = `${homeserverUrl}/_matrix/client/v3/rooms/${roomId}/send/m.room.message/${txnId}`;
+		// roomId is encoded because it is a caller-supplied path segment, the same way ntfy encodes its
+		// topic. Unencoded, a room id containing escaped slashes redirects this authenticated request to
+		// another endpoint on the same homeserver.
+		const url = `${homeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId ?? "")}/send/m.room.message/${txnId}`;
 
 		try {
 			await got.put(url, {

--- a/server/test/unit/controllers/notificationController.test.ts
+++ b/server/test/unit/controllers/notificationController.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import type { NextFunction, Request, Response } from "express";
+import NotificationController from "../../../src/api/controllers/notificationController.ts";
+import type { INotificationsService } from "../../../src/domain/notifications/notification.service.ts";
+import type { IMonitorsRepository } from "../../../src/domain/monitors/monitor.repository.interface.ts";
+import { notificationResponseSchema } from "../../../src/api/validation/notificationValidation.ts";
+import type { Notification } from "../../../src/domain/notifications/notification.type.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeNotification = (overrides?: Partial<Notification>): Notification =>
+	({
+		id: "notif-1",
+		userId: "user-1",
+		teamId: "team-1",
+		type: "telegram",
+		notificationName: "Telegram alerts",
+		address: "-1001234567890",
+		accessToken: "super-secret-bot-token",
+		createdAt: "2026-01-01T00:00:00Z",
+		updatedAt: "2026-01-01T00:00:00Z",
+		...overrides,
+	}) as Notification;
+
+const makeResponse = () => {
+	const json = jest.fn();
+	const status = jest.fn(() => ({ json }));
+	return { res: { status } as unknown as Response, status, json };
+};
+
+const makeRequest = (overrides?: Partial<Request>): Request =>
+	({
+		params: {},
+		body: {},
+		user: { id: "user-1", teamId: "team-1" },
+		...overrides,
+	}) as unknown as Request;
+
+const setup = (serviceOverrides?: Partial<INotificationsService>) => {
+	const notificationsService = {
+		createNotification: jest.fn(),
+		findById: jest.fn(),
+		findNotificationsByTeamId: jest.fn(),
+		updateById: jest.fn(),
+		deleteById: jest.fn(),
+		handleNotifications: jest.fn(),
+		sendTestNotification: jest.fn(),
+		sendTestNotificationById: jest.fn(),
+		testAllNotifications: jest.fn(),
+		...serviceOverrides,
+	} as unknown as INotificationsService;
+
+	const monitorsRepository = {} as IMonitorsRepository;
+	const controller = new NotificationController(notificationsService, monitorsRepository);
+	const next = jest.fn() as unknown as NextFunction;
+
+	return { controller, notificationsService, next };
+};
+
+const dataFrom = (json: jest.Mock) => (json.mock.calls[0][0] as { data: Record<string, unknown> }).data;
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("notificationController — credentials in responses", () => {
+	it("omits the credential and reports that one is stored when fetching by id", async () => {
+		const { controller, next } = setup({
+			findById: jest.fn<INotificationsService["findById"]>().mockResolvedValue(makeNotification()),
+		});
+		const { res, json } = makeResponse();
+
+		await controller.getNotificationById(makeRequest({ params: { id: "notif-1" } }), res, next);
+
+		const data = dataFrom(json);
+		expect(data).not.toHaveProperty("accessToken");
+		expect(data.accessTokenSet).toBe(true);
+		expect(data.notificationName).toBe("Telegram alerts");
+	});
+
+	it("reports no stored credential when the channel has none", async () => {
+		const notification = makeNotification({ type: "webhook", accessToken: undefined });
+		const { controller, next } = setup({
+			findById: jest.fn<INotificationsService["findById"]>().mockResolvedValue(notification),
+		});
+		const { res, json } = makeResponse();
+
+		await controller.getNotificationById(makeRequest({ params: { id: "notif-1" } }), res, next);
+
+		expect(dataFrom(json).accessTokenSet).toBe(false);
+	});
+
+	it("treats a stored empty credential as no credential", async () => {
+		const { controller, next } = setup({
+			findById: jest.fn<INotificationsService["findById"]>().mockResolvedValue(makeNotification({ accessToken: "" })),
+		});
+		const { res, json } = makeResponse();
+
+		await controller.getNotificationById(makeRequest({ params: { id: "notif-1" } }), res, next);
+
+		expect(dataFrom(json).accessTokenSet).toBe(false);
+	});
+
+	it("omits the credential from every notification in the team listing", async () => {
+		const notifications = [makeNotification(), makeNotification({ id: "notif-2", accessToken: undefined })];
+		const { controller, next } = setup({
+			findNotificationsByTeamId: jest.fn<INotificationsService["findNotificationsByTeamId"]>().mockResolvedValue(notifications),
+		});
+		const { res, json } = makeResponse();
+
+		await controller.getNotificationsByTeamId(makeRequest(), res, next);
+
+		const data = (json.mock.calls[0][0] as { data: Record<string, unknown>[] }).data;
+		expect(data).toHaveLength(2);
+		expect(data[0]).not.toHaveProperty("accessToken");
+		expect(data[1]).not.toHaveProperty("accessToken");
+		expect(data[0].accessTokenSet).toBe(true);
+		expect(data[1].accessTokenSet).toBe(false);
+	});
+
+	it("omits the credential from the create response", async () => {
+		const { controller, next } = setup({
+			createNotification: jest.fn<INotificationsService["createNotification"]>().mockResolvedValue(makeNotification()),
+		});
+		const { res, json } = makeResponse();
+		const body = { notificationName: "Telegram alerts", type: "telegram", address: "-1001234567890", accessToken: "super-secret-bot-token" };
+
+		await controller.createNotification(makeRequest({ body }), res, next);
+
+		expect(dataFrom(json)).not.toHaveProperty("accessToken");
+		expect(dataFrom(json).accessTokenSet).toBe(true);
+	});
+
+	it("omits the credential from the edit response", async () => {
+		const { controller, next } = setup({
+			updateById: jest.fn<INotificationsService["updateById"]>().mockResolvedValue(makeNotification()),
+		});
+		const { res, json } = makeResponse();
+		const body = { notificationName: "Renamed", type: "telegram", address: "-1001234567890" };
+
+		await controller.editNotification(makeRequest({ params: { id: "notif-1" }, body }), res, next);
+
+		expect(dataFrom(json)).not.toHaveProperty("accessToken");
+	});
+
+	it("returns exactly the shape the OpenAPI spec documents", async () => {
+		const { controller, next } = setup({
+			findById: jest.fn<INotificationsService["findById"]>().mockResolvedValue(makeNotification()),
+		});
+		const { res, json } = makeResponse();
+
+		await controller.getNotificationById(makeRequest({ params: { id: "notif-1" } }), res, next);
+
+		// strict() rejects any key the response schema does not document, so a field that starts
+		// being returned without being added to the spec fails here.
+		expect(() => notificationResponseSchema.strict().parse(dataFrom(json))).not.toThrow();
+	});
+
+	it("returns identifiers that are not credentials", async () => {
+		const twilio = makeNotification({
+			type: "twilio",
+			accountSid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			twilioPhoneNumber: "+15557654321",
+			phone: "+15551234567",
+		});
+		const { controller, next } = setup({
+			findById: jest.fn<INotificationsService["findById"]>().mockResolvedValue(twilio),
+		});
+		const { res, json } = makeResponse();
+
+		await controller.getNotificationById(makeRequest({ params: { id: "notif-1" } }), res, next);
+
+		const data = dataFrom(json);
+		expect(data.accountSid).toBe("ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
+		expect(data.twilioPhoneNumber).toBe("+15557654321");
+		expect(data).not.toHaveProperty("accessToken");
+	});
+});
+
+describe("notificationController — editing without the credential", () => {
+	it("forwards a patch that leaves the credential out, so the stored one is kept", async () => {
+		const updateById = jest.fn<INotificationsService["updateById"]>().mockResolvedValue(makeNotification());
+		const { controller, next } = setup({ updateById });
+		const { res } = makeResponse();
+		const body = { notificationName: "Renamed", type: "telegram", address: "-1001234567890" };
+
+		await controller.editNotification(makeRequest({ params: { id: "notif-1" }, body }), res, next);
+
+		expect(updateById).toHaveBeenCalledTimes(1);
+		const [, , patch] = updateById.mock.calls[0];
+		expect(patch).not.toHaveProperty("accessToken");
+	});
+
+	it("forwards a replacement credential when one is sent", async () => {
+		const updateById = jest.fn<INotificationsService["updateById"]>().mockResolvedValue(makeNotification());
+		const { controller, next } = setup({ updateById });
+		const { res } = makeResponse();
+		const body = { notificationName: "Renamed", type: "telegram", address: "-1001234567890", accessToken: "new-token" };
+
+		await controller.editNotification(makeRequest({ params: { id: "notif-1" }, body }), res, next);
+
+		const [, , patch] = updateById.mock.calls[0];
+		expect(patch).toHaveProperty("accessToken", "new-token");
+	});
+});

--- a/server/test/unit/controllers/notificationController.test.ts
+++ b/server/test/unit/controllers/notificationController.test.ts
@@ -201,3 +201,70 @@ describe("notificationController — editing without the credential", () => {
 		expect(patch).toHaveProperty("accessToken", "new-token");
 	});
 });
+
+describe("notificationController: testing a saved channel", () => {
+	const body = { notificationName: "Telegram alerts", type: "telegram", address: "-1001234567890" };
+
+	it("passes the id from the path and the team from the caller's token", async () => {
+		const sendTestNotificationById = jest.fn<INotificationsService["sendTestNotificationById"]>().mockResolvedValue(true);
+		const { controller, next } = setup({ sendTestNotificationById });
+		const { res, json } = makeResponse();
+
+		await controller.testSavedNotification(makeRequest({ params: { id: "notif-1" }, body }), res, next);
+
+		expect(sendTestNotificationById).toHaveBeenCalledWith("notif-1", "team-1", expect.objectContaining({ type: "telegram" }));
+		expect(next).not.toHaveBeenCalled();
+		expect((json.mock.calls[0][0] as { success: boolean }).success).toBe(true);
+	});
+
+	it("ignores a teamId supplied in the body", async () => {
+		// Otherwise this endpoint would hand any team's stored credential to a caller-named destination.
+		const sendTestNotificationById = jest.fn<INotificationsService["sendTestNotificationById"]>().mockResolvedValue(true);
+		const { controller, next } = setup({ sendTestNotificationById });
+		const { res } = makeResponse();
+
+		await controller.testSavedNotification(makeRequest({ params: { id: "notif-1" }, body: { ...body, teamId: "team-victim" } }), res, next);
+
+		expect(sendTestNotificationById).toHaveBeenCalledWith("notif-1", "team-1", expect.anything());
+	});
+
+	it("validates the body with the edit schema, so an empty credential is refused", async () => {
+		const sendTestNotificationById = jest.fn<INotificationsService["sendTestNotificationById"]>().mockResolvedValue(true);
+		const { controller, next } = setup({ sendTestNotificationById });
+		const { res } = makeResponse();
+
+		await controller.testSavedNotification(makeRequest({ params: { id: "notif-1" }, body: { ...body, accessToken: "" } }), res, next);
+
+		expect(sendTestNotificationById).not.toHaveBeenCalled();
+		expect(next).toHaveBeenCalled();
+	});
+
+	it("reports a failed send without claiming success", async () => {
+		const sendTestNotificationById = jest.fn<INotificationsService["sendTestNotificationById"]>().mockResolvedValue(false);
+		const { controller, next } = setup({ sendTestNotificationById });
+		const { res, json } = makeResponse();
+
+		await controller.testSavedNotification(makeRequest({ params: { id: "notif-1" }, body }), res, next);
+
+		expect((json.mock.calls[0][0] as { success: boolean }).success).toBe(false);
+	});
+});
+
+describe("notificationResponseSchema", () => {
+	it("refuses to document a credential, so the redaction cannot be undone by widening the schema", () => {
+		const valid = {
+			id: "notif-1",
+			userId: "user-1",
+			teamId: "team-1",
+			type: "telegram",
+			notificationName: "Telegram alerts",
+			address: "-1001234567890",
+			createdAt: "2026-01-01T00:00:00Z",
+			updatedAt: "2026-01-01T00:00:00Z",
+			accessTokenSet: true,
+		};
+
+		expect(notificationResponseSchema.strict().safeParse(valid).success).toBe(true);
+		expect(notificationResponseSchema.strict().safeParse({ ...valid, accessToken: "leaked" }).success).toBe(false);
+	});
+});

--- a/server/test/unit/providers/notifications/matrixProvider.test.ts
+++ b/server/test/unit/providers/notifications/matrixProvider.test.ts
@@ -29,10 +29,22 @@ describe("MatrixProvider", () => {
 		it("sends to Matrix API and returns true", async () => {
 			expect(await createProvider().provider.sendTestAlert(makeNotification())).toBe(true);
 			expect(mockGotPut).toHaveBeenCalledWith(
-				expect.stringContaining("matrix.example.com/_matrix/client/v3/rooms/!room:example.com/send/m.room.message/test-uuid-1234"),
+				expect.stringContaining("matrix.example.com/_matrix/client/v3/rooms/!room%3Aexample.com/send/m.room.message/test-uuid-1234"),
 				expect.objectContaining({
 					headers: expect.objectContaining({ Authorization: "Bearer token-abc" }),
 				})
+			);
+		});
+
+		it("encodes the room id so it cannot redirect the authenticated request", async () => {
+			// An unencoded room id containing escaped slashes would move this PUT, and its Authorization
+			// header, to another endpoint on the same homeserver.
+			await createProvider().provider.sendTestAlert(makeNotification({ roomId: "..%2f..%2faccount_data/m.attacker" }));
+
+			const [url] = mockGotPut.mock.calls[0] as [string];
+			// The escaped slashes are themselves escaped, so nothing decodes back to a path separator.
+			expect(url).toBe(
+				"https://matrix.example.com/_matrix/client/v3/rooms/..%252f..%252faccount_data%2Fm.attacker/send/m.room.message/test-uuid-1234"
 			);
 		});
 

--- a/server/test/unit/services/notificationsService.test.ts
+++ b/server/test/unit/services/notificationsService.test.ts
@@ -360,6 +360,147 @@ describe("NotificationsService", () => {
 		});
 	});
 
+	// ── credentials on the send path ──────────────────────────────────────────
+
+	describe("credentials reaching the providers", () => {
+		it("still hands the provider the stored credential when an alert fires", async () => {
+			const { service, notificationsRepository, telegramProvider } = createService();
+			(notificationsRepository.findNotificationsByIds as jest.Mock).mockResolvedValue([
+				makeNotification({ type: "telegram", accessToken: "stored-token" }),
+			]);
+
+			await service.handleNotifications(makeMonitor(), makeStatusResponse(), makeDecision());
+
+			expect(telegramProvider.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ accessToken: "stored-token" }), expect.anything());
+		});
+
+		it("still hands the provider the stored credential when testing every channel of a monitor", async () => {
+			const { service, notificationsRepository, telegramProvider } = createService();
+			(notificationsRepository.findNotificationsByIds as jest.Mock).mockResolvedValue([
+				makeNotification({ type: "telegram", accessToken: "stored-token" }),
+			]);
+
+			await service.testAllNotifications(["notif-1"]);
+
+			expect(telegramProvider.sendTestAlert).toHaveBeenCalledWith(expect.objectContaining({ accessToken: "stored-token" }));
+		});
+	});
+
+	// ── sendTestNotificationById ──────────────────────────────────────────────
+
+	describe("sendTestNotificationById", () => {
+		const storedMatrix = makeNotification({
+			type: "matrix",
+			homeserverUrl: "https://matrix.example.com",
+			roomId: "!room:example.com",
+			accessToken: "stored-token",
+		});
+
+		it("fills in a credential the caller left out from the stored notification", async () => {
+			const { service, notificationsRepository, matrixProvider } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrix);
+
+			const result = await service.sendTestNotificationById("notif-1", "team-1", {
+				type: "matrix",
+				homeserverUrl: "https://matrix.example.com",
+				roomId: "!other:example.com",
+			});
+
+			expect(result).toBe(true);
+			expect(matrixProvider.sendTestAlert).toHaveBeenCalledWith(
+				expect.objectContaining({ accessToken: "stored-token", roomId: "!other:example.com" })
+			);
+		});
+
+		it("uses the credential the caller supplied instead of the stored one", async () => {
+			const { service, notificationsRepository, matrixProvider } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrix);
+
+			await service.sendTestNotificationById("notif-1", "team-1", {
+				type: "matrix",
+				homeserverUrl: "https://evil.example.com",
+				roomId: "!room:example.com",
+				accessToken: "typed-token",
+			});
+
+			expect(matrixProvider.sendTestAlert).toHaveBeenCalledWith(expect.objectContaining({ accessToken: "typed-token" }));
+		});
+
+		it("refuses to send a stored credential to a destination the caller changed", async () => {
+			const { service, notificationsRepository, matrixProvider } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrix);
+
+			await expect(
+				service.sendTestNotificationById("notif-1", "team-1", {
+					type: "matrix",
+					homeserverUrl: "https://evil.example.com",
+					roomId: "!room:example.com",
+				})
+			).rejects.toMatchObject({ status: 400 });
+
+			expect(matrixProvider.sendTestAlert).not.toHaveBeenCalled();
+		});
+
+		it("allows any change for a channel whose provider posts to a fixed host", async () => {
+			const { service, notificationsRepository, telegramProvider } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+				makeNotification({ type: "telegram", address: "-100111", accessToken: "stored-token" })
+			);
+
+			await service.sendTestNotificationById("notif-1", "team-1", { type: "telegram", address: "-100999" });
+
+			expect(telegramProvider.sendTestAlert).toHaveBeenCalledWith(expect.objectContaining({ address: "-100999", accessToken: "stored-token" }));
+		});
+
+		it("refuses to test a saved channel as a different type", async () => {
+			const { service, notificationsRepository, telegramProvider } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrix);
+
+			await expect(service.sendTestNotificationById("notif-1", "team-1", { type: "telegram", address: "-100999" })).rejects.toMatchObject({
+				status: 400,
+			});
+
+			expect(telegramProvider.sendTestAlert).not.toHaveBeenCalled();
+		});
+
+		it("does not apply the destination check when there is no stored credential to fill in", async () => {
+			const { service, notificationsRepository, webhookProvider } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+				makeNotification({ type: "webhook", address: "https://example.com/hook", accessToken: undefined })
+			);
+
+			await service.sendTestNotificationById("notif-1", "team-1", { type: "webhook", address: "https://elsewhere.example.com/hook" });
+
+			expect(webhookProvider.sendTestAlert).toHaveBeenCalledWith(expect.objectContaining({ address: "https://elsewhere.example.com/hook" }));
+		});
+
+		it("treats a stored empty credential as no credential to fill in", async () => {
+			const { service, notificationsRepository, matrixProvider } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(makeNotification({ ...storedMatrix, accessToken: "" }));
+
+			await service.sendTestNotificationById("notif-1", "team-1", {
+				type: "matrix",
+				homeserverUrl: "https://elsewhere.example.com",
+				roomId: "!room:example.com",
+			});
+
+			expect(matrixProvider.sendTestAlert).toHaveBeenCalledWith(expect.not.objectContaining({ accessToken: expect.anything() }));
+		});
+
+		it("looks the notification up scoped to the caller's team", async () => {
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrix);
+
+			await service.sendTestNotificationById("notif-1", "team-1", {
+				type: "matrix",
+				homeserverUrl: "https://matrix.example.com",
+				roomId: "!room:example.com",
+			});
+
+			expect(notificationsRepository.findById).toHaveBeenCalledWith("notif-1", "team-1");
+		});
+	});
+
 	describe("deleteById", () => {
 		it("deletes notification and removes from monitors", async () => {
 			const deleted = makeNotification();

--- a/server/test/unit/services/notificationsService.test.ts
+++ b/server/test/unit/services/notificationsService.test.ts
@@ -350,13 +350,205 @@ describe("NotificationsService", () => {
 	});
 
 	describe("updateById", () => {
+		const storedMatrixChannel = makeNotification({
+			type: "matrix",
+			homeserverUrl: "https://matrix.example.com",
+			roomId: "!room:example.com",
+			accessToken: "stored-token",
+		});
+
 		it("delegates to repository", async () => {
 			const updated = makeNotification({ address: "new@example.com" });
 			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(makeNotification());
 			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
 
 			const result = await service.updateById("notif-1", "team-1", { address: "new@example.com" });
 			expect(result).toBe(updated);
+		});
+
+		it("refuses to keep a stored credential while repointing the channel", async () => {
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrixChannel);
+
+			await expect(
+				service.updateById("notif-1", "team-1", {
+					type: "matrix",
+					homeserverUrl: "https://evil.example.com",
+					roomId: "!room:example.com",
+				})
+			).rejects.toMatchObject({
+				status: 400,
+				message: "Enter the credentials again to use this channel with a different destination",
+			});
+
+			expect(notificationsRepository.updateById).not.toHaveBeenCalled();
+		});
+
+		it("refuses a conversion that would leave the channel unable to send", async () => {
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+				makeNotification({ type: "telegram", address: "-100111", accessToken: "stored-token" })
+			);
+
+			// The stored Telegram bot token must not follow the channel to Matrix, where it would be
+			// presented to whatever homeserver the caller named. But Matrix cannot send without one, so
+			// silently dropping it would leave a channel that looks configured and never alerts.
+			await expect(
+				service.updateById("notif-1", "team-1", {
+					type: "matrix",
+					homeserverUrl: "https://evil.example.com",
+					roomId: "!room:example.com",
+				})
+			).rejects.toMatchObject({
+				status: 400,
+				message: "Enter the credentials for the channel type you are switching to",
+			});
+
+			expect(notificationsRepository.updateById).not.toHaveBeenCalled();
+		});
+
+		it("drops a stale credential when converting to a channel that cannot use one", async () => {
+			const updated = makeNotification({ type: "ntfy" });
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+				makeNotification({ type: "telegram", address: "-100111", accessToken: "stored-token" })
+			);
+			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
+
+			await service.updateById("notif-1", "team-1", { type: "ntfy", address: "https://ntfy.sh", topic: "alerts" });
+
+			expect(notificationsRepository.updateById).toHaveBeenCalledWith("notif-1", "team-1", expect.objectContaining({ accessToken: "" }));
+		});
+
+		it("converts a credentialed channel to one whose schema has no credential field", async () => {
+			// teams and ntfy do not declare accessToken, so it is stripped before the service sees it.
+			// Refusing the edit here would be unsatisfiable: there is no way to send the field back.
+			const updated = makeNotification({ type: "teams" });
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrixChannel);
+			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
+
+			const result = await service.updateById("notif-1", "team-1", {
+				type: "teams",
+				address: "https://teams.example.com/webhook",
+			});
+
+			expect(result).toBe(updated);
+			expect(notificationsRepository.updateById).toHaveBeenCalledWith("notif-1", "team-1", expect.objectContaining({ accessToken: "" }));
+		});
+
+		it("keeps a credential the caller supplied while changing the provider", async () => {
+			const updated = makeNotification({ type: "matrix" });
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+				makeNotification({ type: "telegram", address: "-100111", accessToken: "stored-token" })
+			);
+			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
+
+			await service.updateById("notif-1", "team-1", {
+				type: "matrix",
+				homeserverUrl: "https://matrix.example.com",
+				roomId: "!room:example.com",
+				accessToken: "typed-token",
+			});
+
+			expect(notificationsRepository.updateById).toHaveBeenCalledWith("notif-1", "team-1", expect.objectContaining({ accessToken: "typed-token" }));
+		});
+
+		it("allows a repointing edit that supplies the credential explicitly", async () => {
+			const updated = makeNotification({ type: "matrix", homeserverUrl: "https://other.example.com" });
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrixChannel);
+			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
+
+			const result = await service.updateById("notif-1", "team-1", {
+				type: "matrix",
+				homeserverUrl: "https://other.example.com",
+				roomId: "!room:example.com",
+				accessToken: "typed-token",
+			});
+
+			expect(result).toBe(updated);
+		});
+
+		it("allows an edit that leaves the destination alone", async () => {
+			const updated = makeNotification({ type: "matrix", roomId: "!other:example.com" });
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrixChannel);
+			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
+
+			const result = await service.updateById("notif-1", "team-1", {
+				type: "matrix",
+				homeserverUrl: "https://matrix.example.com",
+				roomId: "!other:example.com",
+			});
+
+			expect(result).toBe(updated);
+		});
+
+		it.each([["webhook"], ["slack"], ["discord"], ["teams"], ["rocket_chat"], ["ntfy"]] as const)(
+			"lets %s change its address even with a leftover credential it cannot use",
+			async (type) => {
+				// These providers never read accessToken, so a credential left behind by an earlier type
+				// change is inert. Treating it as live made the address unchangeable, and for teams,
+				// rocket_chat and ntfy the field could not even be cleared, so the record was stuck.
+				const updated = makeNotification({ type, address: "https://elsewhere.example.com/hook" });
+				const { service, notificationsRepository } = createService();
+				(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+					makeNotification({ type, address: "https://example.com/hook", accessToken: "leftover-token" })
+				);
+				(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
+
+				const result = await service.updateById("notif-1", "team-1", { type, address: "https://elsewhere.example.com/hook" });
+
+				expect(result).toBe(updated);
+			}
+		);
+
+		it("keeps a credential on a patch that touches neither the type nor a destination", async () => {
+			const updated = makeNotification({ type: "telegram", notificationName: "Renamed" });
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+				makeNotification({ type: "telegram", address: "-100111", accessToken: "stored-token" })
+			);
+			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
+
+			await service.updateById("notif-1", "team-1", { type: "telegram", address: "-100111", notificationName: "Renamed" });
+
+			// The stored credential is kept by absence: the patch must not carry the field at all, and
+			// must not blank it either.
+			expect(notificationsRepository.updateById).toHaveBeenCalledWith(
+				"notif-1",
+				"team-1",
+				expect.not.objectContaining({ accessToken: expect.anything() })
+			);
+		});
+
+		it("does not restrict a channel that has no stored credential", async () => {
+			const updated = makeNotification({ type: "webhook", address: "https://elsewhere.example.com/hook" });
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+				makeNotification({ type: "webhook", address: "https://example.com/hook", accessToken: undefined })
+			);
+			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(updated);
+
+			const result = await service.updateById("notif-1", "team-1", {
+				type: "webhook",
+				address: "https://elsewhere.example.com/hook",
+			});
+
+			expect(result).toBe(updated);
+		});
+
+		it("looks the stored notification up scoped to the caller's team", async () => {
+			const { service, notificationsRepository } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(makeNotification());
+			(notificationsRepository.updateById as jest.Mock).mockResolvedValue(makeNotification());
+
+			await service.updateById("notif-1", "team-1", { notificationName: "Renamed" });
+
+			expect(notificationsRepository.findById).toHaveBeenCalledWith("notif-1", "team-1");
 		});
 	});
 
@@ -436,7 +628,10 @@ describe("NotificationsService", () => {
 					homeserverUrl: "https://evil.example.com",
 					roomId: "!room:example.com",
 				})
-			).rejects.toMatchObject({ status: 400 });
+			).rejects.toMatchObject({
+				status: 400,
+				message: "Enter the credentials again to use this channel with a different destination",
+			});
 
 			expect(matrixProvider.sendTestAlert).not.toHaveBeenCalled();
 		});
@@ -456,11 +651,37 @@ describe("NotificationsService", () => {
 			const { service, notificationsRepository, telegramProvider } = createService();
 			(notificationsRepository.findById as jest.Mock).mockResolvedValue(storedMatrix);
 
+			// The message matters: without it this passes even with the type check deleted, because the
+			// destination guard happens to throw its own 400 for this fixture.
 			await expect(service.sendTestNotificationById("notif-1", "team-1", { type: "telegram", address: "-100999" })).rejects.toMatchObject({
 				status: 400,
+				message: "Notification type does not match the saved channel",
 			});
 
 			expect(telegramProvider.sendTestAlert).not.toHaveBeenCalled();
+		});
+
+		it("refuses to test a fixed-host channel as a host-addressed one", async () => {
+			// The reverse direction, and the reason the type check is load-bearing rather than tidiness:
+			// telegram has no destination fields, so the destination guard structurally cannot fire, and
+			// only the type check stands between the stored bot token and a caller-named homeserver.
+			const { service, notificationsRepository, matrixProvider } = createService();
+			(notificationsRepository.findById as jest.Mock).mockResolvedValue(
+				makeNotification({ type: "telegram", address: "-100111", accessToken: "stored-token" })
+			);
+
+			await expect(
+				service.sendTestNotificationById("notif-1", "team-1", {
+					type: "matrix",
+					homeserverUrl: "https://evil.example.com",
+					roomId: "!room:example.com",
+				})
+			).rejects.toMatchObject({
+				status: 400,
+				message: "Notification type does not match the saved channel",
+			});
+
+			expect(matrixProvider.sendTestAlert).not.toHaveBeenCalled();
 		});
 
 		it("does not apply the destination check when there is no stored credential to fill in", async () => {

--- a/server/test/unit/validation/notificationValidation.test.ts
+++ b/server/test/unit/validation/notificationValidation.test.ts
@@ -124,3 +124,37 @@ describe("notificationValidation — credentials on edit", () => {
 		expect(parsed.type).toBe("webhook");
 	});
 });
+
+// Every channel that authenticates with a credential, so a new one cannot be added un-asserted.
+const credentialledChannels = [
+	{ type: "matrix" as const, body: { notificationName: "Matrix room", homeserverUrl: "https://matrix.example.com", roomId: "!abc:example.com" } },
+	{ type: "telegram" as const, body: { notificationName: "Telegram alerts", address: "-1001234567890" } },
+	{ type: "pushover" as const, body: { notificationName: "Pushover", address: "u1234567890abcdef" } },
+	{
+		type: "twilio" as const,
+		body: {
+			notificationName: "Twilio SMS",
+			accountSid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+			phone: "+15551234567",
+			twilioPhoneNumber: "+15557654321",
+		},
+	},
+];
+
+describe("notificationValidation: every credentialled channel, not just the sampled ones", () => {
+	it.each(credentialledChannels)("requires the credential on create for $type", ({ type, body }) => {
+		expect(createNotificationBodyValidation.safeParse({ ...body, type }).success).toBe(false);
+		expect(createNotificationBodyValidation.safeParse({ ...body, type, accessToken: "a-credential" }).success).toBe(true);
+	});
+
+	it.each(credentialledChannels)("rejects an empty credential on edit for $type", ({ type, body }) => {
+		expect(editNotificationBodyValidation.safeParse({ ...body, type, accessToken: "" }).success).toBe(false);
+	});
+
+	it.each(credentialledChannels)("accepts an omitted credential on edit for $type, which keeps the stored one", ({ type, body }) => {
+		const result = editNotificationBodyValidation.safeParse({ ...body, type });
+
+		expect(result.success).toBe(true);
+		expect(result.success && "accessToken" in result.data).toBe(false);
+	});
+});

--- a/server/test/unit/validation/notificationValidation.test.ts
+++ b/server/test/unit/validation/notificationValidation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { createNotificationBodyValidation } from "@/api/validation/notificationValidation.js";
+import { createNotificationBodyValidation, editNotificationBodyValidation } from "../../../src/api/validation/notificationValidation.ts";
 
 describe("notification validation", () => {
 	it("accepts a Rocket.Chat incoming webhook", () => {
@@ -44,4 +44,83 @@ describe("notification validation", () => {
 			expect(result.success).toBe(false);
 		}
 	);
+});
+
+const telegramBody = {
+	notificationName: "Telegram alerts",
+	type: "telegram" as const,
+	address: "-1001234567890",
+};
+
+const twilioBody = {
+	notificationName: "Twilio SMS",
+	type: "twilio" as const,
+	accountSid: "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	phone: "+15551234567",
+	twilioPhoneNumber: "+15557654321",
+};
+
+describe("notificationValidation — credentials on create", () => {
+	it("requires a credential on every channel that authenticates with one", () => {
+		expect(() => createNotificationBodyValidation.parse(telegramBody)).toThrow();
+		expect(() => createNotificationBodyValidation.parse(twilioBody)).toThrow();
+		expect(() =>
+			createNotificationBodyValidation.parse({
+				notificationName: "Matrix room",
+				type: "matrix",
+				homeserverUrl: "https://matrix.example.com",
+				roomId: "!abc:example.com",
+			})
+		).toThrow();
+	});
+
+	it("accepts a body that carries the credential", () => {
+		const parsed = createNotificationBodyValidation.parse({ ...telegramBody, accessToken: "bot-token" });
+
+		expect(parsed.accessToken).toBe("bot-token");
+	});
+});
+
+describe("notificationValidation — credentials on edit", () => {
+	it("accepts a body that omits the credential, which keeps the stored one", () => {
+		const parsed = editNotificationBodyValidation.parse(telegramBody);
+
+		expect(parsed).not.toHaveProperty("accessToken");
+	});
+
+	it("accepts a replacement credential", () => {
+		const parsed = editNotificationBodyValidation.parse({ ...telegramBody, accessToken: "new-token" });
+
+		expect(parsed.accessToken).toBe("new-token");
+	});
+
+	it("rejects an empty credential, so a required one cannot be blanked out", () => {
+		expect(() => editNotificationBodyValidation.parse({ ...telegramBody, accessToken: "" })).toThrow();
+		expect(() => editNotificationBodyValidation.parse({ ...twilioBody, accessToken: "" })).toThrow();
+	});
+
+	it("still requires the fields that are not credentials", () => {
+		// accountSid is a Twilio identifier, not a credential: it is returned to the client, so the
+		// client can always send it back.
+		expect(() =>
+			editNotificationBodyValidation.parse({
+				notificationName: "Twilio SMS",
+				type: "twilio",
+				phone: "+15551234567",
+				twilioPhoneNumber: "+15557654321",
+			})
+		).toThrow();
+
+		expect(() => editNotificationBodyValidation.parse({ ...telegramBody, address: "" })).toThrow();
+	});
+
+	it("leaves channels without a credential unchanged", () => {
+		const parsed = editNotificationBodyValidation.parse({
+			notificationName: "Ops webhook",
+			type: "webhook",
+			address: "https://example.com/hooks/checkmate",
+		});
+
+		expect(parsed.type).toBe("webhook");
+	});
 });


### PR DESCRIPTION
## Describe your changes

`POST /notifications`, `GET /notifications/team`, `GET /notifications/{id}` and
`PATCH /notifications/{id}` all returned the stored `accessToken` as plain text. That affects
matrix, telegram, twilio and pushover. Any logged in team member could read every channel
credential from the API. #3771 has screenshots of the returned fields on current `develop`.

The Configure form depended on this. It read the token back to prefill its field, so the leak
could not be fixed on the server alone.

This continues #3559 by @egeoztass, which has been idle since early May. It takes the approach
@ajhollid asked for there, rebases it onto the backend changes that have landed since, and adds
the tests that were still missing.

cc @ajhollid

### Credentials are no longer returned

Responses are built from a list of public fields, and each credential is reported as
`accessTokenSet: boolean` instead. This is the same approach the settings page already uses for
`pagespeedKeySet` and `emailPasswordSet`.

<img width="1915" height="703" alt="Step_1" src="https://github.com/user-attachments/assets/e97a3d03-bcc3-4952-a227-01929286998d" />
(the same request on this branch: accessTokenSet, and no token)

### The form no longer prefills

When you edit a channel, the credential field is replaced by "credential is set" and a Reset
button. The input only appears after you press Reset. If you do not replace the credential, it is
left out of the request, and the stored one is kept. The four duplicated token fields are now one
`CredentialField` component, and credential inputs are masked, which they were not before.

<img width="1918" height="612" alt="Step_1 2" src="https://github.com/user-attachments/assets/d3cf3461-1056-4234-bc6f-bdd691a33213" />
(editing a channel: the credential is not prefilled)

<img width="1918" height="615" alt="Step_4" src="https://github.com/user-attachments/assets/c078f5c9-18b7-4107-8c23-723ca2152ae8" />
(after pressing Reset: a masked input for the new value)

### Edit validation is derived, not duplicated

Each channel schema is now declared once. `editNotificationBodyValidation` is built from the
create schemas with `.partial()`, as asked for in #3559. The behaviour follows from that: leave
the credential out to keep it, send a value to replace it, and an empty string is rejected so a
required credential cannot be wiped by mistake.

<img width="1092" height="488" alt="Step_3 2" src="https://github.com/user-attachments/assets/e292b690-da68-4201-a755-6b86c2b3e7f7" />
(editing another field while leaving the credential out: the stored credential is unchanged)

<img width="1919" height="630" alt="Step_5" src="https://github.com/user-attachments/assets/fb4305ef-99a4-4c3f-bba8-83683bcb5111" />
(Reset, then Save with an empty field: rejected before the request is sent)

### Test still works on a saved channel

Hiding the credential would otherwise break the Test button, because it sends the form's current
values. `POST /notifications/{id}/test` fills in any credential the client left out from the
stored record.

### The part worth reviewing closely

A credential that the server fills in can only be sent to the destination it is already stored
against. If the request changes where the notification is delivered and leaves the credential
out, it is rejected with a 400. Otherwise the endpoint could be used to read a stored credential
once: send `{id, homeserverUrl: attacker.example}` with the token left out, and the server would
deliver it there. `NotificationDestinationFields` lists, per channel, which fields decide the
outbound host. Providers that post to a fixed host have no such field, and are listed with an
empty array and a comment.

<img width="1917" height="684" alt="Step_6_guardrail" src="https://github.com/user-attachments/assets/dd218f33-3d1c-4e55-9468-93c8f0aa41a0" />
(changing the Matrix home server and pressing Test, with the credential left out: rejected)

To be clear about what this does and does not buy: someone who can already PATCH the channel can
point it anywhere and wait for an alert. The difference is that a PATCH is saved, visible in the
channel's configuration, and stops alerts from reaching the team. A silent test is none of those
things. I did not want the fix to hand back a quieter version of the problem it removes.

### Safe by default

The list of public fields is written out by hand rather than derived as "everything that is not a
credential". A field added to `Notification` later is not returned until someone classifies it.
Leaving a field unclassified fails the build, and the error names the field. This follows the fix
for the status page leak (GHSA-3m74-8cg9-rp8j) and the drift check already in
`openapi/routes/notification.ts`.

This matters now, because #3785 adds `webhookToken` and `webhookPassword`. If the code simply
stripped the credentials it knew about, those two would be returned the day that PR merges. With
this approach they cannot be, and the build asks which they are.

### Two decisions I would like your call on

1. **`accountSid` is still returned.** #3559 hid it. It is Twilio's Basic auth username and it
   travels in the request URL by design, so it identifies an account rather than authenticating
   one. Hiding it behind a Reset button costs the user something and gains nothing. Happy to
   change it, it is one line plus its flag.
2. **The redaction lives in the controller**, next to `settingsController.buildAppSettings`. The
   response shape is an HTTP concern, and the service has to keep returning full records for the
   send path. The alternative is the service layer. I followed the existing precedent.

### One question for later: where the credential sits in the form

`CredentialField` renders in the same place the old token input was, so its position depends on
the provider. It is first for telegram and pushover, second of four for twilio (between the
Account SID and the phone numbers), and last for matrix. I left the order alone on purpose,
because it is the order the fields were already in. Reordering fields is a UX change with no
security value, and Account SID and Auth Token sit next to each other in the Twilio console, so
splitting them would make the create flow worse.

It is worth deciding before #3785 lands, because that PR adds two credentials to a single
channel. Two credentials are easier to read as one block: a single "credentials are set" state
with one Reset that shows both inputs, rather than two separate Reset buttons that let a pair be
half replaced without anyone noticing. A block that size does look odd in the middle of a
provider's fields.

So the rule I would suggest, if you want one:

> A single credential stays where its input was. A group of credentials is shown as one block at
> the end of its provider's fields.

Happy to do that here, in a follow up, or not at all. Just say which. Nothing in the backend
depends on it, because leaving a field out keeps it per field, so grouping is only a UI
convention.

### Notes

- The send path is untouched. Providers still read full records straight from the repository, and
  there are tests covering that.
- **API change:** `accessToken` is gone from notification responses, and `accessTokenSet` is new.
  The OpenAPI spec now documents a real response schema for these endpoints instead of an untyped
  payload, and a test parses a real response against that schema strictly, so the two cannot
  drift apart.
- `openapi.json` is not regenerated here. Regenerating it on current `develop` already produces a
  diff of about 25k lines that has nothing to do with this change, so I left it to the build.
- API clients that send the full body on edit, credential included, keep working.

### Out of scope

- Switching a saved channel to a different provider type leaves the old provider's credential in
  the document. That is not new. Today the form prefills the old token into the new provider's
  field and saves it, so this PR does not change the behaviour.
- `usePost` logs the request body when a request fails, which includes a credential on a failed
  create or test. That is separate and already there. Happy to open an issue.
- Encryption at rest, and forcing HTTPS.

### Checks

`npm run lint`, `npm run format-check` and `tsc` are clean in both packages. Server suite: 1354
tests passing, 27 of them new. Client builds.

## Write your issue number after "Fixes "

Fixes #3771

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

**P.S. Corrections after rebasing onto `develop`** (the new commits are explained in the
comment below)

Some of the above is now out of date. Rather than rewrite the description and lose the
screenshots, here are the corrections:

- **"The send path is untouched" is no longer true.** One provider file changed: `roomId` is
  now URL-encoded in the Matrix provider, because it was going into the request path raw.
- **`openapi.json` is now regenerated.** My note that regenerating produced a ~25k line diff
  was wrong. That was tabs versus spaces, not content.
- **The first "Out of scope" bullet no longer applies.** Switching a channel to a different
  provider type no longer leaves the old provider's credential in the document. It could not
  stay out of scope once the credential became invisible, since the old behaviour relied on
  the user seeing it prefilled into the new provider's field.
- **The guard now covers saving, not just testing.** The paragraph about "someone who can
  already PATCH the channel can point it anywhere and wait for an alert" is superseded:
  `PATCH` is guarded too, because otherwise the guard on the test endpoint was bypassable in
  two requests.
- **"Destination" means host, not recipient.** A fixed-host channel's credential can still be
  repointed at another chat id, user key or phone number without being re-entered. That
  discloses later alerts to whoever owns the new recipient, but never the credential itself.
  The comment in the code says so now.
- **Checks:** 1401 tests across 80 suites, up from 1339 across 79 on `develop`, so 62 new
  rather than 27. Server `tsc`, lint and format are clean. On the client, `tsc -b` builds and
  lint and format are clean for the files this PR touches, though `npm run lint` reports 12
  errors that are already on `develop`, in files this PR does not open.
- **#3559 is now closed** by @egeoztass in favour of this one, so it is no longer idle.
- **The screenshots predate #3829's form refactor.** The form's layout changed with it; the
  flow they show did not.
- Minor: the request-body logging note applies to `usePatch` and `usePut` as well as
  `usePost`.