### PR TITLE
fix: restore status page custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ The web client needs no configuration by default: it calls the API on the same o
 | Variable | Description |
 |---|---|
 | `CLIENT_CONFIG_API_BASE_URL` | Full base URL the client calls the API at, e.g. `https://api.example.com/api/v1`; defaults to same-origin `/api/v1` |
-| `CLIENT_CONFIG_CLIENT_HOST` | Origin used when the client builds absolute links (invites, status pages); defaults to the browser's current origin |
+| `CLIENT_CONFIG_CLIENT_HOST` | Overrides the canonical origin used for absolute links and custom-domain detection; defaults to `CLIENT_HOST` |
 | `CLIENT_CONFIG_LOG_LEVEL` | Browser console log level: `error`, `warn`, `info`, or `debug` (default `error`) |
 
-> **Upgrading from an older image?** The `UPTIME_APP_*` variables (`UPTIME_APP_API_BASE_URL`, `UPTIME_APP_CLIENT_HOST`, `UPTIME_APP_LOG_LEVEL`) are no longer read. In most setups no replacement is needed — the same-origin defaults cover them; if you pointed the client at a different origin, use the `CLIENT_CONFIG_*` equivalents above. The `checkmate-client`, `checkmate-backend`, `checkmate-mongo`, and `checkmate-backend-mono-multiarch` images are no longer updated — switch to `ghcr.io/bluewave-labs/checkmate`, keeping your existing MongoDB service and data volume.
+> **Upgrading from an older image?** The `UPTIME_APP_*` variables (`UPTIME_APP_API_BASE_URL`, `UPTIME_APP_CLIENT_HOST`, `UPTIME_APP_LOG_LEVEL`) are no longer read. In most setups no replacement is needed — the API stays same-origin and the canonical client origin inherits `CLIENT_HOST`; if you need different client runtime values, use the `CLIENT_CONFIG_*` equivalents above. The `checkmate-client`, `checkmate-backend`, `checkmate-mongo`, and `checkmate-backend-mono-multiarch` images are no longer updated — switch to `ghcr.io/bluewave-labs/checkmate`, keeping your existing MongoDB service and data volume.
 
 See full installation instructions in the [Checkmate documentation portal](https://checkmate.so/docs). 
 

--- a/server/src/config/envValidation.ts
+++ b/server/src/config/envValidation.ts
@@ -25,8 +25,8 @@ const envSchema = z.object({
 	// Client Configuration
 	CLIENT_HOST: z.string().url("CLIENT_HOST must be a valid URL"),
 
-	// Client runtime config overrides, rendered into GET /config.js; unset keys are
-	// omitted and the client uses its same-origin defaults
+	// Client runtime config overrides rendered into GET /config.js. The canonical
+	// client host falls back to CLIENT_HOST so custom domains can identify the app.
 	CLIENT_CONFIG_API_BASE_URL: z.string().optional(),
 	CLIENT_CONFIG_CLIENT_HOST: z.string().url("CLIENT_CONFIG_CLIENT_HOST must be a valid URL").optional(),
 	CLIENT_CONFIG_LOG_LEVEL: z.enum(LogLevels).optional(),
@@ -72,7 +72,7 @@ export const validateEnv = (logger: ILogger): ValidatedEnv => {
 	const legacyClientVars = Object.keys(process.env).filter((key) => key.startsWith("UPTIME_APP_"));
 	if (legacyClientVars.length > 0) {
 		logger.warn({
-			message: `${legacyClientVars.join(", ")} no longer configure the client and will be ignored. The client defaults to the origin it is served from; to override, use CLIENT_CONFIG_API_BASE_URL, CLIENT_CONFIG_CLIENT_HOST, or CLIENT_CONFIG_LOG_LEVEL.`,
+			message: `${legacyClientVars.join(", ")} no longer configure the client and will be ignored. The client uses a same-origin API by default and CLIENT_HOST as its canonical origin; to override, use CLIENT_CONFIG_API_BASE_URL, CLIENT_CONFIG_CLIENT_HOST, or CLIENT_CONFIG_LOG_LEVEL.`,
 			method: "validateEnv",
 			service: "Server",
 		});

--- a/server/src/domain/app-settings/app-settings.service.ts
+++ b/server/src/domain/app-settings/app-settings.service.ts
@@ -44,8 +44,8 @@ export class SettingsService implements ISettingsService {
 			queuePrimaryProcesses: env.QUEUE_PRIMARY_PROCESSES,
 			statusPageThemesEnabled: env.STATUS_PAGE_THEMES_ENABLED,
 			clientConfig: {
+				clientHost: env.CLIENT_CONFIG_CLIENT_HOST ?? env.CLIENT_HOST,
 				...(env.CLIENT_CONFIG_API_BASE_URL && { apiBaseUrl: env.CLIENT_CONFIG_API_BASE_URL }),
-				...(env.CLIENT_CONFIG_CLIENT_HOST && { clientHost: env.CLIENT_CONFIG_CLIENT_HOST }),
 				...(env.CLIENT_CONFIG_LOG_LEVEL && { logLevel: env.CLIENT_CONFIG_LOG_LEVEL }),
 			},
 		};

--- a/server/src/domain/app-settings/app-settings.type.ts
+++ b/server/src/domain/app-settings/app-settings.type.ts
@@ -7,8 +7,8 @@ export type QueueMode = (typeof QueueModes)[number];
 export const LogLevels = ["error", "warn", "info", "debug"] as const;
 export type LogLevel = (typeof LogLevels)[number];
 
-// Rendered into GET /config.js as window.__CHECKMATE_CONFIG__; keys left unset
-// fall back to the client's same-origin defaults.
+// Rendered into GET /config.js as window.__CHECKMATE_CONFIG__. API and logging
+// keys may be omitted; clientHost is populated from the canonical CLIENT_HOST.
 export type ClientRuntimeConfig = {
 	apiBaseUrl?: string;
 	clientHost?: string;

--- a/server/test/unit/services/settingsService.test.ts
+++ b/server/test/unit/services/settingsService.test.ts
@@ -72,11 +72,13 @@ describe("SettingsService", () => {
 				dbConnectionString: "mongodb://localhost:27017/test_db",
 				dbType: "mongodb",
 				statusPageThemesEnabled: false,
-				clientConfig: {},
+				clientConfig: {
+					clientHost: "http://localhost:5173",
+				},
 			});
 		});
 
-		it("maps only set CLIENT_CONFIG_* env vars into clientConfig", () => {
+		it("maps CLIENT_CONFIG_* env vars and falls back to CLIENT_HOST", () => {
 			const { service } = createService({
 				CLIENT_CONFIG_API_BASE_URL: "https://api.example.com/api/v1",
 				CLIENT_CONFIG_LOG_LEVEL: "warn",
@@ -84,8 +86,18 @@ describe("SettingsService", () => {
 
 			expect(service.getSettings().clientConfig).toEqual({
 				apiBaseUrl: "https://api.example.com/api/v1",
+				clientHost: "http://localhost:5173",
 				logLevel: "warn",
 			});
+		});
+
+		it("uses CLIENT_CONFIG_CLIENT_HOST instead of CLIENT_HOST when set", () => {
+			const { service } = createService({
+				CLIENT_HOST: "https://checkmate.internal.example.com",
+				CLIENT_CONFIG_CLIENT_HOST: "https://checkmate.example.com",
+			});
+
+			expect(service.getSettings().clientConfig.clientHost).toBe("https://checkmate.example.com");
 		});
 
 		it("reflects custom env values", () => {


### PR DESCRIPTION
## Describe your changes

Restores custom-domain status page routing when `CLIENT_CONFIG_CLIENT_HOST` is not explicitly configured.

The runtime-config migration omitted `clientHost` from `/config.js` by default. On a custom domain, the client therefore fell back to that domain's own `window.location.origin`, treated it as the main Checkmate host, and rendered the login routes instead of resolving the published status page.

This change:

- always exposes the canonical `CLIENT_HOST` through the generated client config
- preserves `CLIENT_CONFIG_CLIENT_HOST` as the explicit higher-priority override
- adds regression coverage for fallback and override behavior
- updates configuration comments and README guidance to describe the actual precedence

## Write your issue number after "Fixes "

Fixes #3811

## Verification

- Deployed locally and verified that the custom-domain status page resolves correctly when `CLIENT_CONFIG_CLIENT_HOST` is not configured.
- `npm test -- --runTestsByPath test/unit/services/settingsService.test.ts --runInBand --coverage=false` — 13 tests passed
- `npm test -- --runInBand --coverage=false` — 74 suites, 1,328 tests passed
- `npm run typeCheck` in `server`
- `npm run lint` in `server`
- `npm run build` in `server` and `client`
- `npm run format-check` in `server` and `client`
- `git diff --check`

## Checklist

- [x] I deployed the application locally and verified custom-domain status-page routing.
- [x] I have performed a self-review and tested the change.
- [x] I have included the issue number.
- [x] i18n is not applicable because no visible strings were added.
- [x] I have not included unrelated files or dependency changes.
- [x] No production values or styles are hardcoded.
- [x] Theme requirements are not applicable because there is no UI styling change.
- [x] The PR is granular and targeted to one regression.
- [x] Formatting was verified in both server and client.
- [x] A screenshot is not applicable because the change restores routing/configuration behavior without changing the UI.
