### PR TITLE
fix: normalize constant response times

### DIFF
--- a/server/src/utils/dataUtils.ts
+++ b/server/src/utils/dataUtils.ts
@@ -44,6 +44,7 @@ const percentileBy = <T>(arr: T[], percentile: number, value: (item: T) => numbe
 };
 
 const rescale = (raw: number, min: number, max: number, rangeMin: number, rangeMax: number): number => {
+	if (min === max) return rangeMin;
 	const scaled = rangeMin + ((raw - min) * (rangeMax - rangeMin)) / (max - min);
 	return Math.max(rangeMin, Math.min(rangeMax, scaled));
 };

--- a/server/test/unit/utils/dataUtils.test.ts
+++ b/server/test/unit/utils/dataUtils.test.ts
@@ -113,15 +113,11 @@ describe("NormalizeData", () => {
 		expect(result[0]!.originalResponseTime).toBe(0);
 	});
 
-	// Characterization, not endorsement: when every value is equal the p0–p95 window
-	// has zero width and the rescale divides by zero. Fixing this is a planned
-	// follow-up (docs/planning/dataUtils-generic-normalization-refactor.md); this
-	// test pins the current behavior so the fix is a deliberate, visible change.
-	it("produces NaN when all values are equal (division by zero — known edge case)", () => {
+	it("maps equal values to rangeMin when the p0–p95 window has zero width", () => {
 		const result = NormalizeData([makeCheck(50), makeCheck(50), makeCheck(50)], 10, 100);
 
 		result.forEach((check) => {
-			expect(check.responseTime).toBeNaN();
+			expect(check.responseTime).toBe(10);
 			expect(check.originalResponseTime).toBe(50);
 		});
 	});
@@ -164,11 +160,11 @@ describe("NormalizeDataUptimeDetails", () => {
 		expect(result[0]!.originalAvgResponseTime).toBe(0);
 	});
 
-	it("produces NaN when all values are equal (division by zero — known edge case)", () => {
+	it("maps equal averages to rangeMin when the p0–p95 window has zero width", () => {
 		const result = NormalizeDataUptimeDetails([makeGrouped(50), makeGrouped(50)], 10, 100);
 
 		result.forEach((check) => {
-			expect(check.avgResponseTime).toBeNaN();
+			expect(check.avgResponseTime).toBe(10);
 			expect(check.originalAvgResponseTime).toBe(50);
 		});
 	});


### PR DESCRIPTION
## Describe your changes

Prevents constant response-time series from normalizing to `NaN`.

Both normalization paths use p0 and p95 as their display anchors. When every value is equal, those anchors are identical and the rescale denominator is zero. The resulting `NaN` becomes `null` when serialized to JSON, so chart consumers receive no numeric height.

This change maps a zero-width series to `rangeMin`, which is the same value the minimum anchor normally receives and keeps the chart visible without inventing variation. Raw response times remain available through `originalResponseTime` and `originalAvgResponseTime`.

The existing characterization tests are updated to assert finite lower-bound values for both raw checks and grouped uptime details.

## Write your issue number after "Fixes "

Fixes #3813

## Verification

- `npm test -- --runTestsByPath test/unit/utils/dataUtils.test.ts --runInBand --coverage=false` — 26 tests passed
- `npm test -- --runInBand --coverage=false` — 74 suites, 1,327 tests passed
- `npm run typeCheck` in `server`
- `npm run lint` in `server`
- `npm run build` in `server` and `client`
- `npm run format-check` in `server` and `client`
- `git diff --check`

## Checklist

- [ ] I deployed the application locally. This is a draft; the pure normalization change is covered by focused and full automated tests.
- [x] I have performed a self-review and tested the change.
- [x] I have included the issue number.
- [x] i18n is not applicable because no visible strings were added.
- [x] I have not included unrelated files or dependency changes.
- [x] No production values or styles are hardcoded.
- [x] Theme requirements are not applicable because there is no UI styling change.
- [x] The PR is granular and targeted to one edge case.
- [x] Formatting was verified in both server and client.
- [x] A screenshot is not applicable because there is no UI change.
