### PR TITLE
test: cover monitor tag filtering

### DIFF
--- a/server/test/integration/monitorRepository.test.ts
+++ b/server/test/integration/monitorRepository.test.ts
@@ -1,0 +1,54 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "@jest/globals";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import { MonitorModel } from "../../src/domain/monitors/monitor.model.ts";
+import MongoMonitorsRepository from "../../src/domain/monitors/monitor.repository.mongo.ts";
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+	mongod = await MongoMemoryServer.create();
+	await mongoose.connect(mongod.getUri());
+	await MonitorModel.init();
+}, 120_000);
+
+afterAll(async () => {
+	await mongoose.disconnect();
+	await mongod.stop();
+});
+
+beforeEach(async () => {
+	await MonitorModel.deleteMany({});
+});
+
+const seedMonitor = (teamId: mongoose.Types.ObjectId, name: string, tags: mongoose.Types.ObjectId[]) =>
+	MonitorModel.create({
+		userId: new mongoose.Types.ObjectId(),
+		teamId,
+		name,
+		type: "http",
+		url: "https://example.com",
+		tags,
+	});
+
+describe("MongoMonitorsRepository", () => {
+	describe("tag filtering", () => {
+		it("matches ObjectId tag references when filters arrive as query strings", async () => {
+			const repo = new MongoMonitorsRepository();
+			const teamId = new mongoose.Types.ObjectId();
+			const selectedTagId = new mongoose.Types.ObjectId();
+			const otherTagId = new mongoose.Types.ObjectId();
+
+			await seedMonitor(teamId, "selected", [selectedTagId]);
+			await seedMonitor(teamId, "not-selected", [otherTagId]);
+			await seedMonitor(new mongoose.Types.ObjectId(), "other-team", [selectedTagId]);
+
+			const tags = selectedTagId.toString();
+			const monitors = await repo.findByTeamIdWithStats(teamId.toString(), { tags });
+			const summary = await repo.findMonitorsSummaryByTeamId(teamId.toString(), { tags });
+
+			expect(monitors.map((monitor) => monitor.name)).toEqual(["selected"]);
+			expect(summary.totalMonitors).toBe(1);
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes

Adds a real-Mongo regression test for monitor tag filtering.

The test seeds monitors with matching and non-matching ObjectId tag references, including a monitor from another team, then verifies that:

- the aggregation-backed monitor query returns only the selected team's matching monitor
- the aggregation-backed summary reports the same filtered total

The behavior reported in #3805 is already fixed on `develop` by converting query-string tag IDs to ObjectIds before aggregation. This test locks in that behavior and prevents the raw-string comparison from returning an empty result again.

## Issue

Refs #3805

## Verification

- `npm test -- --runTestsByPath test/integration/monitorRepository.test.ts --runInBand --coverage=false`
- `npm run test:integration -- --runInBand` (11 suites, 81 tests)
- `npm run typeCheck`
- `npm run lint`
- `npm run format-check`

The focused test was also checked against the previous raw-string query implementation and failed as expected with an empty monitor array.

## Checklist

- [ ] I deployed the application locally. This is a draft and a test-only change.
- [x] I have performed a self-review and tested the change.
- [x] I have included the issue number.
- [x] i18n is not applicable because there are no user-visible strings.
- [x] I have not included unrelated files or dependency changes.
- [x] No production values or styles were hardcoded.
- [x] Theme requirements are not applicable because there is no UI change.
- [x] The PR is granular and targeted to one behavior.
- [x] Server formatting was verified with `npm run format-check`.
- [x] A screenshot is not applicable because there is no UI change.
