### PR TITLE
feat(client): show uptime percentages with two decimals

### DIFF
--- a/client/src/Utils/FormatUtils.ts
+++ b/client/src/Utils/FormatUtils.ts
@@ -1,25 +1,31 @@
 /**
  * Intl.NumberFormat instance for percentage formatting.
  * Reused across all formatting calls for performance.
+ *
+ * Two decimals rather than one: at a single decimal every value above 99.95%
+ * renders as "100.0%", so a period containing real downtime is reported as
+ * flawless. It also collapses 99.9 / 99.95 / 99.99 — three materially
+ * different SLA commitments — into the same figure.
  */
 const percentageFormatter = new Intl.NumberFormat("en-US", {
 	style: "percent",
-	minimumFractionDigits: 1,
-	maximumFractionDigits: 1,
+	minimumFractionDigits: 2,
+	maximumFractionDigits: 2,
 });
 
 /**
  * Formats a decimal value as a percentage string.
  * @param value - Decimal value (e.g., 0.75 for 75%)
- * @returns Formatted percentage string (e.g., "75.0%")
+ * @returns Formatted percentage string (e.g., "75.00%")
  * @example
- * formatPercentage(0.75)   // "75.0%"
- * formatPercentage(1)      // "100.0%"
- * formatPercentage(0.5432) // "54.3%"
+ * formatPercentage(0.75)   // "75.00%"
+ * formatPercentage(1)      // "100.00%"
+ * formatPercentage(0.5432) // "54.32%"
+ * formatPercentage(0.9999) // "99.99%"
  */
 export const formatPercentage = (value: number): string => {
 	if (typeof value !== "number" || Number.isNaN(value)) {
-		return "0.0%";
+		return "0.00%";
 	}
 	return percentageFormatter.format(value);
 };
@@ -27,11 +33,11 @@ export const formatPercentage = (value: number): string => {
 /**
  * Formats a whole number percentage value as a percentage string.
  * @param value - Whole number percentage (e.g., 75 for 75%)
- * @returns Formatted percentage string (e.g., "75.0%")
+ * @returns Formatted percentage string (e.g., "75.00%")
  * @example
- * formatPercentageFromWhole(75)    // "75.0%"
- * formatPercentageFromWhole(100)   // "100.0%"
- * formatPercentageFromWhole(54.32) // "54.3%"
+ * formatPercentageFromWhole(75)    // "75.00%"
+ * formatPercentageFromWhole(100)   // "100.00%"
+ * formatPercentageFromWhole(54.32) // "54.32%"
  */
 export const formatPercentageFromWhole = (value: number): string => {
 	return formatPercentage(value / 100);


### PR DESCRIPTION
Requested by a user: *"Currently the uptime percentage is xx.x%. I find it better when it's xx.xx%. It gives more trust to clients in my opinion."*

The presentational argument holds, but the stronger reason to do it is that one decimal was **actively misleading**.

## The problem

`Intl.NumberFormat` rounds to the displayed precision, so every value above 99.95% rendered as `100.0%`:

| True uptime | Annual downtime | Was shown | Now shown |
|---|---|---|---|
| 99.99% | ~52 minutes | **100.0%** | 99.99% |
| 99.95% | ~4.4 hours | **100.0%** | 99.95% |
| 99.90% | ~8.7 hours | 99.9% | 99.90% |

A public status page reporting `100.0%` for a month that contained a visible incident is the opposite of reassuring — it reads as a claim of zero downtime that the incident history contradicts.

One decimal also collapsed the range operators care about most: 99.9 / 99.95 / 99.99 are three materially different SLA commitments, and the last two were indistinguishable.

## Scope

Everything routes through the single shared formatter in `client/src/Utils/FormatUtils.ts`, so one change covers both surfaces:

**Web app**
- monitor list uptime column (`UptimeMonitorsTable.tsx`)
- diagnostics gauges (`StatGauges.tsx`)

**Status pages**
- the per-monitor uptime figure (`BaseStatusPage.tsx`)
- bar/heatmap cells (`ChartCells.tsx`)
- hover tooltip (`ThemedChartTooltip.tsx`)

**Deliberately untouched:** infrastructure gauges (CPU/memory/disk) format separately at zero decimals — `43.00%` there would be noise, not precision.

## No server change needed

The aggregation in `check.repository.mongo.ts` divides without rounding and the schemas type it as an unconstrained `number`, so full precision was already reaching the client. This was purely presentational.

Colour banding is unaffected — `getUptimePercentageColor` reads the raw number, not the formatted string. A grep confirmed nothing parses or asserts the old `.0%` output.

## Tests

10 tests pinning the behaviour, including the specific regression: **7 of them fail against the previous one-decimal formatter**, verified by reverting.

## Note on test infrastructure

This restores the client Vitest setup (`vitest.config.ts`, `test` scripts, `vitest` + `jsdom`). PR #3844 introduced it, but the config, scripts and logger tests were all dropped when that branch merged into `develop` — the client was left with no test runner again, so the redaction tests from that PR are no longer running either. Worth a look separately; re-adding those tests is out of scope here.
