### PR TITLE
fix(infrastructure): show the container-namespace notice when it applies

### DIFF
--- a/client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx
+++ b/client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx
@@ -84,18 +84,6 @@ const interfaceIsIdle = (checks: HardwareCheckStats[], name: string): boolean =>
 		);
 	});
 
-// Capture running inside a container sees only that container's network
-// namespace. It reports the loopback and bridge names above, and usually also
-// the container's own veth under a host-looking name (eth0, ens3, ...) - so
-// requiring EVERY interface to be container-only missed the common case, and
-// those users saw plausible-but-meaningless traffic with no explanation.
-//
-// Interface names alone cannot separate the two cases: a host-level agent on a
-// machine running Docker legitimately reports docker0 too. What distinguishes
-// them is that in the container case nothing carries real traffic. So the
-// notice fires when a container-only interface is present AND every interface
-// is idle, which leaves a genuine host reporting docker0 alongside a busy NIC
-// untouched.
 const onlyContainerVisibleInterfaces = (checks: HardwareCheckStats[]): boolean => {
 	const named = new Set<string>();
 	checks.forEach((c) => c.net?.forEach((iface) => named.add(iface.name)));
@@ -104,6 +92,9 @@ const onlyContainerVisibleInterfaces = (checks: HardwareCheckStats[]): boolean =
 	}
 
 	const names = [...named];
+	if (names.every((name) => CONTAINER_ONLY_IFACE_NAMES.has(name))) {
+		return true;
+	}
 	if (!names.some((name) => CONTAINER_ONLY_IFACE_NAMES.has(name))) {
 		return false;
 	}

--- a/client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx
+++ b/client/src/Pages/Infrastructure/Details/Components/ChartsNetwork.tsx
@@ -63,19 +63,51 @@ const getChartConfigs = (
 	return configs;
 };
 
-// Loopback / bridge names Capture sees when it can only observe the container's
-// own network namespace. When ALL reported interfaces match this set we assume
-// the "no real interfaces visible" case and surface the notice.
+// Loopback / bridge names Capture reports when it can only observe the
+// container's own network namespace.
 const CONTAINER_ONLY_IFACE_NAMES = new Set(["lo", "lo0", "docker0"]);
 
+// Below this, an interface is carrying no traffic worth charting. Real host
+// NICs sit orders of magnitude above it; a container's veth sits at or near
+// zero.
+const IDLE_INTERFACE_BYTES_PER_SECOND = 1024;
+
+const interfaceIsIdle = (checks: HardwareCheckStats[], name: string): boolean =>
+	checks.every((check) => {
+		const iface = check.net?.find((candidate) => candidate.name === name);
+		if (!iface) {
+			return true;
+		}
+		return (
+			(iface.bytesSentPerSecond || 0) < IDLE_INTERFACE_BYTES_PER_SECOND &&
+			(iface.deltaBytesRecv || 0) < IDLE_INTERFACE_BYTES_PER_SECOND
+		);
+	});
+
+// Capture running inside a container sees only that container's network
+// namespace. It reports the loopback and bridge names above, and usually also
+// the container's own veth under a host-looking name (eth0, ens3, ...) - so
+// requiring EVERY interface to be container-only missed the common case, and
+// those users saw plausible-but-meaningless traffic with no explanation.
+//
+// Interface names alone cannot separate the two cases: a host-level agent on a
+// machine running Docker legitimately reports docker0 too. What distinguishes
+// them is that in the container case nothing carries real traffic. So the
+// notice fires when a container-only interface is present AND every interface
+// is idle, which leaves a genuine host reporting docker0 alongside a busy NIC
+// untouched.
 const onlyContainerVisibleInterfaces = (checks: HardwareCheckStats[]): boolean => {
 	const named = new Set<string>();
 	checks.forEach((c) => c.net?.forEach((iface) => named.add(iface.name)));
-	if (named.size === 0) return false;
-	for (const name of named) {
-		if (!CONTAINER_ONLY_IFACE_NAMES.has(name)) return false;
+	if (named.size === 0) {
+		return false;
 	}
-	return true;
+
+	const names = [...named];
+	if (!names.some((name) => CONTAINER_ONLY_IFACE_NAMES.has(name))) {
+		return false;
+	}
+	return names.every((name) => interfaceIsIdle(checks, name));
 };
 
 export const InfraNetworkCharts = ({

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -926,7 +926,7 @@
 					"memory": "Memory usage",
 					"netBytesRecv": "{{name}} - Bytes Received",
 					"netBytesSent": "{{name}} - Bytes Sent",
-					"loopbackOnlyNotice": "Capture is only reporting loopback or container-bridge interfaces (lo, lo0, docker0). This is normal when Capture runs inside a container that can only see its own network namespace — run Capture directly on the host to see real network activity.",
+					"loopbackOnlyNotice": "Capture is only seeing container network interfaces, and none of them are carrying real traffic. This is normal when Capture runs inside a container that can only observe its own network namespace — interfaces with host-like names (eth0, ens3) are the container's virtual interfaces, not the host's. Run Capture directly on the host to see real network activity.",
 					"temp": "CPU temperature"
 				}
 			},


### PR DESCRIPTION
The network tab has a notice for when Capture can only see a container's own network namespace. It never fires in the most common case.

## The problem

`onlyContainerVisibleInterfaces` required **every** reported interface to be named `lo`, `lo0` or `docker0`. But a containerised Capture usually also reports the container's veth under a host-looking name — `eth0`, `ens3` — so that test fails and the notice stays hidden.

The result is the worst version of this: the charts render, the interface names look plausible, and the traffic values are meaningless, with nothing on screen explaining why.

## Why not just widen it

"Any container-only name present" would be wrong in the other direction — a host-level Capture on a machine running Docker legitimately reports `docker0` next to its real NIC, and would then get warned incorrectly.

Interface names alone cannot separate the two cases. What does is traffic: in the container case nothing carries any, while a genuine host has a busy NIC.

## The fix

The notice now fires when a container-only interface is present **and** every interface is idle, using a 1 KB/s threshold — real NICs sit orders of magnitude above it, a container's veth sits at or near zero.

Checked against six scenarios:

| Scenario | Before | After |
|---|---|---|
| Containerised Capture — `lo` + `ens3` + `docker0`, all ~0 | no notice | **notice** |
| Host Capture, busy NIC + idle `docker0` | no notice | no notice |
| Host Capture, no Docker | no notice | no notice |
| Fully namespaced container — only `lo` + `docker0` | notice | notice |
| Quiet host, idle NIC, no container-only names | no notice | no notice |
| No interfaces reported | no notice | no notice |

Only the first row changes.

## Notice text

Updated to match. It previously described only the all-container-names case and did not explain that a host-looking interface can be the container's own — which is the specific thing that confuses people here.

## Verification

`tsc -b`, ESLint, Prettier and `npm run build` all clean.

https://claude.ai/code/session_01AbYLvwpEaZFXktHVcqrFRd