### PR TITLE
feat(client): group sidebar navigation into four labelled sections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ client/src/
 - **Data Fetching**: SWR + Axios
 - **Database**: MongoDB with Mongoose ODM
 - **Queue/Cache**: Redis + BullMQ + Pulse (cron scheduling)
-- **i18n**: i18next + react-i18next (translations via PoEditor)
+- **i18n**: i18next + react-i18next (non-English locales are machine translated, not managed through a translation service)
 
 ---
 

--- a/client/src/Components/sidebar/Menu.tsx
+++ b/client/src/Components/sidebar/Menu.tsx
@@ -23,64 +23,84 @@ import {
 export const getMenu = (t: Function) => {
 	return [
 		{
-			name: t("components.sidebar.menu.uptime"),
-			path: "uptime",
-			icon: <Icon icon={Globe} />,
+			group: t("components.sidebar.menu.groups.monitoring"),
+			items: [
+				{
+					name: t("components.sidebar.menu.uptime"),
+					path: "uptime",
+					icon: <Icon icon={Globe} />,
+				},
+				{
+					name: t("components.sidebar.menu.pagespeed"),
+					path: "pagespeed",
+					icon: <Icon icon={Gauge} />,
+				},
+				{
+					name: t("components.sidebar.menu.infrastructure"),
+					path: "infrastructure",
+					icon: <Icon icon={Link} />,
+				},
+			],
 		},
 		{
-			name: t("components.sidebar.menu.pagespeed"),
-			path: "pagespeed",
-			icon: <Icon icon={Gauge} />,
+			group: t("components.sidebar.menu.groups.alerting"),
+			items: [
+				{
+					name: t("components.sidebar.menu.incidents"),
+					path: "incidents",
+					icon: <Icon icon={AlertTriangle} />,
+				},
+				{
+					name: t("components.sidebar.menu.notifications"),
+					path: "notifications",
+					icon: <Icon icon={Bell} />,
+				},
+				{
+					name: t("components.sidebar.menu.maintenance"),
+					path: "maintenance",
+					icon: <Icon icon={Wrench} />,
+				},
+			],
 		},
 		{
-			name: t("components.sidebar.menu.infrastructure"),
-			path: "infrastructure",
-			icon: <Icon icon={Link} />,
+			group: t("components.sidebar.menu.groups.reporting"),
+			items: [
+				{
+					name: t("components.sidebar.menu.statusPages"),
+					path: "status",
+					icon: <Icon icon={Wifi} />,
+				},
+				{
+					name: t("components.sidebar.menu.checks"),
+					path: "checks",
+					icon: <Icon icon={FileText} />,
+				},
+				{
+					name: t("components.sidebar.menu.logs"),
+					path: "logs",
+					icon: <Icon icon={ScrollText} />,
+				},
+			],
 		},
 		{
-			name: t("components.sidebar.menu.notifications"),
-			path: "notifications",
-			icon: <Icon icon={Bell} />,
-		},
-		{
-			name: t("components.sidebar.menu.tags"),
-			path: "tags",
-			icon: <Icon icon={Tag} />,
-		},
-		{
-			name: t("components.sidebar.menu.proxies"),
-			path: "proxies",
-			icon: <Icon icon={Waypoints} />,
-		},
-		{
-			name: t("components.sidebar.menu.checks"),
-			path: "checks",
-			icon: <Icon icon={FileText} />,
-		},
-		{
-			name: t("components.sidebar.menu.incidents"),
-			path: "incidents",
-			icon: <Icon icon={AlertTriangle} />,
-		},
-		{
-			name: t("components.sidebar.menu.statusPages"),
-			path: "status",
-			icon: <Icon icon={Wifi} />,
-		},
-		{
-			name: t("components.sidebar.menu.maintenance"),
-			path: "maintenance",
-			icon: <Icon icon={Wrench} />,
-		},
-		{
-			name: t("components.sidebar.menu.logs"),
-			path: "logs",
-			icon: <Icon icon={ScrollText} />,
-		},
-		{
-			name: t("components.sidebar.menu.settings"),
-			icon: <Icon icon={Settings} />,
-			path: "settings",
+			group: t("components.sidebar.menu.groups.configuration"),
+			items: [
+				{
+					name: t("components.sidebar.menu.tags"),
+					path: "tags",
+					icon: <Icon icon={Tag} />,
+				},
+				{
+					name: t("components.sidebar.menu.proxies"),
+					path: "proxies",
+					icon: <Icon icon={Waypoints} />,
+				},
+				{
+					name: t("components.sidebar.menu.settings"),
+					path: "settings",
+					icon: <Icon icon={Settings} />,
+				},
+			],
 		},
 	];
 };

--- a/client/src/Components/sidebar/index.tsx
+++ b/client/src/Components/sidebar/index.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import Backdrop from "@mui/material/Backdrop";
 import Stack from "@mui/material/Stack";
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
 import List from "@mui/material/List";
 import Divider from "@mui/material/Divider";
 import { LAYOUT } from "@/Utils/Theme/constants";
@@ -89,17 +91,46 @@ export const Sidebar = () => {
 						pt={theme.spacing(LAYOUT.MD)}
 						pb={theme.spacing(LAYOUT.MD)}
 					/>
-					{menu.map((item) => {
-						const selected = location.pathname.startsWith(`/${item.path}`);
-						return (
-							<NavItem
-								key={item.path}
-								item={item}
-								selected={selected}
-								onClick={() => handleNavClick(item.path)}
-							/>
-						);
-					})}
+					{menu.map((group, groupIndex) => (
+						<Box
+							component="li"
+							key={group.group}
+							sx={{ listStyle: "none" }}
+						>
+							{collapsed ? (
+								groupIndex > 0 && (
+									<Divider
+										sx={{
+											borderColor: theme.palette.divider,
+											marginY: theme.spacing(LAYOUT.XS),
+										}}
+									/>
+								)
+							) : (
+								<Typography
+									variant="eyebrow"
+									component="div"
+									color={theme.palette.text.disabled}
+									paddingLeft={theme.spacing(LAYOUT.LG)}
+									paddingTop={theme.spacing(LAYOUT.XS)}
+									paddingBottom={theme.spacing(LAYOUT.XXS)}
+								>
+									{group.group}
+								</Typography>
+							)}
+							{group.items.map((item) => {
+								const selected = location.pathname.startsWith(`/${item.path}`);
+								return (
+									<NavItem
+										key={item.path}
+										item={item}
+										selected={selected}
+										onClick={() => handleNavClick(item.path)}
+									/>
+								);
+							})}
+						</Box>
+					))}
 				</List>
 				<StarPrompt />
 

--- a/client/src/Components/sidebar/index.tsx
+++ b/client/src/Components/sidebar/index.tsx
@@ -92,11 +92,7 @@ export const Sidebar = () => {
 						pb={theme.spacing(LAYOUT.MD)}
 					/>
 					{menu.map((group, groupIndex) => (
-						<Box
-							component="li"
-							key={group.group}
-							sx={{ listStyle: "none" }}
-						>
+						<Box key={group.group}>
 							{collapsed ? (
 								groupIndex > 0 && (
 									<Divider

--- a/client/src/Components/sidebar/index.tsx
+++ b/client/src/Components/sidebar/index.tsx
@@ -32,7 +32,7 @@ export const Sidebar = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const { t } = useTranslation();
-	const { width, transition, collapsed } = useSidebar();
+	const { width, transition, transitionTiming, collapsed } = useSidebar();
 	const theme = useTheme();
 	const isSmall = useMediaQuery(theme.breakpoints.down("md"));
 	const menu = getMenu(t);
@@ -94,16 +94,10 @@ export const Sidebar = () => {
 					/>
 					{menu.map((group, groupIndex) => (
 						<Box key={group.group}>
-							{collapsed ? (
-								groupIndex > 0 && (
-									<Divider
-										sx={{
-											borderColor: theme.palette.divider,
-											marginY: theme.spacing(LAYOUT.XS),
-										}}
-									/>
-								)
-							) : (
+							<Box
+								position="relative"
+								overflow="hidden"
+							>
 								<Typography
 									variant="eyebrow"
 									component="div"
@@ -112,10 +106,27 @@ export const Sidebar = () => {
 									paddingLeft={theme.spacing(5)}
 									paddingTop={theme.spacing(LAYOUT.SM)}
 									paddingBottom={theme.spacing(LAYOUT.XXS)}
+									whiteSpace="nowrap"
+									sx={{
+										opacity: collapsed ? 0 : 1,
+										transition: `opacity ${transitionTiming}`,
+									}}
 								>
 									{group.group}
 								</Typography>
-							)}
+								{groupIndex > 0 && (
+									<Divider
+										sx={{
+											position: "absolute",
+											top: "50%",
+											left: 0,
+											right: 0,
+											opacity: collapsed ? 1 : 0,
+											transition: `opacity ${transitionTiming}`,
+										}}
+									/>
+								)}
+							</Box>
 							{group.items.map((item) => {
 								const selected = location.pathname.startsWith(`/${item.path}`);
 								return (

--- a/client/src/Components/sidebar/index.tsx
+++ b/client/src/Components/sidebar/index.tsx
@@ -92,7 +92,7 @@ export const Sidebar = () => {
 						pt={theme.spacing(LAYOUT.MD)}
 						pb={theme.spacing(LAYOUT.MD)}
 					/>
-					{menu.map((group, groupIndex) => (
+					{menu.map((group) => (
 						<Box key={group.group}>
 							<Box
 								position="relative"
@@ -114,18 +114,16 @@ export const Sidebar = () => {
 								>
 									{group.group}
 								</Typography>
-								{groupIndex > 0 && (
-									<Divider
-										sx={{
-											position: "absolute",
-											top: "50%",
-											left: 0,
-											right: 0,
-											opacity: collapsed ? 1 : 0,
-											transition: `opacity ${transitionTiming}`,
-										}}
-									/>
-								)}
+								<Divider
+									sx={{
+										position: "absolute",
+										top: "50%",
+										left: 0,
+										right: 0,
+										opacity: collapsed ? 1 : 0,
+										transition: `opacity ${transitionTiming}`,
+									}}
+								/>
 							</Box>
 							{group.items.map((item) => {
 								const selected = location.pathname.startsWith(`/${item.path}`);

--- a/client/src/Components/sidebar/index.tsx
+++ b/client/src/Components/sidebar/index.tsx
@@ -6,6 +6,7 @@ import Typography from "@mui/material/Typography";
 import List from "@mui/material/List";
 import Divider from "@mui/material/Divider";
 import { LAYOUT } from "@/Utils/Theme/constants";
+import { typographyLevels } from "@/Utils/Theme/Palette";
 import { useSidebar } from "@/Hooks/useSidebar.js";
 import { Logo } from "@/Components/sidebar/Logo";
 import { getMenu, getAccountMenu } from "@/Components/sidebar/Menu";
@@ -107,8 +108,9 @@ export const Sidebar = () => {
 									variant="eyebrow"
 									component="div"
 									color={theme.palette.text.disabled}
-									paddingLeft={theme.spacing(LAYOUT.LG)}
-									paddingTop={theme.spacing(LAYOUT.XS)}
+									fontSize={typographyLevels.s}
+									paddingLeft={theme.spacing(5)}
+									paddingTop={theme.spacing(LAYOUT.SM)}
 									paddingBottom={theme.spacing(LAYOUT.XXS)}
 								>
 									{group.group}

--- a/client/src/Hooks/useSidebar.ts
+++ b/client/src/Hooks/useSidebar.ts
@@ -6,7 +6,8 @@ const SIDEBAR_WIDTH_VAR = 250;
 const SIDEBAR_COLLAPSED_WIDTH_VAR = 64;
 
 // Transition timing for sidebar width changes
-const SIDEBAR_TRANSITION = "width 650ms cubic-bezier(0.36, -0.01, 0, 0.77)";
+const SIDEBAR_TRANSITION_TIMING = "650ms cubic-bezier(0.36, -0.01, 0, 0.77)";
+const SIDEBAR_TRANSITION = `width ${SIDEBAR_TRANSITION_TIMING}`;
 
 export const useSidebar = () => {
 	const collapsed = useSelector(
@@ -19,6 +20,7 @@ export const useSidebar = () => {
 		expandedWidth: SIDEBAR_WIDTH_VAR,
 		width: collapsed ? SIDEBAR_COLLAPSED_WIDTH_VAR : SIDEBAR_WIDTH_VAR,
 		transition: SIDEBAR_TRANSITION,
+		transitionTiming: SIDEBAR_TRANSITION_TIMING,
 	};
 };
 

--- a/client/src/locales/ar.json
+++ b/client/src/locales/ar.json
@@ -181,7 +181,13 @@
 				"statusPages": "صفحات الحالة",
 				"maintenance": "الصيانة",
 				"logs": "السجلات",
-				"settings": "الإعدادات"
+				"settings": "الإعدادات",
+				"groups": {
+					"monitoring": "المراقبة",
+					"alerting": "التنبيهات",
+					"reporting": "التقارير",
+					"configuration": "الإعدادات العامة"
+				}
 			},
 			"bottomMenu": {
 				"support": "الدعم",

--- a/client/src/locales/ca.json
+++ b/client/src/locales/ca.json
@@ -189,7 +189,13 @@
 				"statusPages": "Pàgines d'estat",
 				"maintenance": "Manteniment",
 				"logs": "Registres",
-				"settings": "Configuració"
+				"settings": "Configuració",
+				"groups": {
+					"monitoring": "Monitoratge",
+					"alerting": "Alertes",
+					"reporting": "Informes",
+					"configuration": "Configuració"
+				}
 			},
 			"bottomMenu": {
 				"support": "Suport",

--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -181,7 +181,13 @@
 				"statusPages": "Stavové stránky",
 				"maintenance": "Údržba",
 				"logs": "Záznamy",
-				"settings": "Nastavení"
+				"settings": "Nastavení",
+				"groups": {
+					"monitoring": "Monitorování",
+					"alerting": "Upozornění",
+					"reporting": "Přehledy",
+					"configuration": "Konfigurace"
+				}
 			},
 			"bottomMenu": {
 				"support": "Podpora",

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -181,7 +181,13 @@
 				"statusPages": "Statusseite",
 				"maintenance": "Wartung",
 				"logs": "Protokolle",
-				"settings": "Einstellungen"
+				"settings": "Einstellungen",
+				"groups": {
+					"monitoring": "Überwachung",
+					"alerting": "Benachrichtigungen",
+					"reporting": "Berichte",
+					"configuration": "Konfiguration"
+				}
 			},
 			"bottomMenu": {
 				"support": "Support",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -211,7 +211,13 @@
 				"statusPages": "Status pages",
 				"maintenance": "Maintenance",
 				"logs": "Logs",
-				"settings": "Settings"
+				"settings": "Settings",
+				"groups": {
+					"monitoring": "Monitoring",
+					"alerting": "Alerting",
+					"reporting": "Reporting",
+					"configuration": "Configuration"
+				}
 			},
 			"bottomMenu": {
 				"support": "Support",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -181,7 +181,13 @@
 				"statusPages": "Páginas de estado",
 				"maintenance": "Mantenimiento",
 				"logs": "Registros",
-				"settings": "Configuración"
+				"settings": "Configuración",
+				"groups": {
+					"monitoring": "Monitorización",
+					"alerting": "Alertas",
+					"reporting": "Informes",
+					"configuration": "Configuración"
+				}
 			},
 			"bottomMenu": {
 				"support": "Soporte",

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -181,7 +181,13 @@
 				"statusPages": "Tilasivut",
 				"maintenance": "Huolto",
 				"logs": "Lokit",
-				"settings": "Asetukset"
+				"settings": "Asetukset",
+				"groups": {
+					"monitoring": "Valvonta",
+					"alerting": "Hälytykset",
+					"reporting": "Raportointi",
+					"configuration": "Määritykset"
+				}
 			},
 			"bottomMenu": {
 				"support": "Tuki",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -181,7 +181,13 @@
 				"statusPages": "Pages de statut",
 				"maintenance": "Maintenance",
 				"logs": "Journaux",
-				"settings": "Paramètres"
+				"settings": "Paramètres",
+				"groups": {
+					"monitoring": "Surveillance",
+					"alerting": "Alertes",
+					"reporting": "Rapports",
+					"configuration": "Configuration"
+				}
 			},
 			"bottomMenu": {
 				"support": "Support",

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -193,7 +193,13 @@
 				"statusPages": "Pagine di stato",
 				"maintenance": "Manutenzione",
 				"logs": "Log",
-				"settings": "Impostazioni"
+				"settings": "Impostazioni",
+				"groups": {
+					"monitoring": "Monitoraggio",
+					"alerting": "Avvisi",
+					"reporting": "Report",
+					"configuration": "Configurazione"
+				}
 			},
 			"bottomMenu": {
 				"support": "Supporto",

--- a/client/src/locales/ja.json
+++ b/client/src/locales/ja.json
@@ -181,7 +181,13 @@
 				"statusPages": "ステータスページ",
 				"maintenance": "メンテナンス",
 				"logs": "ログ",
-				"settings": "設定"
+				"settings": "設定",
+				"groups": {
+					"monitoring": "監視",
+					"alerting": "アラート",
+					"reporting": "レポート",
+					"configuration": "設定"
+				}
 			},
 			"bottomMenu": {
 				"support": "サポート",

--- a/client/src/locales/pl.json
+++ b/client/src/locales/pl.json
@@ -214,7 +214,13 @@
 				"settings": "Ustawienia",
 				"statusPages": "Strony statusu",
 				"tags": "Tagi",
-				"uptime": "Czas działania"
+				"uptime": "Czas działania",
+				"groups": {
+					"monitoring": "Monitorowanie",
+					"alerting": "Alerty",
+					"reporting": "Raporty",
+					"configuration": "Konfiguracja"
+				}
 			},
 			"starPrompt": {
 				"description": "Zobacz najnowsze wydania i pomóż rozwijać społeczność na GitHub",

--- a/client/src/locales/pt-BR.json
+++ b/client/src/locales/pt-BR.json
@@ -181,7 +181,13 @@
 				"statusPages": "Pagina de status",
 				"maintenance": "Manutenção",
 				"logs": "Registros",
-				"settings": "Configurações"
+				"settings": "Configurações",
+				"groups": {
+					"monitoring": "Monitoramento",
+					"alerting": "Alertas",
+					"reporting": "Relatórios",
+					"configuration": "Configuração"
+				}
 			},
 			"bottomMenu": {
 				"support": "Suporte",

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -181,7 +181,13 @@
 				"statusPages": "Страницы статуса",
 				"maintenance": "Обслуживание",
 				"logs": "Логи",
-				"settings": "Настройки"
+				"settings": "Настройки",
+				"groups": {
+					"monitoring": "Мониторинг",
+					"alerting": "Оповещения",
+					"reporting": "Отчёты",
+					"configuration": "Конфигурация"
+				}
 			},
 			"bottomMenu": {
 				"support": "Поддержка",

--- a/client/src/locales/th.json
+++ b/client/src/locales/th.json
@@ -181,7 +181,13 @@
 				"statusPages": "หน้าสถานะ",
 				"maintenance": "การบำรุงรักษา",
 				"logs": "บันทึก",
-				"settings": "การตั้งค่า"
+				"settings": "การตั้งค่า",
+				"groups": {
+					"monitoring": "การตรวจสอบ",
+					"alerting": "การแจ้งเตือน",
+					"reporting": "รายงาน",
+					"configuration": "การกำหนดค่า"
+				}
 			},
 			"bottomMenu": {
 				"support": "การสนับสนุน",

--- a/client/src/locales/tr.json
+++ b/client/src/locales/tr.json
@@ -181,7 +181,13 @@
 				"statusPages": "Durum sayfaları",
 				"maintenance": "Bakım",
 				"logs": "Günlükler",
-				"settings": "Ayarlar"
+				"settings": "Ayarlar",
+				"groups": {
+					"monitoring": "İzleme",
+					"alerting": "Uyarılar",
+					"reporting": "Raporlama",
+					"configuration": "Yapılandırma"
+				}
 			},
 			"bottomMenu": {
 				"support": "Destek",

--- a/client/src/locales/uk.json
+++ b/client/src/locales/uk.json
@@ -181,7 +181,13 @@
 				"statusPages": "Сторінки статусу",
 				"maintenance": "Обслуговування",
 				"logs": "Журнали",
-				"settings": "Налаштування"
+				"settings": "Налаштування",
+				"groups": {
+					"monitoring": "Моніторинг",
+					"alerting": "Сповіщення",
+					"reporting": "Звіти",
+					"configuration": "Конфігурація"
+				}
 			},
 			"bottomMenu": {
 				"support": "Підтримка",

--- a/client/src/locales/vi.json
+++ b/client/src/locales/vi.json
@@ -181,7 +181,13 @@
 				"statusPages": "Trang trạng thái",
 				"maintenance": "Bảo trì",
 				"logs": "Nhật ký",
-				"settings": "Cài đặt"
+				"settings": "Cài đặt",
+				"groups": {
+					"monitoring": "Giám sát",
+					"alerting": "Cảnh báo",
+					"reporting": "Báo cáo",
+					"configuration": "Cấu hình"
+				}
 			},
 			"bottomMenu": {
 				"support": "Hỗ trợ",

--- a/client/src/locales/zh-CN.json
+++ b/client/src/locales/zh-CN.json
@@ -181,7 +181,13 @@
 				"statusPages": "状态页",
 				"maintenance": "维护",
 				"logs": "日志",
-				"settings": "设置"
+				"settings": "设置",
+				"groups": {
+					"monitoring": "监控",
+					"alerting": "告警",
+					"reporting": "报表",
+					"configuration": "配置"
+				}
 			},
 			"bottomMenu": {
 				"support": "支持",

--- a/client/src/locales/zh-TW.json
+++ b/client/src/locales/zh-TW.json
@@ -181,7 +181,13 @@
 				"statusPages": "狀態頁面",
 				"maintenance": "維護",
 				"logs": "日誌",
-				"settings": "設定"
+				"settings": "設定",
+				"groups": {
+					"monitoring": "監控",
+					"alerting": "警示",
+					"reporting": "報表",
+					"configuration": "設定"
+				}
 			},
 			"bottomMenu": {
 				"support": "支援",


### PR DESCRIPTION
## Problem

The sidebar listed twelve items in a flat column, ordered roughly by when each feature was added. Nothing signalled that Uptime, Pagespeed and Infrastructure are the same kind of thing, or that Tags and Proxies are configuration rather than views.

Adding a new monitor type makes this worse: the natural place for a new entry is the end of the list, three rows below the item it most resembles.

## Changes

Groups the menu into four sections:

| Group | Items |
|---|---|
| **Monitoring** | Uptime, Pagespeed, Infrastructure |
| **Alerting** | Incidents, Notifications, Maintenance |
| **Reporting** | Status pages, Checks, Logs |
| **Configuration** | Tags, Proxies, Settings |

- `getMenu` returns groups of items rather than a flat array; the sidebar renders an eyebrow label per group.
- **Collapsed (64px):** no room for labels, so they are replaced by dividers between groups — the grouping survives as rhythm rather than disappearing.
- **Settings** moves from the middle of the list to the end of Configuration.
- Four `components.sidebar.menu.groups.*` keys added across **all 19 locales**.
- Group labels align with the nav icon column and sit a step below the item text: `paddingLeft` matches `NavItem`'s own `theme.spacing(5)`, and the size drops to `typographyLevels.s` (11px) since the `eyebrow` variant is the same 13px as the items.

Also corrects the i18n note in `CLAUDE.md`: PoEditor has been dropped, so the claim that translations are managed through it is no longer true.

## Notes for review

**Docker monitoring is not wired in here.** This groups the twelve items that exist today. When Docker lands it is a three-line addition to the Monitoring group — deliberately not stubbed, since a nav entry pointing at a non-existent route would be worse than nothing. `Container` from lucide is the intended icon (already installed, no new dependency).

**Group names are the part worth arguing with.** "Alerting" covers the alert lifecycle — what raises an alert (Incidents), where it goes (Notifications), when it is muted (Maintenance). "Reporting" is the weakest of the four: Checks and Logs are raw data, while Status pages is an outward-facing artifact. Happy to rename.

**Non-English group labels are machine translations** and have not been reviewed by a speaker of each language.

## Verification

- `npm run build` (tsc + vite) passes
- `npm run format-check` passes
- `npm run lint` reports zero warnings on both changed sidebar files
- All 19 locale files re-parsed and asserted to contain the four keys with non-empty values
- Rendered locally and measured: group label and first nav icon both start at x=12, label renders 11px against the items' 13px

## Testing notes

Worth checking: expanded sidebar; collapsed at 64px (dividers, tooltips still correct); whether the ~112px of added vertical chrome causes scrolling on a short viewport; and a couple of non-Latin locales (`ja`, `ar` for RTL) for label wrapping.

https://claude.ai/code/session_01AbYLvwpEaZFXktHVcqrFRd
