### PR TITLE
docs(readme): clarify MongoDB requirement for single-image deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Usage instructions can be found [here](https://checkmate.so/docs).
 <a id="installation"></a>
 ## Installation
 
-The quickest way to run Checkmate is the reference Docker Compose file, which runs the all-in-one image (`ghcr.io/bluewave-labs/checkmate`) plus MongoDB:
+The quickest way to run Checkmate is the reference Docker Compose file. It starts two services: the all-in-one Checkmate application image (`ghcr.io/bluewave-labs/checkmate`) and a separate MongoDB service.
+
+> **What “all-in-one” means:** the Checkmate application is packaged in a single image; MongoDB is not embedded in that image and remains required. The reference Compose file starts MongoDB for you. For custom deployments, configure `DB_CONNECTION_STRING` to use an external MongoDB instance.
 
 ```bash
 curl -O https://raw.githubusercontent.com/bluewave-labs/checkmate/master/docker/docker-compose.yaml


### PR DESCRIPTION
## Describe your changes

Clarified the Docker Compose installation documentation to explain that the all-in-one image packages the Checkmate application only.

MongoDB remains a separate required dependency. The reference Docker Compose file starts MongoDB as a separate service, while custom deployments can use an external MongoDB instance through `DB_CONNECTION_STRING`.

## Write your issue number after "Fixes "

Fixes #3823

## Verification

- [x] Reviewed the rendered Markdown locally.
- [x] Ran `git diff --check`.
- [x] Confirmed that this PR changes only `README.md`.

## Checklist

- [x] Not applicable: this is a documentation-only PR and does not change runtime behavior, Docker configuration, UI, or application code.
- [x] I performed a self-review of the documentation change.
- [x] I have included the issue number in this PR.
- [x] No user-facing application strings were added, so i18n is not applicable.
- [x] I have not included unrelated files or dependency changes.
- [x] No application hardcoded values were added or changed.
- [x] No UI styles, theme values, or dimensions were changed.
- [x] My PR is granular and addresses only #3823.
- [x] No client or server source files changed; client/server formatting is not applicable.
- [x] No UI change was made, so a screenshot or video is not applicable.