### PR TITLE
feat(status-page): show monitor tags in status page selector

### DIFF
--- a/client/src/Pages/StatusPage/Create/index.tsx
+++ b/client/src/Pages/StatusPage/Create/index.tsx
@@ -1,4 +1,9 @@
-import { BasePage, ConfigBox, StepProgress } from "@/Components/design-elements";
+import {
+	BasePage,
+	ColoredLabel,
+	ConfigBox,
+	StepProgress,
+} from "@/Components/design-elements";
 import Stack from "@mui/material/Stack";
 import { logger } from "@/Utils/logger";
 import { LAYOUT } from "@/Utils/Theme/constants";
@@ -16,6 +21,7 @@ import { statusPageStepCount, statusPageStepFieldsFor } from "@/Validation/statu
 import { useGet, usePost, usePut, useDelete } from "@/Hooks/UseApi";
 import type { Monitor } from "@/Types/Monitor";
 import { SelectableMonitorTypes } from "@/Types/Monitor";
+import type { Tag } from "@/Types/Tag";
 import type { MonitorDisplayType, StatusPageResponse } from "@/Types/StatusPage";
 import { getMonitorTypeLabel } from "@/Types/StatusPage";
 import { timezoneOptions } from "@/Utils/timezoneOptions";
@@ -86,6 +92,8 @@ const CreateStatusPage = () => {
 
 	const { data: monitorsResponse } = useGet<Monitor[]>(monitorsUrl);
 	const monitors = useMemo(() => monitorsResponse ?? [], [monitorsResponse]);
+	const { data: tagsResponse } = useGet<Tag[]>("/tags/team");
+	const tags = useMemo(() => tagsResponse ?? [], [tagsResponse]);
 
 	const { post, loading: isSubmittingPost } = usePost();
 	const { put, loading: isSubmittingPut } = usePut();
@@ -308,6 +316,28 @@ const CreateStatusPage = () => {
 									"pages.statusPages.form.monitors.option.monitors.placeholder"
 								)}
 								options={monitors}
+								renderOptionContent={(monitor) => (
+									<Stack
+										direction="row"
+										alignItems="center"
+										gap={theme.spacing(2)}
+										flexWrap="wrap"
+									>
+										<Typography>
+											{`${monitor.name} (${getMonitorTypeLabel(monitor.type, t)})`}
+										</Typography>
+										{monitor.tags.map((tagId) => {
+											const tag = tags.find(({ id }) => id === tagId);
+											return tag ? (
+												<ColoredLabel
+													key={tag.id}
+													text={tag.name}
+													color={tag.color}
+												/>
+											) : null;
+										})}
+									</Stack>
+								)}
 								renderRow={(monitor) => (
 									<Typography flexGrow={1}>
 										{`${monitor.name} (${getMonitorTypeLabel(monitor.type, t)})`}


### PR DESCRIPTION
## Describe your changes

This PR makes monitor selection easier when creating or configuring a status page by displaying each monitor's existing tags directly in the dropdown.

- Fetches team tags through the existing `/tags/team` endpoint.
- Uses the shared `ColoredLabel` component for consistent tag styling.
- Preserves the existing monitor selection, ordering, and removal behavior.
- Keeps monitors without tags unchanged.
- Requires no backend or dependency changes.

## Validation

- Built and tested the application locally with Docker.
- Verified that monitor tags appear correctly in the status page selector.
- Passed ESLint on the changed file.
- Passed the client production build and format checks.
- Ran formatting in both client and server directories.
- Completed an independent code review with no actionable findings.

## Write your issue number after "Fixes "

Fixes #3862

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings. No new user-facing strings were introduced.
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed.
- [x] I didn't use any hardcoded values.
- [x] I made sure font sizes, color choices, and spacing are referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories.
- [x] I took a screenshot or a video and attached it to this PR because it includes a UI change.



<img width="757" height="765" alt="feature-image" src="https://github.com/user-attachments/assets/52ead634-a971-4bb5-8b96-08e1419bcf6a" />


