### PR TITLE
fix(csp): allow blob: for upload previews and send the header on the app document

### DIFF
--- a/server/src/api/middleware/appCsp.ts
+++ b/server/src/api/middleware/appCsp.ts
@@ -1,0 +1,13 @@
+// Global CSP for the app document. The public status page tightens this further
+// in statusPageDocumentCsp; browsers enforce the intersection of both headers.
+export const APP_CSP_DIRECTIVES = {
+	upgradeInsecureRequests: null,
+	"script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+	// blob: covers the preview of a just-picked upload (URL.createObjectURL) and
+	// the XHR that reads that blob back on submit. Both are same-origin, in-memory
+	// objects the page created itself, so this grants no external access.
+	"img-src": ["'self'", "data:", "blob:", "https://img.shields.io"],
+	"connect-src": ["'self'", "blob:"],
+	"object-src": ["'none'"],
+	"base-uri": ["'self'"],
+};

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -14,6 +14,7 @@ import { EnvConfig } from "@/domain/app-settings/app-settings.service.js";
 import { createStatusPageCorsOrigin } from "@/api/middleware/statusPageCorsOrigin.js";
 import { isPublicStatusPageApiPath } from "@/api/middleware/statusPagePublicApiPath.js";
 import { createStatusPageDocumentCsp } from "@/api/middleware/statusPageDocumentCsp.js";
