### PR TITLE
Email auth not required

### DIFF
--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -197,12 +197,14 @@ export const SettingsPage = () => {
 			systemEmailHost: formValues.systemEmailHost,
 			systemEmailPort: formValues.systemEmailPort,
 			systemEmailAddress: formValues.systemEmailAddress,
-			systemEmailPassword: formValues.systemEmailPassword,
 			systemEmailSecure: formValues.systemEmailSecure,
 			systemEmailPool: formValues.systemEmailPool,
 			systemEmailIgnoreTLS: formValues.systemEmailIgnoreTLS,
 			systemEmailRequireTLS: formValues.systemEmailRequireTLS,
 			systemEmailRejectUnauthorized: formValues.systemEmailRejectUnauthorized,
+			...(formValues.systemEmailPassword && {
+				systemEmailPassword: formValues.systemEmailPassword,
+			}),
 			...(formValues.systemEmailUser && { systemEmailUser: formValues.systemEmailUser }),
 			...(formValues.systemEmailDisplayName && {
 				systemEmailDisplayName: formValues.systemEmailDisplayName,

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -186,8 +186,7 @@ export const SettingsPage = () => {
 		if (
 			!formValues.systemEmailHost ||
 			!formValues.systemEmailPort ||
-			!formValues.systemEmailAddress ||
-			!formValues.systemEmailPassword
+			!formValues.systemEmailAddress
 		) {
 			alert("Please fill in all required email fields before testing.");
 			return;
@@ -749,8 +748,7 @@ export const SettingsPage = () => {
 										disabled={
 											!form.watch("systemEmailHost") ||
 											!form.watch("systemEmailPort") ||
-											!form.watch("systemEmailAddress") ||
-											!form.watch("systemEmailPassword")
+											!form.watch("systemEmailAddress")
 										}
 									>
 										{t("common.buttons.sendTestEmail")}

--- a/server/src/service/emailService.ts
+++ b/server/src/service/emailService.ts
@@ -127,10 +127,12 @@ export class EmailService implements IEmailService {
 			host: systemEmailHost,
 			port: Number(systemEmailPort),
 			secure: systemEmailSecure,
-			auth: {
-				user: systemEmailUser || systemEmailAddress,
-				pass: systemEmailPassword,
-			},
+			...(systemEmailPassword && {
+				auth: {
+					user: systemEmailUser || systemEmailAddress,
+					pass: systemEmailPassword,
+				},
+			}),
 			name: systemEmailConnectionHost || "localhost",
 			connectionTimeout: 5000,
 			pool: systemEmailPool,

--- a/server/test/unit/services/emailService.test.ts
+++ b/server/test/unit/services/emailService.test.ts
@@ -315,6 +315,33 @@ describe("EmailService", () => {
 			);
 		});
 
+		it("omits auth from the transport config when no password is configured", async () => {
+			const transporter = createMockTransporter();
+			const nodemailer = createMockNodemailer(transporter);
+			const { service } = createService({ nodemailer });
+			const config = makeTransportConfig({ systemEmailPassword: undefined });
+
+			await service.sendEmail("to@example.com", "Subject", "<p>body</p>", config);
+
+			const transportArg = (nodemailer.createTransport as jest.Mock).mock.calls[0]?.[0] as Record<string, unknown>;
+			expect(transportArg).not.toHaveProperty("auth");
+		});
+
+		it("includes auth in the transport config when a password is configured", async () => {
+			const transporter = createMockTransporter();
+			const nodemailer = createMockNodemailer(transporter);
+			const { service } = createService({ nodemailer });
+			const config = makeTransportConfig({ systemEmailPassword: "password123" });
+
+			await service.sendEmail("to@example.com", "Subject", "<p>body</p>", config);
+
+			expect(nodemailer.createTransport).toHaveBeenCalledWith(
+				expect.objectContaining({
+					auth: { user: "user@example.com", pass: "password123" },
+				})
+			);
+		});
+
 		it("uses 'localhost' as name when systemEmailConnectionHost is falsy", async () => {
 			const transporter = createMockTransporter();
 			const nodemailer = createMockNodemailer(transporter);


### PR DESCRIPTION
## Describe your changes

The email settings form required an SMTP password before a test email could be sent or the "Send Test Email" button enabled, even though the backend already treats `systemEmailPassword` as optional. Providers like Google Workspace that use IP allowlisting instead of SMTP auth have no password to enter, so the form blocked a valid configuration.

- Removed the password requirement from the pre-flight check in `handleSendTestEmail` and from the "Send Test Email" button's `disabled` condition — only host, port, and address remain required.
- Fixed a regression this introduced: when a password is already saved server-side, the (hidden) password field defaults to `""`, so the test-email request would silently send an empty password and could break a working authenticated config. `systemEmailPassword` is now only included in the payload when the user actually enters one, matching the existing pattern used for the other optional email fields.

## Write your issue number after "Fixes "

Fixes #3866

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): n/a — no new UI strings added
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [ ] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change.****