### PR TITLE
fix(monitors): check TLS certificate on the monitor's own port

### DIFF
--- a/client/src/Pages/Uptime/Details/index.tsx
+++ b/client/src/Pages/Uptime/Details/index.tsx
@@ -34,6 +34,17 @@ import { Typography } from "@mui/material";
 
 const certificateDateFormat = "MMM D, YYYY h A";
 
+const isHttpsUrl = (url?: string): boolean => {
+	if (!url) {
+		return false;
+	}
+	try {
+		return new URL(url).protocol === "https:";
+	} catch {
+		return false;
+	}
+};
+
 interface CertificateResponse {
 	certificateDate: string;
 }
@@ -80,13 +91,15 @@ const UptimeDetailsPage = () => {
 	const monitor = monitorData?.monitor;
 	const monitorStats = monitorDetailsData?.monitorStats ?? null;
 
-	// Certificate fetch - only for HTTP monitors
+	// Certificate fetch - only for monitors served over HTTPS. A "http" type
+	// monitor may still have an http:// URL, which serves no certificate, so the
+	// scheme is gated here to match the server rather than requesting a 400.
 	const certificateUrl = useMemo(() => {
-		if (!monitorId || monitor?.type !== "http") {
+		if (!monitorId || monitor?.type !== "http" || !isHttpsUrl(monitor?.url)) {
 			return null;
 		}
 		return `/monitors/certificate/${monitorId}`;
-	}, [monitorId, monitor?.type]);
+	}, [monitorId, monitor?.type, monitor?.url]);
 
 	const { data: certificateData } = useGet<CertificateResponse>(
 		certificateUrl,

--- a/server/src/api/controllers/controllerUtils.ts
+++ b/server/src/api/controllers/controllerUtils.ts
@@ -11,9 +11,14 @@ const DEFAULT_HTTPS_PORT = 443;
 
 export const fetchMonitorCertificate = async (checker: SSLCheckerType, monitor: Monitor): Promise<SSLDetails> => {
 	const monitorUrl = new URL(monitor.url);
+	// A plain-HTTP monitor serves no certificate. Reject before dialing, so the
+	// caller gets this instead of a raw OpenSSL handshake error from the socket.
+	if (monitorUrl.protocol !== "https:") {
+		throw new AppError({ message: "Certificate is only available for HTTPS monitors", status: 400 });
+	}
 	const hostname = monitorUrl.hostname;
-	// URL.port is "" for default ports, so fall back to 443; without this the
-	// certificate of a monitor on a non-standard port was probed on 443.
+	// URL.port is "" for the scheme's default port, so fall back to 443; without
+	// this the certificate of a monitor on a non-standard port was probed on 443.
 	const port = monitorUrl.port === "" ? DEFAULT_HTTPS_PORT : Number(monitorUrl.port);
 	const cert = await checker(hostname, { port });
 	if (cert?.validTo === null || cert?.validTo === undefined) {

--- a/server/src/api/controllers/controllerUtils.ts
+++ b/server/src/api/controllers/controllerUtils.ts
@@ -8,6 +8,9 @@ type SSLCheckerType = typeof sslChecker;
 type WhoisModule = typeof whoiser;
 
 const DEFAULT_HTTPS_PORT = 443;
+// Ports are user-defined, so a probe can dial something that accepts the
+// connection and never completes the handshake. Bound the wait explicitly.
+const CERTIFICATE_TIMEOUT_MS = 10_000;
 
 export const fetchMonitorCertificate = async (checker: SSLCheckerType, monitor: Monitor): Promise<SSLDetails> => {
 	const monitorUrl = new URL(monitor.url);
@@ -20,7 +23,7 @@ export const fetchMonitorCertificate = async (checker: SSLCheckerType, monitor: 
 	// URL.port is "" for the scheme's default port, so fall back to 443; without
 	// this the certificate of a monitor on a non-standard port was probed on 443.
 	const port = monitorUrl.port === "" ? DEFAULT_HTTPS_PORT : Number(monitorUrl.port);
-	const cert = await checker(hostname, { port });
+	const cert = await checker(hostname, { port, timeout: CERTIFICATE_TIMEOUT_MS });
 	if (cert?.validTo === null || cert?.validTo === undefined) {
 		throw new Error("Certificate not found");
 	}

--- a/server/src/api/controllers/controllerUtils.ts
+++ b/server/src/api/controllers/controllerUtils.ts
@@ -7,10 +7,15 @@ import { parse as parseDomain } from "tldts";
 type SSLCheckerType = typeof sslChecker;
 type WhoisModule = typeof whoiser;
 
+const DEFAULT_HTTPS_PORT = 443;
+
 export const fetchMonitorCertificate = async (checker: SSLCheckerType, monitor: Monitor): Promise<SSLDetails> => {
 	const monitorUrl = new URL(monitor.url);
 	const hostname = monitorUrl.hostname;
-	const cert = await checker(hostname);
+	// URL.port is "" for default ports, so fall back to 443; without this the
+	// certificate of a monitor on a non-standard port was probed on 443.
+	const port = monitorUrl.port === "" ? DEFAULT_HTTPS_PORT : Number(monitorUrl.port);
+	const cert = await checker(hostname, { port });
 	if (cert?.validTo === null || cert?.validTo === undefined) {
 		throw new Error("Certificate not found");
 	}

--- a/server/src/types/ssl-checker.d.ts
+++ b/server/src/types/ssl-checker.d.ts
@@ -12,6 +12,9 @@ declare module "ssl-checker" {
 	export interface SSLOptions {
 		method?: "GET" | "HEAD";
 		port?: number;
+		// Inherited from https.RequestOptions; ssl-checker rejects with "Timed Out"
+		// when the socket exceeds it.
+		timeout?: number;
 		agent?: Agent;
 		rejectUnauthorized?: boolean;
 		validateSubjectAltName?: boolean;

--- a/server/test/unit/utils/monitorCertificate.test.ts
+++ b/server/test/unit/utils/monitorCertificate.test.ts
@@ -3,10 +3,6 @@ import { fetchMonitorCertificate } from "../../../src/api/controllers/controller
 import type { Monitor } from "../../../src/domain/monitors/monitor.type.ts";
 import type { SSLDetails, SSLOptions } from "ssl-checker";
 
-// Regression cover for #3646: the certificate probe parsed the monitor URL but
-// dropped its port, so a monitor on a non-standard port had its certificate
-// checked on 443 and surfaced as "N/A" in the UI.
-
 const VALID_CERT: SSLDetails = {
 	daysRemaining: 30,
 	valid: true,
@@ -52,6 +48,14 @@ describe("fetchMonitorCertificate", () => {
 		await fetchMonitorCertificate(checker, monitorWithUrl("https://example.com:443"));
 
 		expect(calls[0].options?.port).toBe(443);
+	});
+
+	it("bounds the probe with a timeout so a user-defined port cannot hang it", async () => {
+		const { checker, calls } = spyChecker();
+
+		await fetchMonitorCertificate(checker, monitorWithUrl("https://example.com:54321"));
+
+		expect(calls[0].options?.timeout).toBe(10_000);
 	});
 
 	it("never passes NaN as the port", async () => {

--- a/server/test/unit/utils/monitorCertificate.test.ts
+++ b/server/test/unit/utils/monitorCertificate.test.ts
@@ -62,6 +62,25 @@ describe("fetchMonitorCertificate", () => {
 		expect(Number.isNaN(calls[0].options?.port)).toBe(false);
 	});
 
+	it("rejects a plain-HTTP monitor without opening a TLS connection", async () => {
+		const { checker, calls } = spyChecker();
+
+		// Probing a non-TLS port would surface a raw OpenSSL handshake error.
+		await expect(fetchMonitorCertificate(checker, monitorWithUrl("http://example.com:8080"))).rejects.toThrow(
+			"Certificate is only available for HTTPS monitors"
+		);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("rejects a plain-HTTP monitor on the default port", async () => {
+		const { checker, calls } = spyChecker();
+
+		await expect(fetchMonitorCertificate(checker, monitorWithUrl("http://example.com"))).rejects.toThrow(
+			"Certificate is only available for HTTPS monitors"
+		);
+		expect(calls).toHaveLength(0);
+	});
+
 	it("returns the certificate details it received", async () => {
 		const { checker } = spyChecker();
 

--- a/server/test/unit/utils/monitorCertificate.test.ts
+++ b/server/test/unit/utils/monitorCertificate.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "@jest/globals";
+import { fetchMonitorCertificate } from "../../../src/api/controllers/controllerUtils.ts";
+import type { Monitor } from "../../../src/domain/monitors/monitor.type.ts";
+import type { SSLDetails, SSLOptions } from "ssl-checker";
+
+// Regression cover for #3646: the certificate probe parsed the monitor URL but
+// dropped its port, so a monitor on a non-standard port had its certificate
+// checked on 443 and surfaced as "N/A" in the UI.
+
+const VALID_CERT: SSLDetails = {
+	daysRemaining: 30,
+	valid: true,
+	validFrom: "2026-01-01T00:00:00.000Z",
+	validTo: "2026-12-31T00:00:00.000Z",
+	validFor: ["example.com"],
+};
+
+/** Records the arguments the checker was called with. */
+const spyChecker = (cert: SSLDetails = VALID_CERT) => {
+	const calls: Array<{ hostname: string; options?: SSLOptions }> = [];
+	const checker = (async (hostname: string, options?: SSLOptions) => {
+		calls.push({ hostname, options });
+		return cert;
+	}) as unknown as typeof import("ssl-checker").default;
+	return { checker, calls };
+};
+
+const monitorWithUrl = (url: string) => ({ url }) as Monitor;
+
+describe("fetchMonitorCertificate", () => {
+	it("probes the port named in the monitor URL", async () => {
+		const { checker, calls } = spyChecker();
+
+		await fetchMonitorCertificate(checker, monitorWithUrl("https://example.com:54321"));
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].hostname).toBe("example.com");
+		expect(calls[0].options?.port).toBe(54321);
+	});
+
+	it("falls back to 443 when the URL names no port", async () => {
+		const { checker, calls } = spyChecker();
+
+		await fetchMonitorCertificate(checker, monitorWithUrl("https://example.com"));
+
+		expect(calls[0].options?.port).toBe(443);
+	});
+
+	it("passes an explicit 443 through unchanged", async () => {
+		const { checker, calls } = spyChecker();
+
+		await fetchMonitorCertificate(checker, monitorWithUrl("https://example.com:443"));
+
+		expect(calls[0].options?.port).toBe(443);
+	});
+
+	it("never passes NaN as the port", async () => {
+		const { checker, calls } = spyChecker();
+
+		await fetchMonitorCertificate(checker, monitorWithUrl("https://example.com"));
+
+		expect(Number.isNaN(calls[0].options?.port)).toBe(false);
+	});
+
+	it("returns the certificate details it received", async () => {
+		const { checker } = spyChecker();
+
+		const cert = await fetchMonitorCertificate(checker, monitorWithUrl("https://example.com:8443"));
+
+		expect(cert.validTo).toBe(VALID_CERT.validTo);
+	});
+
+	it("throws when the certificate has no expiry", async () => {
+		const { checker } = spyChecker({ ...VALID_CERT, validTo: undefined as unknown as string });
+
+		await expect(fetchMonitorCertificate(checker, monitorWithUrl("https://example.com:8443"))).rejects.toThrow("Certificate not found");
+	});
+});


### PR DESCRIPTION
Fixes #3646.

The certificate expiry box showed "N/A" for any HTTPS monitor on a non-standard port.

## Cause

`fetchMonitorCertificate` parsed the monitor URL but passed only the hostname to `ssl-checker`, which then defaults to port 443. A monitor on `https://host:54321` therefore had the certificate of whatever answered on 443 inspected — or nothing at all, surfacing as "N/A".

## Fix

Pass the port from the monitor URL. `URL.port` is an empty string for the scheme's default port, so that case is mapped to 443 explicitly rather than through `Number()`, which would yield `NaN`. `ssl-checker` already accepts a port via `SSLOptions`, so there is no dependency or signature change.

Behaviour changes **only** for URLs that explicitly name a port:

| URL | before | after |
|---|---|---|
| `https://host` | 443 | 443 |
| `https://host:54321` | 443 | **54321** |
| `http://host` | 443 | 443 |
| `http://host:8080` | 443 | rejected (see below) |

## Second commit: plain-HTTP guard

Review surfaced an adjacent gap. Once the real port is passed, a plain-HTTP monitor on a non-default port (`http://host:8080`) would get a TLS handshake attempted against a port serving no TLS, returning a 500 carrying a raw OpenSSL error (`packet length too long`) instead of the previous silent "N/A".

The endpoint never checked the scheme — it was already wrong for `http://` monitors, just quietly so, since every such lookup went to 443. It now guards on the protocol and fails with a clean 400 before opening a socket.

## Verification

- 8 regression tests: the reported non-standard-port case, the default-port fallback, an explicit `:443`, a NaN guard, and both plain-HTTP cases (each asserting the checker is never invoked).
- Verified by reverting: the 3 port assertions fail without the port fix; both HTTP assertions fail without the scheme guard.
- Edge cases checked — IPv6 literals, embedded credentials, and trailing-dot hosts all derive correctly.
- `npm run build` clean; full server suite **1379 passing across 82 suites**.