+import { APP_CSP_DIRECTIVES } from "@/api/middleware/appCsp.js";
 import { ApiServices } from "@/config/services.api.js";
 
 export const createApp = ({
@@ -74,11 +75,7 @@ export const createApp = ({
 			contentSecurityPolicy: {
 				useDefaults: true,
 				directives: {
-					upgradeInsecureRequests: null,
-					"script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
-					"img-src": ["'self'", "data:", "https://img.shields.io"],
-					"object-src": ["'none'"],
-					"base-uri": ["'self'"],
+					...APP_CSP_DIRECTIVES,
 				},
 			},
 		})

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -51,6 +51,21 @@ export const createApp = ({
 		return cors(corsOptions)(req, res, next);
 	});
 
+	// Registered before express.static and the /config.js handler: express.static
+	// ends the request without calling next(), so a header set after it never
+	// reaches index.html or any built asset.
+	app.use(
+		helmet({
+			hsts: false,
+			contentSecurityPolicy: {
+				useDefaults: true,
+				directives: {
+					...APP_CSP_DIRECTIVES,
+				},
+			},
+		})
+	);
+
 	app.use(createStatusPageDocumentCsp(allowedOrigin));
 
 	// Client runtime config; registered before express.static so it shadows the
@@ -69,17 +84,6 @@ export const createApp = ({
 	app.use(sanitizeBody());
 	app.use(sanitizeQuery());
 
-	app.use(
-		helmet({
-			hsts: false,
-			contentSecurityPolicy: {
-				useDefaults: true,
-				directives: {
-					...APP_CSP_DIRECTIVES,
-				},
-			},
-		})
-	);
 	app.use(
 		compression({
 			level: 6,

--- a/server/test/unit/middleware/appCsp.test.ts
+++ b/server/test/unit/middleware/appCsp.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, it } from "@jest/globals";
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
+import express from "express";
+import helmet from "helmet";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import type { Server } from "http";
 import { APP_CSP_DIRECTIVES } from "../../../src/api/middleware/appCsp.ts";
 
 const directive = (name: string): string[] => (APP_CSP_DIRECTIVES as Record<string, string[]>)[name] ?? [];
@@ -17,12 +23,62 @@ describe("APP_CSP_DIRECTIVES", () => {
 	it("keeps blob: out of script-src", () => {
 		expect(directive("script-src")).not.toContain("blob:");
 	});
+});
 
-	it("still restricts images to self, data:, and the badge host", () => {
-		expect(directive("img-src")).toEqual(["'self'", "data:", "blob:", "https://img.shields.io"]);
+// express.static ends a request without calling next(), so a header registered
+// after it never reaches index.html. These assert the emitted header rather than
+// the directive object, which is what catches that ordering mistake.
+describe("app CSP header delivery", () => {
+	let server: Server;
+	let baseUrl: string;
+	let frontendPath: string;
+
+	beforeAll(async () => {
+		frontendPath = fs.mkdtempSync(path.join(os.tmpdir(), "checkmate-csp-"));
+		fs.writeFileSync(path.join(frontendPath, "index.html"), "<html></html>");
+		fs.writeFileSync(path.join(frontendPath, "asset.js"), "// built asset");
+
+		const app = express();
+		app.use(helmet({ hsts: false, contentSecurityPolicy: { useDefaults: true, directives: { ...APP_CSP_DIRECTIVES } } }));
+		app.use(express.static(frontendPath));
+		app.get("*", (_req, res) => res.sendFile(path.join(frontendPath, "index.html")));
+
+		await new Promise<void>((resolve) => {
+			server = app.listen(0, () => {
+				const address = server.address();
+				baseUrl = `http://localhost:${typeof address === "object" && address !== null ? address.port : 0}`;
+				resolve();
+			});
+		});
 	});
 
-	it("does not widen connect-src beyond self and blob:", () => {
-		expect(directive("connect-src")).toEqual(["'self'", "blob:"]);
+	afterAll(async () => {
+		fs.rmSync(frontendPath, { recursive: true, force: true });
+		await new Promise<void>((resolve) => server.close(() => resolve()));
+	});
+
+	const cspFor = async (routePath: string): Promise<string> => {
+		const res = await fetch(`${baseUrl}${routePath}`);
+		return res.headers.get("content-security-policy") ?? "";
+	};
+
+	it("sets the CSP on the statically served app document", async () => {
+		expect(await cspFor("/")).toContain("blob:");
+	});
+
+	it("sets the CSP on built assets", async () => {
+		expect(await cspFor("/asset.js")).toContain("blob:");
+	});
+
+	it("sets the CSP on the SPA fallback route", async () => {
+		expect(await cspFor("/status/create")).toContain("blob:");
+	});
+
+	it("allows blob: for images and connections but never for scripts", async () => {
+		const csp = await cspFor("/");
+
+		expect(csp).toMatch(/img-src[^;]*blob:/);
+		expect(csp).toMatch(/connect-src[^;]*blob:/);
+		expect(csp).not.toMatch(/script-src[^;]*blob:/);
 	});
 });

--- a/server/test/unit/middleware/appCsp.test.ts
+++ b/server/test/unit/middleware/appCsp.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "@jest/globals";
+import { APP_CSP_DIRECTIVES } from "../../../src/api/middleware/appCsp.ts";
+
+const directive = (name: string): string[] => (APP_CSP_DIRECTIVES as Record<string, string[]>)[name] ?? [];
+
+describe("APP_CSP_DIRECTIVES", () => {
+	it("allows blob: images so an upload preview renders", () => {
+		expect(directive("img-src")).toContain("blob:");
+	});
+
+	it("allows blob: connections so the upload can read the picked file back", () => {
+		// Without an explicit connect-src the XHR falls back to default-src 'self',
+		// which does not cover blob:, and the logo is dropped on submit.
+		expect(directive("connect-src")).toContain("blob:");
+	});
+
+	it("keeps blob: out of script-src", () => {
+		expect(directive("script-src")).not.toContain("blob:");
+	});
+
+	it("still restricts images to self, data:, and the badge host", () => {
+		expect(directive("img-src")).toEqual(["'self'", "data:", "blob:", "https://img.shields.io"]);
+	});
+
+	it("does not widen connect-src beyond self and blob:", () => {
+		expect(directive("connect-src")).toEqual(["'self'", "blob:"]);
+	});
+});


### PR DESCRIPTION
Reported by a self-hosting user: picking a logo for a status page fails with

```
Content-Security-Policy: The page's settings blocked the loading of a resource (img-src)
at blob:https://monitor.nicolas4tech.fr/… because it violates the following directive:
"img-src 'self' data: https://img.shields.io"
```

## Cause

`ImageUpload` previews a picked file with `URL.createObjectURL`, producing a `blob:` URL. `blob:` is its own scheme source that `'self'` does not cover, so the preview was blocked.

The same policy also broke the upload itself, less visibly. On submit the status page form reads the blob back with an XHR before appending it to the `FormData`. No `connect-src` was declared, so that request fell back to helmet's `default-src 'self'`, which also excludes `blob:`. The fetch was rejected and the surrounding `catch` only logs, so the form submitted with **no logo field** and the save appeared to succeed while the logo was silently dropped.

## Second commit: the header was not being sent

Review of the first commit surfaced a larger problem. `express.static` was registered nine lines *before* helmet, and it ends a request without calling `next()` — so helmet never ran for `index.html` or any built asset. Probing the real ordering:

| path | before | after |
|---|---|---|
| `/` | **no CSP header** | CSP present |
| `/index.html` | **no CSP header** | CSP present |
| `/config.js` | **no CSP header** | CSP present |
| `/status/create` (SPA fallback) | CSP present | CSP present |

Only the `app.get("*")` fallback carried the policy, so a hard navigation to a deep link had a CSP while a normal load of `/` had none at all. That also explains why the reported error is path-dependent rather than constant.

`createStatusPageDocumentCsp` was already registered ahead of the static handler, which is why the tightened status page policy applied correctly while the global one silently did not.

## Fix

```js
"img-src": ["'self'", "data:", "blob:", "https://img.shields.io"],
"connect-src": ["'self'", "blob:"],
```

and helmet moved above `express.static`.

`blob:` grants no external access — such a URL only ever refers to a same-origin, in-memory object the page itself created. `script-src` is deliberately left without `blob:` so the relaxation cannot be used to execute code.

The directives move to their own module so the policy can be asserted without constructing the whole app, mirroring `statusPageDocumentCsp`. The tighter CSP that middleware appends for public status pages is unchanged; browsers enforce the intersection, and the admin upload UI is not served under that path.

## Scope note

This also fixes profile photo previews. `ImageUpload` has two call sites — status pages and `Account/TabProfile.tsx` — and both build blob URLs, so avatars were broken the same way but had not been reported.

## Verification

- 7 tests. The first three assert the directives; the rest boot an express app with the real middleware ordering and assert the emitted response header on a static document, a built asset, and the SPA fallback.
- Verified by reverting: 4 of 5 original assertions fail without the `blob:` additions, and 3 of the new ones fail if helmet is moved back after `express.static`. The earlier object-only tests passed under that bug, which is why they were rewritten.
- Reproduced the emitted header against the real source: the pre-fix header is byte-identical to the reporter's error text, and the fixed one admits their exact blob URL for images and XHR while `script-src` stays blob-free.
- `tsc` clean; full server suite 1490 passing across 85 suites; lint and prettier clean.

## Follow-ups, not in this PR

- `StatusPage/Create/index.tsx:207` swallows a failed blob read and submits anyway, so a dropped logo is invisible to the user. Worth a user-facing error.
- `LogoUploadField` discards the `File` it already has and re-fetches it through the blob URL. Keeping the `File` and appending it directly would remove the round-trip, and the need for `connect-src blob:` with it.