### PR TITLE
Add RepoCloud one-click deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 <p align="center"><strong>An open source uptime and infrastructure monitoring application</strong></p>
 
-[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=checkmate)
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=checkmate) <a href="https://repocloud.io/details/Checkmate/"><img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="32"></a>
 
 <img width="1703" height="1041" alt="image" src="https://github.com/user-attachments/assets/0f4dcf38-9b42-4b84-8633-ff34778df1a8" />
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 <p align="center"><strong>An open source uptime and infrastructure monitoring application</strong></p>
 
-[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=checkmate) <a href="https://repocloud.io/details/Checkmate/"><img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="32"></a>
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=checkmate) <a href="https://repocloud.io/details/Checkmate/"><img src="https://dnk92k33or340.cloudfront.net/rcdeploy-30px.png" alt="Deploy on RepoCloud" height="32"></a>
 
 <img width="1703" height="1041" alt="image" src="https://github.com/user-attachments/assets/0f4dcf38-9b42-4b84-8633-ff34778df1a8" />
 


### PR DESCRIPTION
Added a RepoCloud deploy button next to the existing PikaPods deploy button.

The button links to https://repocloud.io/details/Checkmate/ where users can deploy Checkmate with one click.