### PR TITLE
feat: enrich Rocket.Chat notifications

### DIFF
--- a/server/src/domain/notifications/providers/rocketChat.ts
+++ b/server/src/domain/notifications/providers/rocketChat.ts
@@ -4,6 +4,16 @@ import { NotificationProvider } from "@/domain/notifications/providers/INotifica
 import { getTestMessage } from "@/domain/notifications/providers/utils.js";
 import got from "got";
 
+type RocketChatField = { title: string; value: string; short: boolean };
+type RocketChatAttachment = {
+	color: string;
+	title: string;
+	title_link?: string;
+	fields?: RocketChatField[];
+	ts?: string;
+};
+type RocketChatPayload = { text: string; attachments: [RocketChatAttachment] };
+
 export class RocketChatProvider extends NotificationProvider {
 	async sendTestAlert(notification: Partial<Notification>): Promise<boolean> {
 		if (!notification.address) {
@@ -12,7 +22,7 @@ export class RocketChatProvider extends NotificationProvider {
 
 		try {
 			await got.post(notification.address, {
-				json: { text: getTestMessage() },
+				json: this.buildTestPayload(),
 				headers: {
 					"Content-Type": "application/json",
 				},
@@ -29,6 +39,22 @@ export class RocketChatProvider extends NotificationProvider {
 			});
 			return false;
 		}
+	}
+
+	private buildTestPayload(): RocketChatPayload {
+		return {
+			text: getTestMessage(),
+			attachments: [
+				{
+					color: "#0000FF",
+					title: "Checkmate test notification",
+					fields: [
+						{ title: "Channel", value: "Rocket.Chat", short: true },
+						{ title: "Status", value: "Test notification", short: true },
+					],
+				},
+			],
+		};
 	}
 
 	async sendMessage(notification: Notification, message: NotificationMessage): Promise<boolean> {

--- a/server/src/domain/notifications/providers/rocketChat.ts
+++ b/server/src/domain/notifications/providers/rocketChat.ts
@@ -1,4 +1,5 @@
 const SERVICE_NAME = "RocketChatProvider";
+import { supportsUptimeDetails, type MonitorType } from "@/domain/monitors/monitor.type.js";
 import type { Notification, NotificationMessage } from "@/domain/notifications/notification.type.js";
 import { NotificationProvider } from "@/domain/notifications/providers/INotificationProvider.js";
 import { getTestMessage } from "@/domain/notifications/providers/utils.js";
@@ -84,6 +85,7 @@ export class RocketChatProvider extends NotificationProvider {
 	}
 
 	private buildPayload(message: NotificationMessage): RocketChatPayload {
+		const monitorUrl = this.monitorUrl(message);
 		const fields: RocketChatField[] = [
 			{ title: "Monitor", value: message.monitor.name, short: true },
 			{ title: "Type", value: message.monitor.type, short: true },
@@ -123,12 +125,33 @@ export class RocketChatProvider extends NotificationProvider {
 				{
 					color: this.severityColor(message.severity),
 					title: message.content.title,
-					title_link: `${message.clientHost}/infrastructure/${message.monitor.id}`,
+					...(monitorUrl ? { title_link: monitorUrl } : {}),
 					fields,
 					ts: message.content.timestamp.toISOString(),
 				},
 			],
 		};
+	}
+
+	private monitorUrl(message: NotificationMessage): string | undefined {
+		const clientHost = message.clientHost?.trim();
+		if (!clientHost || clientHost === "Host not defined") {
+			return undefined;
+		}
+
+		if (message.monitor.type === "hardware") {
+			return `${clientHost}/infrastructure/${message.monitor.id}`;
+		}
+
+		if (message.monitor.type === "pagespeed") {
+			return `${clientHost}/pagespeed/${message.monitor.id}`;
+		}
+
+		if (supportsUptimeDetails(message.monitor.type as MonitorType)) {
+			return `${clientHost}/uptime/${message.monitor.id}`;
+		}
+
+		return undefined;
 	}
 
 	private severityColor(severity: NotificationMessage["severity"]): string {

--- a/server/src/domain/notifications/providers/rocketChat.ts
+++ b/server/src/domain/notifications/providers/rocketChat.ts
@@ -84,6 +84,39 @@ export class RocketChatProvider extends NotificationProvider {
 	}
 
 	private buildPayload(message: NotificationMessage): RocketChatPayload {
+		const fields: RocketChatField[] = [
+			{ title: "Monitor", value: message.monitor.name, short: true },
+			{ title: "Type", value: message.monitor.type, short: true },
+			{ title: "Status", value: message.monitor.status, short: true },
+			{ title: "URL", value: message.monitor.url, short: false },
+		];
+
+		if (message.content.thresholds?.length) {
+			fields.push(
+				...message.content.thresholds.map((breach) => ({
+					title: breach.metric.toUpperCase(),
+					value: `${breach.formattedValue} (threshold: ${breach.threshold}${breach.unit})`,
+					short: true,
+				}))
+			);
+		}
+
+		if (message.content.details?.length) {
+			fields.push({
+				title: "Details",
+				value: message.content.details.map((detail) => `- ${detail}`).join("\n"),
+				short: false,
+			});
+		}
+
+		if (message.content.incident) {
+			fields.push({
+				title: "Incident",
+				value: message.content.incident.url,
+				short: false,
+			});
+		}
+
 		return {
 			text: message.content.summary,
 			attachments: [
@@ -91,12 +124,7 @@ export class RocketChatProvider extends NotificationProvider {
 					color: this.severityColor(message.severity),
 					title: message.content.title,
 					title_link: `${message.clientHost}/infrastructure/${message.monitor.id}`,
-					fields: [
-						{ title: "Monitor", value: message.monitor.name, short: true },
-						{ title: "Type", value: message.monitor.type, short: true },
-						{ title: "Status", value: message.monitor.status, short: true },
-						{ title: "URL", value: message.monitor.url, short: false },
-					],
+					fields,
 					ts: message.content.timestamp.toISOString(),
 				},
 			],

--- a/server/src/domain/notifications/providers/rocketChat.ts
+++ b/server/src/domain/notifications/providers/rocketChat.ts
@@ -109,7 +109,7 @@ export class RocketChatProvider extends NotificationProvider {
 			});
 		}
 
-		if (message.content.incident) {
+		if (message.content.incident?.url.trim()) {
 			fields.push({
 				title: "Incident",
 				value: message.content.incident.url,

--- a/server/src/domain/notifications/providers/rocketChat.ts
+++ b/server/src/domain/notifications/providers/rocketChat.ts
@@ -64,7 +64,7 @@ export class RocketChatProvider extends NotificationProvider {
 
 		try {
 			await got.post(notification.address, {
-				json: { text: this.buildText(message) },
+				json: this.buildPayload(message),
 				headers: {
 					"Content-Type": "application/json",
 				},
@@ -83,34 +83,38 @@ export class RocketChatProvider extends NotificationProvider {
 		}
 	}
 
-	private buildText(message: NotificationMessage): string {
-		const lines = [
-			message.content.title,
-			message.content.summary,
-			"",
-			`Monitor: ${message.monitor.name}`,
-			`Type: ${message.monitor.type}`,
-			`Status: ${message.monitor.status}`,
-			`URL: ${message.monitor.url}`,
-		];
+	private buildPayload(message: NotificationMessage): RocketChatPayload {
+		return {
+			text: message.content.summary,
+			attachments: [
+				{
+					color: this.severityColor(message.severity),
+					title: message.content.title,
+					title_link: `${message.clientHost}/infrastructure/${message.monitor.id}`,
+					fields: [
+						{ title: "Monitor", value: message.monitor.name, short: true },
+						{ title: "Type", value: message.monitor.type, short: true },
+						{ title: "Status", value: message.monitor.status, short: true },
+						{ title: "URL", value: message.monitor.url, short: false },
+					],
+					ts: message.content.timestamp.toISOString(),
+				},
+			],
+		};
+	}
 
-		if (message.content.details?.length) {
-			lines.push("", "Details:", ...message.content.details.map((detail) => `- ${detail}`));
+	private severityColor(severity: NotificationMessage["severity"]): string {
+		switch (severity) {
+			case "critical":
+				return "#FF0000";
+			case "warning":
+				return "#FFA500";
+			case "success":
+				return "#00FF00";
+			case "info":
+				return "#0000FF";
+			default:
+				return "#808080";
 		}
-		if (message.content.thresholds?.length) {
-			lines.push(
-				"",
-				"Thresholds:",
-				...message.content.thresholds.map(
-					(threshold) => `- ${threshold.metric.toUpperCase()}: ${threshold.formattedValue} (threshold: ${threshold.threshold}${threshold.unit})`
-				)
-			);
-		}
-
-		if (message.content.incident) {
-			lines.push("", `Incident: ${message.clientHost}/infrastructure/${message.monitor.id}`);
-		}
-
-		return lines.join("\n");
 	}
 }

--- a/server/test/unit/providers/notifications/rocketChatProvider.test.ts
+++ b/server/test/unit/providers/notifications/rocketChatProvider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import type { NotificationSeverity } from "../../../../src/domain/notifications/notification.type.ts";
 import { createMockLogger } from "../../../helpers/createMockLogger.ts";
-import { makeMessage, makeNotification } from "../../../helpers/notificationMessage.ts";
+import { makeMessage, makeMessageWithIncident, makeMessageWithThresholds, makeNotification } from "../../../helpers/notificationMessage.ts";
 import { testNotificationProviderContract } from "../../../helpers/notificationProviderContract.ts";
 
 const mockGotPost = jest.fn().mockResolvedValue({});
@@ -108,6 +108,11 @@ describe("RocketChatProvider", () => {
 								{ title: "Type", value: "http", short: true },
 								{ title: "Status", value: "down", short: true },
 								{ title: "URL", value: "https://example.com", short: false },
+								{
+									title: "Details",
+									value: "- URL: https://example.com\n- Status: Down",
+									short: false,
+								},
 							],
 							ts: "2025-01-01T00:00:00.000Z",
 						},
@@ -136,6 +141,64 @@ describe("RocketChatProvider", () => {
 
 		const payload = mockGotPost.mock.calls[0][1].json;
 		expect(payload.attachments[0].color).toBe(color);
+	});
+
+	it("appends threshold fields before details", async () => {
+		const { provider } = createProvider();
+
+		await provider.sendMessage(makeNotification({ type: "rocket_chat" }), makeMessageWithThresholds());
+
+		const fields = mockGotPost.mock.calls[0][1].json.attachments[0].fields;
+		expect(fields).toEqual([
+			{ title: "Monitor", value: "Infra Server", short: true },
+			{ title: "Type", value: "hardware", short: true },
+			{ title: "Status", value: "up", short: true },
+			{ title: "URL", value: "https://infra.example.com", short: false },
+			{ title: "CPU", value: "90.0% (threshold: 80%)", short: true },
+			{ title: "MEMORY", value: "85.0% (threshold: 70%)", short: true },
+			{ title: "Details", value: "- URL: https://infra.example.com", short: false },
+		]);
+	});
+
+	it("appends the incident URL after details", async () => {
+		const { provider } = createProvider();
+
+		await provider.sendMessage(makeNotification({ type: "rocket_chat" }), makeMessageWithIncident());
+
+		const fields = mockGotPost.mock.calls[0][1].json.attachments[0].fields;
+		expect(fields).toEqual([
+			{ title: "Monitor", value: "Test Monitor", short: true },
+			{ title: "Type", value: "http", short: true },
+			{ title: "Status", value: "down", short: true },
+			{ title: "URL", value: "https://example.com", short: false },
+			{ title: "Details", value: "- URL: https://example.com\n- Status: Down", short: false },
+			{ title: "Incident", value: "https://app.example.com/incidents/inc-1", short: false },
+		]);
+	});
+
+	it("omits empty optional fields", async () => {
+		const { provider } = createProvider();
+		const message = makeMessage();
+
+		await provider.sendMessage(
+			makeNotification({ type: "rocket_chat" }),
+			makeMessage({
+				content: {
+					...message.content,
+					details: [],
+					thresholds: [],
+					incident: undefined,
+				},
+			})
+		);
+
+		const fields = mockGotPost.mock.calls[0][1].json.attachments[0].fields;
+		expect(fields).toEqual([
+			{ title: "Monitor", value: "Test Monitor", short: true },
+			{ title: "Type", value: "http", short: true },
+			{ title: "Status", value: "down", short: true },
+			{ title: "URL", value: "https://example.com", short: false },
+		]);
 	});
 
 	it("returns false when the message webhook URL is missing", async () => {

--- a/server/test/unit/providers/notifications/rocketChatProvider.test.ts
+++ b/server/test/unit/providers/notifications/rocketChatProvider.test.ts
@@ -201,6 +201,24 @@ describe("RocketChatProvider", () => {
 		]);
 	});
 
+	it("omits the incident field when its URL is empty", async () => {
+		const { provider } = createProvider();
+		const message = makeMessageWithIncident();
+
+		await provider.sendMessage(
+			makeNotification({ type: "rocket_chat" }),
+			makeMessage({
+				content: {
+					...message.content,
+					incident: { ...message.content.incident!, url: "" },
+				},
+			})
+		);
+
+		const fields = mockGotPost.mock.calls[0][1].json.attachments[0].fields;
+		expect(fields).not.toContainEqual(expect.objectContaining({ title: "Incident" }));
+	});
+
 	it("returns false when the message webhook URL is missing", async () => {
 		const { provider } = createProvider();
 

--- a/server/test/unit/providers/notifications/rocketChatProvider.test.ts
+++ b/server/test/unit/providers/notifications/rocketChatProvider.test.ts
@@ -25,7 +25,7 @@ testNotificationProviderContract("RocketChatProvider", {
 describe("RocketChatProvider", () => {
 	beforeEach(() => mockGotPost.mockReset().mockResolvedValue({}));
 
-	it("sends a text-only test alert", async () => {
+	it("sends a rich test alert without webhook overrides", async () => {
 		const { provider } = createProvider();
 
 		const result = await provider.sendTestAlert(makeNotification({ type: "rocket_chat" }));
@@ -34,11 +34,29 @@ describe("RocketChatProvider", () => {
 		expect(mockGotPost).toHaveBeenCalledWith(
 			"https://hooks.example.com/webhook",
 			expect.objectContaining({
-				json: { text: "This is a test notification from Checkmate" },
+				json: {
+					text: "This is a test notification from Checkmate",
+					attachments: [
+						{
+							color: "#0000FF",
+							title: "Checkmate test notification",
+							fields: [
+								{ title: "Channel", value: "Rocket.Chat", short: true },
+								{ title: "Status", value: "Test notification", short: true },
+							],
+						},
+					],
+				},
 				timeout: { request: 30000 },
 				retry: { limit: 0 },
 			})
 		);
+
+		const payload = mockGotPost.mock.calls[0][1].json;
+		expect(payload).not.toHaveProperty("alias");
+		expect(payload).not.toHaveProperty("avatar");
+		expect(payload).not.toHaveProperty("emoji");
+		expect(payload).not.toHaveProperty("channel");
 	});
 
 	it("returns false when the test webhook URL is missing", async () => {

--- a/server/test/unit/providers/notifications/rocketChatProvider.test.ts
+++ b/server/test/unit/providers/notifications/rocketChatProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest } from "@jest/globals";
+import type { NotificationSeverity } from "../../../../src/domain/notifications/notification.type.ts";
 import { createMockLogger } from "../../../helpers/createMockLogger.ts";
-import { makeMessage, makeMessageWithIncident, makeMessageWithThresholds, makeNotification } from "../../../helpers/notificationMessage.ts";
+import { makeMessage, makeNotification } from "../../../helpers/notificationMessage.ts";
 import { testNotificationProviderContract } from "../../../helpers/notificationProviderContract.ts";
 
 const mockGotPost = jest.fn().mockResolvedValue({});
@@ -84,7 +85,7 @@ describe("RocketChatProvider", () => {
 		);
 	});
 
-	it("sends monitor details as a text-only message", async () => {
+	it("sends a rich monitor attachment without webhook overrides", async () => {
 		const { provider } = createProvider();
 
 		const result = await provider.sendMessage(makeNotification({ type: "rocket_chat" }), makeMessage());
@@ -96,22 +97,45 @@ describe("RocketChatProvider", () => {
 				timeout: { request: 30000 },
 				retry: { limit: 0 },
 				json: {
-					text: [
-						"Monitor Down: Test Monitor",
-						'Monitor "Test Monitor" is currently down.',
-						"",
-						"Monitor: Test Monitor",
-						"Type: http",
-						"Status: down",
-						"URL: https://example.com",
-						"",
-						"Details:",
-						"- URL: https://example.com",
-						"- Status: Down",
-					].join("\n"),
+					text: 'Monitor "Test Monitor" is currently down.',
+					attachments: [
+						{
+							color: "#FF0000",
+							title: "Monitor Down: Test Monitor",
+							title_link: "https://app.example.com/infrastructure/mon-1",
+							fields: [
+								{ title: "Monitor", value: "Test Monitor", short: true },
+								{ title: "Type", value: "http", short: true },
+								{ title: "Status", value: "down", short: true },
+								{ title: "URL", value: "https://example.com", short: false },
+							],
+							ts: "2025-01-01T00:00:00.000Z",
+						},
+					],
 				},
 			})
 		);
+
+		const payload = mockGotPost.mock.calls[0][1].json;
+		expect(payload).not.toHaveProperty("alias");
+		expect(payload).not.toHaveProperty("avatar");
+		expect(payload).not.toHaveProperty("emoji");
+		expect(payload).not.toHaveProperty("channel");
+	});
+
+	it.each([
+		["critical", "#FF0000"],
+		["warning", "#FFA500"],
+		["success", "#00FF00"],
+		["info", "#0000FF"],
+		["unknown", "#808080"],
+	])("maps %s severity to %s", async (severity, color) => {
+		const { provider } = createProvider();
+
+		await provider.sendMessage(makeNotification({ type: "rocket_chat" }), makeMessage({ severity: severity as NotificationSeverity }));
+
+		const payload = mockGotPost.mock.calls[0][1].json;
+		expect(payload.attachments[0].color).toBe(color);
 	});
 
 	it("returns false when the message webhook URL is missing", async () => {
@@ -121,40 +145,6 @@ describe("RocketChatProvider", () => {
 
 		expect(result).toBe(false);
 		expect(mockGotPost).not.toHaveBeenCalled();
-	});
-
-	it("includes threshold breaches in the text", async () => {
-		const { provider } = createProvider();
-
-		await provider.sendMessage(makeNotification({ type: "rocket_chat" }), makeMessageWithThresholds());
-
-		const payload = mockGotPost.mock.calls[0][1].json;
-		expect(payload.text).toContain("Thresholds:\n- CPU: 90.0% (threshold: 80%)\n- MEMORY: 85.0% (threshold: 70%)");
-	});
-
-	it("includes a monitor-scoped link when incident data is present", async () => {
-		const { provider } = createProvider();
-
-		await provider.sendMessage(makeNotification({ type: "rocket_chat" }), makeMessageWithIncident());
-
-		const payload = mockGotPost.mock.calls[0][1].json;
-		expect(payload.text).toContain("Incident: https://app.example.com/infrastructure/mon-1");
-	});
-
-	it("omits the incident link when incident data is absent", async () => {
-		const { provider } = createProvider();
-
-		await provider.sendMessage(
-			makeNotification({ type: "rocket_chat" }),
-			makeMessage({
-				type: "monitor_up",
-				severity: "success",
-				monitor: { id: "mon-1", name: "Test Monitor", url: "https://example.com", type: "http", status: "up" },
-			})
-		);
-
-		const payload = mockGotPost.mock.calls[0][1].json;
-		expect(payload.text).not.toContain("Incident:");
 	});
 
 	it("returns false and logs when message delivery fails", async () => {

--- a/server/test/unit/providers/notifications/rocketChatProvider.test.ts
+++ b/server/test/unit/providers/notifications/rocketChatProvider.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, jest } from "@jest/globals";
+import type { MonitorType } from "../../../../src/domain/monitors/monitor.type.ts";
 import type { NotificationSeverity } from "../../../../src/domain/notifications/notification.type.ts";
 import { createMockLogger } from "../../../helpers/createMockLogger.ts";
 import { makeMessage, makeMessageWithIncident, makeMessageWithThresholds, makeNotification } from "../../../helpers/notificationMessage.ts";
@@ -102,7 +103,7 @@ describe("RocketChatProvider", () => {
 						{
 							color: "#FF0000",
 							title: "Monitor Down: Test Monitor",
-							title_link: "https://app.example.com/infrastructure/mon-1",
+							title_link: "https://app.example.com/uptime/mon-1",
 							fields: [
 								{ title: "Monitor", value: "Test Monitor", short: true },
 								{ title: "Type", value: "http", short: true },
@@ -126,6 +127,32 @@ describe("RocketChatProvider", () => {
 		expect(payload).not.toHaveProperty("avatar");
 		expect(payload).not.toHaveProperty("emoji");
 		expect(payload).not.toHaveProperty("channel");
+	});
+
+	it.each([
+		["http", "https://app.example.com/uptime/mon-1"],
+		["ping", "https://app.example.com/uptime/mon-1"],
+		["pagespeed", "https://app.example.com/pagespeed/mon-1"],
+		["hardware", "https://app.example.com/infrastructure/mon-1"],
+	])("links %s monitors to %s", async (type, expectedLink) => {
+		const { provider } = createProvider();
+
+		await provider.sendMessage(
+			makeNotification({ type: "rocket_chat" }),
+			makeMessage({ monitor: { id: "mon-1", name: "Test Monitor", url: "https://example.com", type: type as MonitorType, status: "down" } })
+		);
+
+		const payload = mockGotPost.mock.calls[0][1].json;
+		expect(payload.attachments[0].title_link).toBe(expectedLink);
+	});
+
+	it.each([["Host not defined"], [""], ["   "]])("omits title_link when clientHost is %j", async (clientHost) => {
+		const { provider } = createProvider();
+
+		await provider.sendMessage(makeNotification({ type: "rocket_chat" }), makeMessage({ clientHost }));
+
+		const payload = mockGotPost.mock.calls[0][1].json;
+		expect(payload.attachments[0]).not.toHaveProperty("title_link");
 	});
 
 	it.each([


### PR DESCRIPTION
## Changes
- [x] Add rich Rocket.Chat attachments for test and monitor notifications
- [x] Map severity colors and link alert titles to Checkmate monitors
- [x] Include structured monitor, threshold, detail, and incident fields
- [x] Preserve Incoming Webhook identity and routing settings
- [x] Add provider regression tests

Fixes #3830