### PR TITLE
fix(infrastructure): clamp gauge arc and fix disk key fallback

### DIFF
--- a/client/src/Components/design-elements/Gauge.tsx
+++ b/client/src/Components/design-elements/Gauge.tsx
@@ -39,9 +39,12 @@ export const Gauge = forwardRef<HTMLDivElement, GaugeProps>(function Gauge(
 		() => ({
 			circumference: 2 * Math.PI * radius,
 			totalSize: radius * 2 + strokeWidth * 2,
-			strokeLength: (progress / 100) * (2 * Math.PI * radius),
+			// Uses the clamped value, like the label and the fill color: an
+			// out-of-range reading would otherwise sweep the arc past a full circle
+			// while the label read 100%.
+			strokeLength: (progressWithinRange / 100) * (2 * Math.PI * radius),
 		}),
-		[radius, strokeWidth, progress]
+		[radius, strokeWidth, progressWithinRange]
 	);
 
 	const [offset, setOffset] = useState(circumference);
@@ -52,7 +55,7 @@ export const Gauge = forwardRef<HTMLDivElement, GaugeProps>(function Gauge(
 		}, 100);
 
 		return () => clearTimeout(timer);
-	}, [progress, circumference, strokeLength]);
+	}, [circumference, strokeLength]);
 
 	const fillColor = getInfraGaugeColor(progressWithinRange, theme);
 

--- a/client/src/Components/design-elements/Gauge.tsx
+++ b/client/src/Components/design-elements/Gauge.tsx
@@ -39,9 +39,6 @@ export const Gauge = forwardRef<HTMLDivElement, GaugeProps>(function Gauge(
 		() => ({
 			circumference: 2 * Math.PI * radius,
 			totalSize: radius * 2 + strokeWidth * 2,
-			// Uses the clamped value, like the label and the fill color: an
-			// out-of-range reading would otherwise sweep the arc past a full circle
-			// while the label read 100%.
 			strokeLength: (progressWithinRange / 100) * (2 * Math.PI * radius),
 		}),
 		[radius, strokeWidth, progressWithinRange]

--- a/client/src/Pages/Infrastructure/Details/Components/Gauges.tsx
+++ b/client/src/Pages/Infrastructure/Details/Components/Gauges.tsx
@@ -48,7 +48,7 @@ export const InfraDetailsGauges = ({
 			{snapshot?.disk?.map((disk, idx) => {
 				return (
 					<DetailGauge
-						key={disk?.device || 0 + idx}
+						key={disk?.device || `disk-${idx}`}
 						// title={`Disk ${idx} usage`}
 						title={t("pages.infrastructure.gauges.disk.title", { idx })}
 						maxWidth={260}


### PR DESCRIPTION
Two small pre-existing bugs in the infrastructure gauges, spotted while reviewing #3895. Independent of that PR.

## Arc overdraw

`Gauge` computed `strokeLength` from the raw `progress` prop, while the label and the fill colour both used `progressWithinRange` — the value clamped to 0–100.

A reading above 100% therefore swept the arc past a full circle (the offset, `circumference - strokeLength`, went negative) while the label still read "100.0%". A negative reading drew the arc backwards for the same reason.

`strokeLength` now uses the clamped value, so out-of-range input stops at exactly one turn and matches what the label and colour already showed:

| progress | label | arc before | arc after |
|---|---|---|---|
| 45.5 | 45.5% | 0.455 turns | 0.455 turns |
| 100 | 100.0% | 1.000 turns | 1.000 turns |
| 120 | 100.0% | **1.200 turns** | 1.000 turns |
| 250 | 100.0% | **2.500 turns** | 1.000 turns |
| −5 | 0.0% | **−0.050 turns** | 0.000 turns |

Values in range are unaffected.

The effect that animates the arc also listed `progress` in its dependency array while only reading `strokeLength`, so it re-ran the 100ms animation on changes that could not alter the arc (105% → 110%, say). Now that `strokeLength` is derived from the clamped value, that stale dependency is dropped.

## Disk key fallback

```js
key={disk?.device || 0 + idx}
```

parses as `disk?.device || (0 + idx)` — `+` binds tighter than `||` — so the fallback was just `idx` and the leading `0` did nothing. It happened to produce unique keys, but by accident rather than intent, and a disk whose `device` is the empty string collided with index 0.

Replaced with a `disk-${idx}` template so the intent is explicit.

## Verification

`tsc -b`, ESLint, Prettier and `npm run build` all clean. Arc behaviour checked across the range, including the out-of-range and negative cases in the table above.

https://claude.ai/code/session_01AbYLvwpEaZFXktHVcqrFRd