### PR TITLE
fix(status-page): allow DNS monitors to be added to status pages

### DIFF
--- a/client/src/Pages/StatusPage/Create/index.tsx
+++ b/client/src/Pages/StatusPage/Create/index.tsx
@@ -15,6 +15,7 @@ import type { StatusPageFormData } from "@/Validation/statusPage";
 import { statusPageStepCount, statusPageStepFieldsFor } from "@/Validation/statusPage";
 import { useGet, usePost, usePut, useDelete } from "@/Hooks/UseApi";
 import type { Monitor } from "@/Types/Monitor";
+import { SelectableMonitorTypes } from "@/Types/Monitor";
 import type { MonitorDisplayType, StatusPageResponse } from "@/Types/StatusPage";
 import { getMonitorTypeLabel } from "@/Types/StatusPage";
 import { timezoneOptions } from "@/Utils/timezoneOptions";
@@ -58,11 +59,13 @@ const LogoUploadField = () => {
 	);
 };
 
+// Derived from SelectableMonitorTypes so a newly supported monitor type is
+// offered here automatically; the previous hardcoded list silently omitted DNS.
+// "hardware" is appended because infrastructure monitors are created on their
+// own page and so are absent from the selectable set.
 const monitorsUrl = (() => {
 	const params = new URLSearchParams();
-	["http", "ping", "port", "docker", "game", "grpc", "websocket", "hardware"].forEach(
-		(type) => params.append("type", type)
-	);
+	[...SelectableMonitorTypes, "hardware"].forEach((type) => params.append("type", type));
 	return `/monitors/team?${params.toString()}`;
 })();
 


### PR DESCRIPTION
Fixes #3721.

DNS monitors could not be selected when creating or configuring a status page — they were absent from the monitor picker dialog.

## Cause

The picker builds its query from a hardcoded list of monitor types (`client/src/Pages/StatusPage/Create/index.tsx`) that omitted `"dns"`, so the server filtered DNS monitors out before they ever reached the dialog.

Nothing else was missing: the DNS provider stores checks like any other monitor type, the server validator already accepts `"dns"`, and the status page renders DNS monitors correctly once attached. It was purely the client-side filter.

## Fix

Rather than appending `"dns"` to the hardcoded list, the query is derived from the existing `SelectableMonitorTypes` tuple in `@/Types/Monitor`. The two lists had silently drifted apart, and deriving prevents the next new monitor type from reproducing this bug.

`"hardware"` is appended explicitly, because infrastructure monitors are created on their own page and so are deliberately absent from the selectable set.

Net effect on the requested types: **gains `dns`, loses none.**

## Verification

- Type-set delta checked explicitly — before `{http, ping, port, docker, game, grpc, websocket, hardware}`, after the same set plus `dns`.
- Server accepts the new value: `getMonitorsByTeamIdQueryValidation` validates against `MonitorTypes`, which includes `"dns"`.
- DNS classifies as `"uptime"` (not `"infrastructure"`) via the existing `m.type === "hardware"` branch — no new case needed.
- The `optionDns` i18n key resolves to "DNS" rather than falling back to a raw type string.
- `npm run build`, ESLint, and Prettier all clean.
