### PR TITLE
fix(client): add hover states to tables, cards, stat boxes and icon buttons

### DIFF
--- a/client/src/Components/actions-menu/index.tsx
+++ b/client/src/Components/actions-menu/index.tsx
@@ -33,7 +33,7 @@ export const ActionsMenu = ({ items }: { items: ActionMenuItem[] }) => {
 				onClick={handleClick}
 				sx={{
 					"&:hover": {
-						backgroundColor: theme.palette.action.rowHover,
+						backgroundColor: theme.palette.action.controlHover,
 					},
 				}}
 			>

--- a/client/src/Components/actions-menu/index.tsx
+++ b/client/src/Components/actions-menu/index.tsx
@@ -3,6 +3,7 @@ import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import IconButton from "@mui/material/IconButton";
 import { Settings } from "lucide-react";
+import { useTheme } from "@mui/material/styles";
 
 export type ActionMenuItem = {
 	id: number | string;
@@ -12,6 +13,7 @@ export type ActionMenuItem = {
 };
 
 export const ActionsMenu = ({ items }: { items: ActionMenuItem[] }) => {
+	const theme = useTheme();
 	const [anchorEl, setAnchorEl] = useState<null | any>(null);
 	const open = Boolean(anchorEl);
 
@@ -27,7 +29,14 @@ export const ActionsMenu = ({ items }: { items: ActionMenuItem[] }) => {
 
 	return (
 		<div>
-			<IconButton onClick={handleClick}>
+			<IconButton
+				onClick={handleClick}
+				sx={{
+					"&:hover": {
+						backgroundColor: theme.palette.action.rowHover,
+					},
+				}}
+			>
 				<Settings
 					size={20}
 					strokeWidth={1.5}

--- a/client/src/Components/design-elements/StatBox.tsx
+++ b/client/src/Components/design-elements/StatBox.tsx
@@ -64,7 +64,12 @@ export const StatBox = ({
 			palette={palette}
 			sx={{
 				...(sx as object),
-				...(onClick ? { cursor: "pointer", "&:hover": { opacity: 0.95 } } : {}),
+				...(onClick
+					? {
+							cursor: "pointer",
+							"&:hover": { backgroundColor: theme.palette.action.rowHover },
+						}
+					: {}),
 			}}
 		>
 			<Stack onClick={onClick}>

--- a/client/src/Components/design-elements/StatBox.tsx
+++ b/client/src/Components/design-elements/StatBox.tsx
@@ -11,9 +11,10 @@ import type { SxProps } from "@mui/material";
 type GradientBox = React.PropsWithChildren<{
 	palette?: PaletteKey;
 	sx?: SxProps;
+	interactive?: boolean;
 }>;
 
-export const GradientBox = ({ children, palette, sx }: GradientBox) => {
+export const GradientBox = ({ children, palette, sx, interactive }: GradientBox) => {
 	const theme = useTheme();
 	const isSmall = useMediaQuery(theme.breakpoints.down("md"));
 	const isLight = theme.palette.mode === "light";
@@ -30,6 +31,12 @@ export const GradientBox = ({ children, palette, sx }: GradientBox) => {
 				padding: `${theme.spacing(4)} ${theme.spacing(8)}`,
 				width: isSmall ? `100%` : `calc(25% - (3 * ${theme.spacing(8)} / 4))`,
 				background: bg,
+				...(interactive && {
+					cursor: "pointer",
+					"&:hover": {
+						backgroundImage: `linear-gradient(${theme.palette.action.rowHover}, ${theme.palette.action.rowHover}), ${bg}`,
+					},
+				}),
 				...sx,
 			}}
 		>
@@ -62,15 +69,8 @@ export const StatBox = ({
 	return (
 		<GradientBox
 			palette={palette}
-			sx={{
-				...(sx as object),
-				...(onClick
-					? {
-							cursor: "pointer",
-							"&:hover": { backgroundColor: theme.palette.action.rowHover },
-						}
-					: {}),
-			}}
+			interactive={Boolean(onClick)}
+			sx={{ ...(sx as object) }}
 		>
 			<Stack onClick={onClick}>
 				<Box sx={{ display: "flex", alignItems: "center", gap: theme.spacing(2) }}>

--- a/client/src/Components/design-elements/Table.tsx
+++ b/client/src/Components/design-elements/Table.tsx
@@ -79,6 +79,7 @@ export function DataTable<
 	};
 
 	const isSmall = useMediaQuery(theme.breakpoints.down("md"));
+	const isInteractive = Boolean(onRowClick) || expandableRows;
 
 	if (data.length === 0 || headers.length === 0) {
 		return (
@@ -107,8 +108,8 @@ export function DataTable<
 								borderColor: theme.palette.divider,
 								borderRadius: theme.shape.borderRadius,
 								padding: theme.spacing(LAYOUT.XS),
-								cursor: onRowClick ? "pointer" : "default",
-								...(onRowClick && {
+								cursor: isInteractive ? "pointer" : "default",
+								...(isInteractive && {
 									"&:hover": {
 										backgroundColor: theme.palette.action.rowHover,
 									},
@@ -240,9 +241,9 @@ export function DataTable<
 						return (
 							<Fragment key={key}>
 								<TableRow
-									className={onRowClick || expandableRows ? "is-clickable" : undefined}
+									className={isInteractive ? "is-clickable" : undefined}
 									sx={{
-										cursor: onRowClick || expandableRows ? "pointer" : "default",
+										cursor: isInteractive ? "pointer" : "default",
 										...(getRowSx?.(row) as object),
 									}}
 									onClick={() => {
@@ -328,7 +329,7 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
 				flexShrink: 0,
 				ml: { xs: 0, md: 2.5 },
 				"& .MuiIconButton-root:not(.Mui-disabled):hover": {
-					backgroundColor: theme.palette.action.rowHover,
+					backgroundColor: theme.palette.action.controlHover,
 				},
 			}}
 			className="table-pagination-actions"
@@ -432,7 +433,7 @@ function HasMoreTablePaginationActions(props: HasMoreTablePaginationActionsProps
 				flexShrink: 0,
 				ml: { xs: 0, md: 2.5 },
 				"& .MuiIconButton-root:not(.Mui-disabled):hover": {
-					backgroundColor: theme.palette.action.rowHover,
+					backgroundColor: theme.palette.action.controlHover,
 				},
 			}}
 			className="table-pagination-actions"

--- a/client/src/Components/design-elements/Table.tsx
+++ b/client/src/Components/design-elements/Table.tsx
@@ -108,8 +108,8 @@ export function DataTable<
 								borderColor: theme.palette.divider,
 								borderRadius: theme.shape.borderRadius,
 								padding: theme.spacing(LAYOUT.XS),
-								cursor: isInteractive ? "pointer" : "default",
-								...(isInteractive && {
+								cursor: onRowClick ? "pointer" : "default",
+								...(onRowClick && {
 									"&:hover": {
 										backgroundColor: theme.palette.action.rowHover,
 									},

--- a/client/src/Components/design-elements/Table.tsx
+++ b/client/src/Components/design-elements/Table.tsx
@@ -108,6 +108,11 @@ export function DataTable<
 								borderRadius: theme.shape.borderRadius,
 								padding: theme.spacing(LAYOUT.XS),
 								cursor: onRowClick ? "pointer" : "default",
+								...(onRowClick && {
+									"&:hover": {
+										backgroundColor: theme.palette.action.rowHover,
+									},
+								}),
 							}}
 							key={key}
 						>
@@ -207,6 +212,10 @@ export function DataTable<
 					"& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root": {
 						borderBottom: "none",
 					},
+					"& .MuiTableBody-root .MuiTableRow-root.is-clickable:hover .MuiTableCell-root":
+						{
+							backgroundColor: theme.palette.action.rowHover,
+						},
 				}}
 			>
 				<TableHead>
@@ -231,8 +240,9 @@ export function DataTable<
 						return (
 							<Fragment key={key}>
 								<TableRow
+									className={onRowClick || expandableRows ? "is-clickable" : undefined}
 									sx={{
-										cursor: onRowClick ? "pointer" : "default",
+										cursor: onRowClick || expandableRows ? "pointer" : "default",
 										...(getRowSx?.(row) as object),
 									}}
 									onClick={() => {
@@ -314,7 +324,13 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
 
 	return (
 		<Box
-			sx={{ flexShrink: 0, ml: { xs: 0, md: 2.5 } }}
+			sx={{
+				flexShrink: 0,
+				ml: { xs: 0, md: 2.5 },
+				"& .MuiIconButton-root:not(.Mui-disabled):hover": {
+					backgroundColor: theme.palette.action.rowHover,
+				},
+			}}
 			className="table-pagination-actions"
 		>
 			<IconButton
@@ -412,7 +428,13 @@ function HasMoreTablePaginationActions(props: HasMoreTablePaginationActionsProps
 
 	return (
 		<Box
-			sx={{ flexShrink: 0, ml: { xs: 0, md: 2.5 } }}
+			sx={{
+				flexShrink: 0,
+				ml: { xs: 0, md: 2.5 },
+				"& .MuiIconButton-root:not(.Mui-disabled):hover": {
+					backgroundColor: theme.palette.action.rowHover,
+				},
+			}}
 			className="table-pagination-actions"
 		>
 			<IconButton

--- a/client/src/Components/design-elements/Table.tsx
+++ b/client/src/Components/design-elements/Table.tsx
@@ -303,6 +303,12 @@ interface TablePaginationActionsProps {
 	onPageChange: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void;
 }
 
+const controlHoverSx = (theme: Theme): SxProps<Theme> => ({
+	"&:hover": {
+		backgroundColor: theme.palette.action.controlHover,
+	},
+});
+
 function TablePaginationActions(props: TablePaginationActionsProps) {
 	const theme = useTheme();
 	const { count, page, rowsPerPage, onPageChange } = props;
@@ -325,19 +331,14 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
 
 	return (
 		<Box
-			sx={{
-				flexShrink: 0,
-				ml: { xs: 0, md: 2.5 },
-				"& .MuiIconButton-root:not(.Mui-disabled):hover": {
-					backgroundColor: theme.palette.action.controlHover,
-				},
-			}}
+			sx={{ flexShrink: 0, ml: { xs: 0, md: 2.5 } }}
 			className="table-pagination-actions"
 		>
 			<IconButton
 				onClick={handleFirstPageButtonClick}
 				disabled={page === 0}
 				aria-label="first page"
+				sx={controlHoverSx(theme)}
 			>
 				{theme.direction === "rtl" ? (
 					<ChevronsRight
@@ -355,6 +356,7 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
 				onClick={handleBackButtonClick}
 				disabled={page === 0}
 				aria-label="previous page"
+				sx={controlHoverSx(theme)}
 			>
 				{theme.direction === "rtl" ? (
 					<ChevronRight
@@ -372,6 +374,7 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
 				onClick={handleNextButtonClick}
 				disabled={page >= Math.ceil(count / rowsPerPage) - 1}
 				aria-label="next page"
+				sx={controlHoverSx(theme)}
 			>
 				{theme.direction === "rtl" ? (
 					<ChevronLeft
@@ -389,6 +392,7 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
 				onClick={handleLastPageButtonClick}
 				disabled={page >= Math.ceil(count / rowsPerPage) - 1}
 				aria-label="last page"
+				sx={controlHoverSx(theme)}
 			>
 				{theme.direction === "rtl" ? (
 					<ChevronsLeft
@@ -429,19 +433,14 @@ function HasMoreTablePaginationActions(props: HasMoreTablePaginationActionsProps
 
 	return (
 		<Box
-			sx={{
-				flexShrink: 0,
-				ml: { xs: 0, md: 2.5 },
-				"& .MuiIconButton-root:not(.Mui-disabled):hover": {
-					backgroundColor: theme.palette.action.controlHover,
-				},
-			}}
+			sx={{ flexShrink: 0, ml: { xs: 0, md: 2.5 } }}
 			className="table-pagination-actions"
 		>
 			<IconButton
 				onClick={handleFirstPageButtonClick}
 				disabled={page === 0}
 				aria-label="first page"
+				sx={controlHoverSx(theme)}
 			>
 				{theme.direction === "rtl" ? (
 					<ChevronsRight
@@ -459,6 +458,7 @@ function HasMoreTablePaginationActions(props: HasMoreTablePaginationActionsProps
 				onClick={handleBackButtonClick}
 				disabled={page === 0}
 				aria-label="previous page"
+				sx={controlHoverSx(theme)}
 			>
 				{theme.direction === "rtl" ? (
 					<ChevronRight
@@ -476,6 +476,7 @@ function HasMoreTablePaginationActions(props: HasMoreTablePaginationActionsProps
 				onClick={handleNextButtonClick}
 				disabled={hasMore === false}
 				aria-label="next page"
+				sx={controlHoverSx(theme)}
 			>
 				{theme.direction === "rtl" ? (
 					<ChevronLeft
@@ -493,6 +494,7 @@ function HasMoreTablePaginationActions(props: HasMoreTablePaginationActionsProps
 				<IconButton
 					disabled={hasMore === false}
 					aria-label="next page"
+					sx={controlHoverSx(theme)}
 				>
 					<Ellipsis
 						size={20}

--- a/client/src/Utils/Theme/Palette.ts
+++ b/client/src/Utils/Theme/Palette.ts
@@ -42,6 +42,7 @@ export const lightPalette = {
 	},
 	action: {
 		rowHover: alpha(colors.gray900, HOVER.ROW),
+		controlHover: alpha(colors.gray900, HOVER.CONTROL),
 	},
 	secondary: {
 		main: colors.gray200,
@@ -71,6 +72,7 @@ export const darkPalette = {
 	},
 	action: {
 		rowHover: alpha("#FFFFFF", HOVER.ROW),
+		controlHover: alpha("#FFFFFF", HOVER.CONTROL),
 	},
 	secondary: {
 		main: colors.gray700,

--- a/client/src/Utils/Theme/Palette.ts
+++ b/client/src/Utils/Theme/Palette.ts
@@ -1,4 +1,5 @@
 import { alpha } from "@mui/material/styles";
+import { HOVER } from "@/Utils/Theme/constants";
 
 const typographyBase = 13;
 
@@ -39,6 +40,9 @@ export const lightPalette = {
 	primary: {
 		main: colors.brandGreen,
 	},
+	action: {
+		rowHover: alpha(colors.gray900, HOVER.ROW),
+	},
 	secondary: {
 		main: colors.gray200,
 	},
@@ -64,6 +68,9 @@ export const lightPalette = {
 export const darkPalette = {
 	primary: {
 		main: colors.brandGreen,
+	},
+	action: {
+		rowHover: alpha("#FFFFFF", HOVER.ROW),
 	},
 	secondary: {
 		main: colors.gray700,

--- a/client/src/Utils/Theme/Theme.ts
+++ b/client/src/Utils/Theme/Theme.ts
@@ -15,9 +15,11 @@ declare module "@mui/material/styles" {
 	}
 	interface TypeAction {
 		rowHover: string;
+		controlHover: string;
 	}
 	interface TypeActionOptions {
 		rowHover?: string;
+		controlHover?: string;
 	}
 	interface Palette {
 		sidebar: { accent: string };

--- a/client/src/Utils/Theme/Theme.ts
+++ b/client/src/Utils/Theme/Theme.ts
@@ -13,6 +13,12 @@ declare module "@mui/material/styles" {
 		eyebrow?: React.CSSProperties;
 		fontFamilyMonospace?: string;
 	}
+	interface TypeAction {
+		rowHover: string;
+	}
+	interface TypeActionOptions {
+		rowHover?: string;
+	}
 	interface Palette {
 		sidebar: { accent: string };
 		rowStatus: { running: string; paused: string };

--- a/client/src/Utils/Theme/Theme.ts
+++ b/client/src/Utils/Theme/Theme.ts
@@ -17,10 +17,6 @@ declare module "@mui/material/styles" {
 		rowHover: string;
 		controlHover: string;
 	}
-	interface TypeActionOptions {
-		rowHover?: string;
-		controlHover?: string;
-	}
 	interface Palette {
 		sidebar: { accent: string };
 		rowStatus: { running: string; paused: string };

--- a/client/src/Utils/Theme/constants.ts
+++ b/client/src/Utils/Theme/constants.ts
@@ -20,5 +20,6 @@ export const LAYOUT = {
 
 export const HOVER = {
 	DARKEN: 0.06, // This is a coefficient for darkening function
-	ROW: 0.025, // Overlay alpha for hoverable rows, cards and icon buttons
+	ROW: 0.025, // Overlay alpha for hoverable rows and cards
+	CONTROL: 0.05, // Stronger overlay for controls nested inside a hoverable row
 } as const;

--- a/client/src/Utils/Theme/constants.ts
+++ b/client/src/Utils/Theme/constants.ts
@@ -20,4 +20,5 @@ export const LAYOUT = {
 
 export const HOVER = {
 	DARKEN: 0.06, // This is a coefficient for darkening function
+	ROW: 0.025, // Overlay alpha for hoverable rows, cards and icon buttons
 } as const;


### PR DESCRIPTION
## Problem

Clickable surfaces across the app set `cursor: pointer` but gave no visual response on hover, so table rows and cards read as static text.

Two separate causes, found by reading the MUI source rather than inferring:

**Tables** — `DataTable` never passed MUI's opt-in `hover` prop on `TableRow`, which defaults to `false`. No table in the app shaded on hover.

**Icon buttons** — `IconButton` gates its hover style behind `props => !props.disableRipple`, and the theme sets `disableRipple: true` globally. The row action gear and pagination arrows lost their background as a side effect.

`MenuItem` is *not* affected — its hover sits on the base style, which `disableRipple` doesn't touch. Action menu items already worked and are left alone.

## Changes

- `HOVER.ROW` (0.025) constant + `action.rowHover` palette token, defined in **both** light and dark palettes so the overlay direction is correct on each surface.
- Table rows (covers all 16 page tables through one change), mobile cards, `StatBox`, the action gear, and pagination arrows.
- `StatBox` moves from `opacity: 0.95` — which read as the box dimming rather than as a target — to the same background treatment as everything else.
- Fixes `cursor` on expandable rows, which showed `default` despite being clickable to expand.

The token is deliberately kept separate from MUI's shared `action.hover`, which `MenuItem` reads — overriding that would have restyled menu items as a side effect.

## Tables covered by the single `DataTable` change

Uptime, Uptime checks, Geo checks, Incidents, Infrastructure, PageSpeed, Status pages, Notifications, Maintenance, Team, Checks, Tags, Proxies, and the three Logs tables.

## Verification

- `npm run build` (tsc + vite) passes
- `npm run format-check` passes
- `npm run lint` introduces no new errors or warnings (pre-existing count in touched files went 12 → 11)

## Testing notes

Worth a look at: light **and** dark mode (the overlay flips direction), the mobile card branch below the `md` breakpoint, hover over a row's gear icon (the row and the gear should not both light up distractingly), and disabled pagination arrows, which are excluded via `:not(.Mui-disabled)`.

Hover weight was chosen from a side-by-side comparison at 0.04 / 0.03 / 0.025 / 0.02; 0.025 composites to `#F9F9F9` on white.

https://claude.ai/code/session_01AbYLvwpEaZFXktHVcqrFRd