### PR TITLE
feat(status-page): display active maintenance banner and monitor maintenance alert (#2679)

### DIFF
--- a/client/src/Pages/StatusPage/Status/index.tsx
+++ b/client/src/Pages/StatusPage/Status/index.tsx
@@ -149,6 +149,7 @@ const StatusPageView = () => {
 				<BaseStatusPage
 					statusPage={statusPage}
 					monitors={monitors}
+					activeMaintenances={data?.activeMaintenances}
 					config={themeConfig}
 				/>
 			</StatusPageThemeProvider>

--- a/client/src/Pages/StatusPage/Status/themes/shared/BaseStatusPage.tsx
+++ b/client/src/Pages/StatusPage/Status/themes/shared/BaseStatusPage.tsx
@@ -4,9 +4,10 @@ import Stack from "@mui/material/Stack";
 import { useTranslation } from "react-i18next";
 import type { SxProps, Theme } from "@mui/material/styles";
 import type { Monitor } from "@/Types/Monitor";
-import type { StatusPage } from "@/Types/StatusPage";
+import type { StatusPage, ActiveMaintenanceInfo } from "@/Types/StatusPage";
 import { getMonitorTypeLabel } from "@/Types/StatusPage";
 import type { StatusPageThemeTokens } from "@/Pages/StatusPage/Status/themes/tokens";
+import { MaintenanceBanner } from "@/Pages/StatusPage/Status/themes/shared/MaintenanceBanner";
 import {
 	ThemedHeatmap,
 	type HeatCellKind,
@@ -81,10 +82,16 @@ export interface ThemeConfig<S extends BaseStyles = BaseStyles> {
 interface Props {
 	statusPage: StatusPage;
 	monitors: StatusPageMonitor[];
+	activeMaintenances?: ActiveMaintenanceInfo[];
 	config: ThemeConfig<any>;
 }
 
-export const BaseStatusPage = ({ statusPage, monitors, config }: Props) => {
+export const BaseStatusPage = ({
+	statusPage,
+	monitors,
+	activeMaintenances,
+	config,
+}: Props) => {
 	const { t } = useTranslation();
 	const { tokens, mode } = useStatusPageTheme();
 	const styles = useMemo(
@@ -123,6 +130,12 @@ export const BaseStatusPage = ({ statusPage, monitors, config }: Props) => {
 				overall={overall}
 				monitorCount={monitors.length}
 				styles={styles}
+			/>
+
+			<MaintenanceBanner
+				activeMaintenances={activeMaintenances}
+				monitors={monitors}
+				timezone={statusPage.timezone}
 			/>
 
 			{statusPage.showCharts && (

--- a/client/src/Pages/StatusPage/Status/themes/shared/MaintenanceBanner.tsx
+++ b/client/src/Pages/StatusPage/Status/themes/shared/MaintenanceBanner.tsx
@@ -1,0 +1,164 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { Wrench, Clock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { Monitor } from "@/Types/Monitor";
+import type { ActiveMaintenanceInfo } from "@/Types/StatusPage";
+import { useStatusPageTheme } from "@/Pages/StatusPage/Status/themes/StatusPageThemeProvider";
+import { formatDateWithTz } from "@/Utils/TimeUtils";
+
+interface Props {
+	activeMaintenances?: ActiveMaintenanceInfo[];
+	monitors: Monitor[];
+	timezone?: string;
+}
+
+export const MaintenanceBanner = ({ activeMaintenances, monitors, timezone }: Props) => {
+	const { t } = useTranslation();
+	const { tokens, timezone: themeTimezone } = useStatusPageTheme();
+	const effectiveTimezone = timezone || themeTimezone;
+
+	if (!activeMaintenances || activeMaintenances.length === 0) {
+		return null;
+	}
+
+	const monitorMap = new Map(monitors.map((m) => [m.id, m.name]));
+
+	return (
+		<Stack
+			spacing={2}
+			sx={{
+				width: "100%",
+				mb: 4,
+			}}
+		>
+			{activeMaintenances.map((mw) => {
+				const affectedNames = mw.monitorIds
+					.map((id) => monitorMap.get(id))
+					.filter(Boolean);
+
+				const formattedEnd = formatDateWithTz(
+					mw.end,
+					"MMM D, YYYY h:mm A",
+					effectiveTimezone
+				);
+
+				const etaText = t("pages.statusPages.maintenanceBanner.eta", {
+					time: `${formattedEnd} (${effectiveTimezone})`,
+				});
+
+				return (
+					<Box
+						key={mw.id}
+						sx={{
+							p: 2.5,
+							borderRadius: tokens.radius,
+							backgroundColor: tokens.warnSoft,
+							border: `1px solid ${tokens.warn}`,
+							color: tokens.text,
+							display: "flex",
+							flexDirection: "column",
+							gap: 1.5,
+							boxShadow: "0 2px 8px rgba(0, 0, 0, 0.04)",
+						}}
+					>
+						<Stack
+							direction="row"
+							alignItems="center"
+							justifyContent="space-between"
+							flexWrap="wrap"
+							gap={1}
+						>
+							<Stack
+								direction="row"
+								alignItems="center"
+								spacing={1.5}
+							>
+								<Box
+									sx={{
+										display: "inline-flex",
+										alignItems: "center",
+										justifyContent: "center",
+										p: 0.75,
+										borderRadius: "8px",
+										backgroundColor: tokens.warn,
+										color: "#ffffff",
+									}}
+								>
+									<Wrench size={18} />
+								</Box>
+								<Typography
+									variant="subtitle1"
+									sx={{
+										fontWeight: 600,
+										fontFamily: tokens.headingFontFamily || "inherit",
+										color: tokens.text,
+										lineHeight: 1.2,
+									}}
+								>
+									{mw.name || t("pages.statusPages.maintenanceBanner.title")}
+								</Typography>
+							</Stack>
+
+							<Stack
+								direction="row"
+								alignItems="center"
+								spacing={0.75}
+								sx={{
+									fontSize: "0.875rem",
+									color: tokens.textMuted,
+									backgroundColor: "rgba(0, 0, 0, 0.04)",
+									px: 1.25,
+									py: 0.5,
+									borderRadius: "6px",
+								}}
+							>
+								<Clock size={15} />
+								<span>{etaText}</span>
+							</Stack>
+						</Stack>
+
+						{affectedNames.length > 0 && (
+							<Stack
+								direction="row"
+								alignItems="center"
+								flexWrap="wrap"
+								gap={0.75}
+								sx={{ mt: 0.5 }}
+							>
+								<Typography
+									variant="body2"
+									sx={{
+										color: tokens.textMuted,
+										fontSize: "0.8125rem",
+										fontWeight: 500,
+									}}
+								>
+									{t("pages.statusPages.maintenanceBanner.affectedServices")}
+								</Typography>
+								{affectedNames.map((name, idx) => (
+									<Box
+										key={idx}
+										sx={{
+											fontSize: "0.75rem",
+											fontWeight: 500,
+											px: 1,
+											py: 0.25,
+											borderRadius: "4px",
+											backgroundColor: tokens.surface,
+											border: `1px solid ${tokens.border}`,
+											color: tokens.text,
+										}}
+									>
+										{name}
+									</Box>
+								))}
+							</Stack>
+						)}
+					</Box>
+				);
+			})}
+		</Stack>
+	);
+};

--- a/client/src/Pages/Uptime/Details/index.tsx
+++ b/client/src/Pages/Uptime/Details/index.tsx
@@ -9,7 +9,8 @@ import {
 	HeaderGeoTabs,
 	GeoChecksMap,
 } from "@/Components/monitors";
-import { TrendingUp, AlertTriangle } from "lucide-react";
+import { TrendingUp, AlertTriangle, Wrench } from "lucide-react";
+import Alert from "@mui/material/Alert";
 import { ChecksTable } from "@/Pages/Uptime/Details/Components/ChecksTable";
 import { GeoChecksTable } from "@/Pages/Uptime/Details/Components/GeoChecksTable";
 import { MonitorStatBoxes } from "@/Components/monitors";
@@ -189,6 +190,18 @@ const UptimeDetailsPage = () => {
 				isAdmin={isAdmin}
 				refetch={refetchMonitor}
 			/>
+			{monitor.status === "maintenance" && (
+				<Alert
+					severity="warning"
+					icon={<Wrench size={20} />}
+					sx={{
+						borderRadius: "8px",
+						fontWeight: 500,
+					}}
+				>
+					{t("pages.uptime.details.maintenanceAlert")}
+				</Alert>
+			)}
 			<MonitorStatBoxes
 				monitor={monitor}
 				monitorStats={monitorStats}

--- a/client/src/Types/StatusPage.ts
+++ b/client/src/Types/StatusPage.ts
@@ -75,7 +75,16 @@ export interface StatusPage {
 	updatedAt: string;
 }
 
+export interface ActiveMaintenanceInfo {
+	id: string;
+	name: string;
+	start: string;
+	end: string;
+	monitorIds: string[];
+}
+
 export interface StatusPageResponse {
 	statusPage: StatusPage;
 	monitors: Monitor[];
+	activeMaintenances?: ActiveMaintenanceInfo[];
 }

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1437,6 +1437,11 @@
 		},
 		"statusPages": {
 			"deleteSuccess": "Status page deleted successfully",
+			"maintenanceBanner": {
+				"title": "Scheduled Maintenance in Progress",
+				"eta": "Expected completion: {{time}}",
+				"affectedServices": "Affected services:"
+			},
 			"fallback": {
 				"title": "No status pages yet",
 				"description": "Publish a public page that shows real-time uptime and incident history to your customers and stakeholders.",
@@ -1669,6 +1674,9 @@
 			"header": {
 				"title": "Uptime monitors",
 				"description": "Watch HTTP endpoints, pings, containers, and ports — and get alerted the moment something goes down."
+			},
+			"details": {
+				"maintenanceAlert": "This monitor is currently under scheduled maintenance. Incident detection and alert notifications are temporarily paused."
 			}
 		}
 	}

--- a/server/src/config/services.api.ts
+++ b/server/src/config/services.api.ts
@@ -91,7 +91,7 @@ export const buildApi = (shared: SharedServices, jobScheduler: IJobScheduler): A
 		emailService,
 	});
 
-	const statusPageService = new StatusPageService(statusPagesRepository, settingsService, monitorsRepository);
+	const statusPageService = new StatusPageService(statusPagesRepository, settingsService, monitorsRepository, maintenanceWindowsRepository);
 	const tagsService = new TagsService(tagsRepository, monitorsRepository);
 	const diagnosticService = new DiagnosticService(db);
 

--- a/server/src/domain/status-pages/status-page.service.ts
+++ b/server/src/domain/status-pages/status-page.service.ts
@@ -1,7 +1,9 @@
 import { type IStatusPagesRepository } from "@/domain/status-pages/status-page-repository.interface.js";
 import { ISettingsService } from "@/domain/app-settings/app-settings.service.js";
 import { IMonitorsRepository } from "@/domain/monitors/monitor.repository.interface.js";
+import { type IMaintenanceWindowsRepository } from "@/domain/maintenance-windows/maintenance-window.repository.interface.js";
 import {
+	ActiveMaintenanceInfo,
 	DEFAULT_STATUS_PAGE_THEME,
 	DEFAULT_STATUS_PAGE_THEME_MODE,
 	PublicStatusPagePayload,
@@ -9,6 +11,7 @@ import {
 } from "@/domain/status-pages/status-page.type.js";
 import { AppError } from "@/utils/AppError.js";
 import { normalizeStatusPageDomain } from "@/utils/statusPageDomain.js";
+import { isWindowActive, getActiveWindowEnd } from "@/utils/maintenanceWindow.js";
 import { Monitor } from "@/domain/monitors/monitor.type.js";
 
 export interface IStatusPageService {
@@ -26,7 +29,8 @@ export class StatusPageService implements IStatusPageService {
 	constructor(
 		private statusPagesRepository: IStatusPagesRepository,
 		private settingsService: ISettingsService,
-		private monitorsRepository: IMonitorsRepository
+		private monitorsRepository: IMonitorsRepository,
+		private maintenanceWindowsRepository?: IMaintenanceWindowsRepository
 	) {}
 
 	private assertCustomDomainAllowed = (customDomain: string | null | undefined) => {
@@ -128,7 +132,35 @@ export class StatusPageService implements IStatusPageService {
 		const order = new Map(statusPage.monitors.map((id, i) => [id, i]));
 		const sorted = [...monitors].sort((a, b) => (order.get(a.id) ?? Number.MAX_SAFE_INTEGER) - (order.get(b.id) ?? Number.MAX_SAFE_INTEGER));
 
-		return { statusPage, monitors: sorted.map((monitor) => this.toPublicMonitor(monitor, showURL)) };
+		let activeMaintenances: ActiveMaintenanceInfo[] | undefined;
+		if (this.maintenanceWindowsRepository && statusPage.monitors.length > 0) {
+			const windows = await this.maintenanceWindowsRepository.findByMonitorIds(statusPage.monitors, statusPage.teamId);
+			const now = new Date();
+			const activeList = windows
+				.filter((win) => isWindowActive(win, now))
+				.map((win) => {
+					const activeEnd = getActiveWindowEnd(win, now) ?? new Date(win.end);
+					const affectedMonitorIds = win.monitorIds.filter((id) => statusPage.monitors.includes(id));
+					return {
+						id: win.id,
+						name: win.name,
+						start: win.start,
+						end: activeEnd.toISOString(),
+						monitorIds: affectedMonitorIds,
+					};
+				})
+				.filter((m) => m.monitorIds.length > 0);
+
+			if (activeList.length > 0) {
+				activeMaintenances = activeList;
+			}
+		}
+
+		return {
+			statusPage,
+			monitors: sorted.map((monitor) => this.toPublicMonitor(monitor, showURL)),
+			...(activeMaintenances ? { activeMaintenances } : {}),
+		};
 	};
 
 	updateStatusPage = async (id: string, teamId: string, image: Express.Multer.File | undefined, data: Partial<StatusPage>): Promise<StatusPage> => {

--- a/server/src/domain/status-pages/status-page.type.ts
+++ b/server/src/domain/status-pages/status-page.type.ts
@@ -49,7 +49,16 @@ export interface StatusPage {
 export type PublicStatusPageMonitor = Pick<Monitor, "id" | "name" | "type" | "status" | "uptimePercentage" | "recentChecks"> &
 	Partial<Pick<Monitor, "url" | "port">>;
 
+export interface ActiveMaintenanceInfo {
+	id: string;
+	name: string;
+	start: string;
+	end: string;
+	monitorIds: string[];
+}
+
 export interface PublicStatusPagePayload {
 	statusPage: StatusPage;
 	monitors: PublicStatusPageMonitor[];
+	activeMaintenances?: ActiveMaintenanceInfo[];
 }

--- a/server/src/utils/maintenanceWindow.ts
+++ b/server/src/utils/maintenanceWindow.ts
@@ -26,3 +26,27 @@ export const isWindowActive = (window: MaintenanceWindow, now: Date = new Date()
 
 	return false;
 };
+
+export const getActiveWindowEnd = (window: MaintenanceWindow, now: Date = new Date()): Date | null => {
+	if (!window.active) {
+		return null;
+	}
+
+	const start = new Date(window.start);
+	const end = new Date(window.end);
+	const repeatInterval = window.repeat || 0;
+
+	if (start <= now && end >= now) {
+		return new Date(end);
+	}
+
+	while (start < now && repeatInterval !== 0) {
+		start.setTime(start.getTime() + repeatInterval);
+		end.setTime(end.getTime() + repeatInterval);
+		if (start <= now && end >= now) {
+			return new Date(end);
+		}
+	}
+
+	return null;
+};

--- a/server/src/utils/maintenanceWindow.ts
+++ b/server/src/utils/maintenanceWindow.ts
@@ -34,19 +34,27 @@ export const getActiveWindowEnd = (window: MaintenanceWindow, now: Date = new Da
 
 	const start = new Date(window.start);
 	const end = new Date(window.end);
-	const repeatInterval = window.repeat || 0;
+	if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+		return null;
+	}
 
 	if (start <= now && end >= now) {
 		return new Date(end);
 	}
 
-	while (start < now && repeatInterval !== 0) {
-		start.setTime(start.getTime() + repeatInterval);
-		end.setTime(end.getTime() + repeatInterval);
-		if (start <= now && end >= now) {
-			return new Date(end);
-		}
+	const repeatInterval = window.repeat ?? 0;
+	if (repeatInterval <= 0 || now < start) {
+		return null;
 	}
 
-	return null;
+	const durationMs = end.getTime() - start.getTime();
+	if (durationMs < 0) {
+		return null;
+	}
+
+	const occurrencesPassed = Math.floor((now.getTime() - start.getTime()) / repeatInterval);
+	const occurrenceStart = start.getTime() + occurrencesPassed * repeatInterval;
+	const occurrenceEnd = occurrenceStart + durationMs;
+
+	return occurrenceStart <= now.getTime() && occurrenceEnd >= now.getTime() ? new Date(occurrenceEnd) : null;
 };

--- a/server/test/unit/services/statusPageService.test.ts
+++ b/server/test/unit/services/statusPageService.test.ts
@@ -1,10 +1,14 @@
+import type { Express } from "express";
+import "multer";
 import { describe, expect, it, jest } from "@jest/globals";
 import { StatusPageService } from "../../../src/domain/status-pages/status-page.service.ts";
 import type { IStatusPagesRepository } from "../../../src/domain/status-pages/status-page-repository.interface.ts";
 import type { ISettingsService } from "../../../src/domain/app-settings/app-settings.service.ts";
 import type { IMonitorsRepository } from "../../../src/domain/monitors/monitor.repository.interface.ts";
+import type { IMaintenanceWindowsRepository } from "../../../src/domain/maintenance-windows/maintenance-window.repository.interface.ts";
+import type { MaintenanceWindow } from "../../../src/domain/maintenance-windows/maintenance-window.type.ts";
 import type { Monitor } from "../../../src/domain/monitors/monitor.type.ts";
-import type { StatusPage } from "../../../src/domain/status-pages/status-page.type.ts";
+import type { StatusPage, PublicStatusPageMonitor } from "../../../src/domain/status-pages/status-page.type.ts";
 import { DEFAULT_STATUS_PAGE_THEME, DEFAULT_STATUS_PAGE_THEME_MODE } from "../../../src/domain/status-pages/status-page.type.ts";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -26,13 +30,13 @@ const makeStatusPage = (overrides?: Partial<StatusPage>): StatusPage =>
 
 const createRepo = () =>
 	({
-		create: jest.fn().mockResolvedValue(makeStatusPage()),
-		findByUrl: jest.fn().mockResolvedValue(makeStatusPage()),
-		findByCustomDomain: jest.fn().mockResolvedValue(makeStatusPage()),
-		findByTeamId: jest.fn().mockResolvedValue([makeStatusPage()]),
-		updateById: jest.fn().mockResolvedValue(makeStatusPage()),
-		deleteById: jest.fn().mockResolvedValue(makeStatusPage()),
-		removeMonitorFromStatusPages: jest.fn().mockResolvedValue(1),
+		create: jest.fn(async () => makeStatusPage()),
+		findByUrl: jest.fn(async () => makeStatusPage()),
+		findByCustomDomain: jest.fn(async () => makeStatusPage()),
+		findByTeamId: jest.fn(async () => [makeStatusPage()]),
+		updateById: jest.fn(async () => makeStatusPage()),
+		deleteById: jest.fn(async () => makeStatusPage()),
+		removeMonitorFromStatusPages: jest.fn(async () => 1),
 	}) as unknown as jest.Mocked<IStatusPagesRepository>;
 
 const makeMonitor = (overrides?: Partial<Monitor>): Monitor =>
@@ -69,20 +73,26 @@ const createSettingsService = (themesEnabled: boolean, clientHost = "http://loca
 	({
 		areStatusPageThemesEnabled: jest.fn().mockReturnValue(themesEnabled),
 		getSettings: jest.fn().mockReturnValue({ clientHost }),
-		getDBSettings: jest.fn().mockResolvedValue({ showURL }),
+		getDBSettings: jest.fn(async () => ({ showURL })),
 	}) as unknown as jest.Mocked<ISettingsService>;
+
+const createMaintenanceWindowsRepo = () =>
+	({
+		findByMonitorIds: jest.fn(async () => []),
+	}) as unknown as jest.Mocked<IMaintenanceWindowsRepository>;
 
 const createMonitorsRepo = () =>
 	({
-		findByIds: jest.fn().mockResolvedValue([makeMonitor()]),
+		findByIds: jest.fn(async () => [makeMonitor()]),
 	}) as unknown as jest.Mocked<IMonitorsRepository>;
 
 const createService = (themesEnabled = true, clientHost = "http://localhost:5173", showURL = false) => {
 	const repo = createRepo();
 	const settingsService = createSettingsService(themesEnabled, clientHost, showURL);
 	const monitorsRepo = createMonitorsRepo();
-	const service = new StatusPageService(repo, settingsService, monitorsRepo);
-	return { service, repo, settingsService, monitorsRepo };
+	const maintenanceWindowsRepo = createMaintenanceWindowsRepo();
+	const service = new StatusPageService(repo, settingsService, monitorsRepo, maintenanceWindowsRepo);
+	return { service, repo, settingsService, monitorsRepo, maintenanceWindowsRepo };
 };
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -196,10 +206,7 @@ describe("StatusPageService", () => {
 
 		it("applies default theme to every result when themes disabled", async () => {
 			const { service, repo } = createService(false);
-			(repo.findByTeamId as jest.Mock).mockResolvedValue([
-				makeStatusPage({ id: "sp-1", theme: "bold" }),
-				makeStatusPage({ id: "sp-2", theme: "editorial" }),
-			]);
+			repo.findByTeamId.mockResolvedValue([makeStatusPage({ id: "sp-1", theme: "bold" }), makeStatusPage({ id: "sp-2", theme: "editorial" })]);
 
 			const result = await service.getStatusPagesByTeamId("team-1");
 
@@ -215,7 +222,7 @@ describe("StatusPageService", () => {
 		it("delegates to repository with all parameters", async () => {
 			const { service, repo } = createService(true);
 			const updated = makeStatusPage({ companyName: "Updated Co" });
-			(repo.updateById as jest.Mock).mockResolvedValue(updated);
+			repo.updateById.mockResolvedValue(updated);
 			const file = { originalname: "new-logo.png" } as Express.Multer.File;
 
 			const result = await service.updateStatusPage("sp-1", "team-1", file, { companyName: "Updated Co" });
@@ -321,12 +328,12 @@ describe("StatusPageService", () => {
 
 		it("orders monitors to match the status page's monitor list", async () => {
 			const { service, monitorsRepo } = createService();
-			(monitorsRepo.findByIds as jest.Mock).mockResolvedValue([makeMonitor({ id: "mon-1" }), makeMonitor({ id: "mon-2" })]);
+			monitorsRepo.findByIds.mockResolvedValue([makeMonitor({ id: "mon-1" }), makeMonitor({ id: "mon-2" })]);
 			const page = makeStatusPage({ isPublished: true, monitors: ["mon-2", "mon-1"] });
 
 			const { monitors } = await service.getPublicStatusPagePayload(page, undefined);
 
-			expect(monitors.map((monitor) => monitor.id)).toEqual(["mon-2", "mon-1"]);
+			expect(monitors.map((monitor: PublicStatusPageMonitor) => monitor.id)).toEqual(["mon-2", "mon-1"]);
 		});
 
 		it("rejects an unpublished page for a mismatched or absent requester team (403)", async () => {
@@ -352,6 +359,60 @@ describe("StatusPageService", () => {
 			await expect(service.getPublicStatusPagePayload(publishedPage(), undefined)).resolves.toMatchObject({
 				statusPage: expect.objectContaining({ id: "sp-1" }),
 			});
+		});
+
+		it("includes activeMaintenances when active maintenance windows cover status page monitors", async () => {
+			const { service, maintenanceWindowsRepo } = createService();
+			const now = Date.now();
+			const activeWindow: MaintenanceWindow = {
+				id: "mw-1",
+				name: "Scheduled DB Migration",
+				teamId: "team-1",
+				monitorIds: ["mon-1", "mon-99"],
+				active: true,
+				duration: 60,
+				durationUnit: "minutes",
+				repeat: 0,
+				start: new Date(now - 60_000).toISOString(),
+				end: new Date(now + 60_000).toISOString(),
+				createdAt: "2026-01-01T00:00:00Z",
+				updatedAt: "2026-01-01T00:00:00Z",
+			};
+			maintenanceWindowsRepo.findByMonitorIds.mockResolvedValue([activeWindow]);
+
+			const result = await service.getPublicStatusPagePayload(publishedPage(), undefined);
+
+			expect(result.activeMaintenances).toBeDefined();
+			expect(result.activeMaintenances).toHaveLength(1);
+			expect(result.activeMaintenances![0]).toMatchObject({
+				id: "mw-1",
+				name: "Scheduled DB Migration",
+				monitorIds: ["mon-1"], // only includes mon-1 since mon-99 is not on this status page
+			});
+		});
+
+		it("does not include activeMaintenances when maintenance windows are inactive", async () => {
+			const { service, maintenanceWindowsRepo } = createService();
+			const now = Date.now();
+			const inactiveWindow: MaintenanceWindow = {
+				id: "mw-1",
+				name: "Past Maintenance",
+				teamId: "team-1",
+				monitorIds: ["mon-1"],
+				active: true,
+				duration: 60,
+				durationUnit: "minutes",
+				repeat: 0,
+				start: new Date(now - 120_000).toISOString(),
+				end: new Date(now - 60_000).toISOString(),
+				createdAt: "2026-01-01T00:00:00Z",
+				updatedAt: "2026-01-01T00:00:00Z",
+			};
+			maintenanceWindowsRepo.findByMonitorIds.mockResolvedValue([inactiveWindow]);
+
+			const result = await service.getPublicStatusPagePayload(publishedPage(), undefined);
+
+			expect(result.activeMaintenances).toBeUndefined();
 		});
 	});
 

--- a/server/test/unit/utils/maintenanceWindow.test.ts
+++ b/server/test/unit/utils/maintenanceWindow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { isWindowActive } from "../../../src/utils/maintenanceWindow.ts";
+import { isWindowActive, getActiveWindowEnd } from "../../../src/utils/maintenanceWindow.ts";
 import type { MaintenanceWindow } from "../../../src/domain/maintenance-windows/maintenance-window.type.ts";
 
 const makeWindow = (overrides?: Partial<MaintenanceWindow>): MaintenanceWindow => {
@@ -91,5 +91,39 @@ describe("isWindowActive", () => {
 		expect(isWindowActive(win, new Date("2026-01-15T12:00:00Z"))).toBe(true);
 		expect(isWindowActive(win, new Date("2026-01-15T14:00:00Z"))).toBe(false);
 		expect(isWindowActive(win, new Date("2026-01-15T10:00:00Z"))).toBe(false);
+	});
+});
+
+describe("getActiveWindowEnd", () => {
+	it("returns null when window is not active", () => {
+		expect(getActiveWindowEnd(makeWindow({ active: false }))).toBeNull();
+	});
+
+	it("returns correct end date for one-time active window", () => {
+		const win = makeWindow({
+			start: "2026-01-15T11:00:00Z",
+			end: "2026-01-15T13:00:00Z",
+		});
+		const result = getActiveWindowEnd(win, new Date("2026-01-15T12:00:00Z"));
+		expect(result?.toISOString()).toBe("2026-01-15T13:00:00.000Z");
+	});
+
+	it("returns advanced end date for recurring active window", () => {
+		const win = makeWindow({
+			start: "2026-01-15T10:00:00Z",
+			end: "2026-01-15T10:30:00Z",
+			repeat: 3_600_000, // 1 hour repeat
+		});
+		// at 12:15, current occurrence is 12:00 -> 12:30
+		const result = getActiveWindowEnd(win, new Date("2026-01-15T12:15:00Z"));
+		expect(result?.toISOString()).toBe("2026-01-15T12:30:00.000Z");
+	});
+
+	it("returns null when window is outside active time", () => {
+		const win = makeWindow({
+			start: "2026-01-15T11:00:00Z",
+			end: "2026-01-15T13:00:00Z",
+		});
+		expect(getActiveWindowEnd(win, new Date("2026-01-15T14:00:00Z"))).toBeNull();
 	});
 });


### PR DESCRIPTION
### Summary
This PR implements maintenance mode visibility on public status pages and monitor detail pages as requested in #2679.

- **Status Pages**: Displays a themed `MaintenanceBanner` when any monitors attached to the status page are undergoing active scheduled maintenance, detailing affected services and estimated completion time (ETA).
- **Monitor Detail Page**: Displays an informative warning alert banner when the viewed monitor is currently in maintenance mode.
- **Backend**:
  - Implemented `getActiveWindowEnd()` utility to calculate end times for one-time and recurring maintenance windows.
  - Updated `StatusPageService.getPublicStatusPagePayload` to query `maintenanceWindowsRepository` for active windows covering the status page monitors.
  - Injected `IMaintenanceWindowsRepository` in `services.api.ts`.
- **Localization**: Added translation strings to `en.json`.

Fixes #2679

### PR Checklist
- [x] Tested the app locally and confirmed changes work as intended.
- [x] Code reviewed and no debug logs or leftover code.
- [x] Included related issue (`Fixes #2679`).
- [x] All user-facing strings use `t(...)` translations with keys in `en.json`.
- [x] Shared themes/tokens used for styling.
- [x] Code passes `npm run lint` and all unit tests (67 test suites, 1262 tests passing).
- [x] Opened against the `develop` branch.
