### PR TITLE
feat(client): group settings into five tabs

### DIFF
--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { BasePage, ConfigBox, TextLink } from "@/Components/design-elements";
+import { BasePage, ConfigBox, TextLink, Tabs, Tab } from "@/Components/design-elements";
 import { Autocomplete, Select, Dialog } from "@/Components/inputs";
 import { logger } from "@/Utils/logger";
 import { LAYOUT } from "@/Utils/Theme/constants";
@@ -46,6 +46,33 @@ import { FormNumberField } from "@/Components/inputs/forms/FormNumberField";
 import { FormSelectField } from "@/Components/inputs/forms/FormSelectField";
 import type { ProxyResponse } from "@/Types/Proxy";
 import type { AppSettingsResponse } from "@/Types/Settings";
+import { useSearchParams } from "react-router-dom";
+
+const SETTINGS_TABS = [
+	{ key: "general", labelKey: "pages.settings.tabs.general" },
+	{ key: "monitoring", labelKey: "pages.settings.tabs.monitoring", adminOnly: true },
+	{ key: "email", labelKey: "pages.settings.tabs.email", adminOnly: true },
+	{ key: "integrations", labelKey: "pages.settings.tabs.integrations", adminOnly: true },
+	{ key: "data", labelKey: "pages.settings.tabs.data", adminOnly: true },
+] as const;
+
+type SettingsTabKey = (typeof SETTINGS_TABS)[number]["key"];
+
+// Maps a validation error back to the tab holding it, so a failed save can
+// reveal the offending field instead of naming one on a hidden tab.
+const FIELD_TAB: Record<string, SettingsTabKey> = {
+	checkTTL: "monitoring",
+	globalThresholds: "monitoring",
+	pagespeedApiKey: "integrations",
+	globalProxyEnabled: "integrations",
+	globalProxyId: "integrations",
+	showURL: "general",
+};
+
+const tabForField = (field: string): SettingsTabKey =>
+	field.startsWith("systemEmail")
+		? "email"
+		: (FIELD_TAB[field.split(".")[0]] ?? "general");
 
 export const SettingsPage = () => {
 	const theme = useTheme();
@@ -53,6 +80,28 @@ export const SettingsPage = () => {
 	const dispatch = useDispatch();
 	const isAdmin = useIsAdmin();
 	const { toastError } = useToast();
+	const [searchParams, setSearchParams] = useSearchParams();
+
+	const visibleTabs = useMemo(
+		() => SETTINGS_TABS.filter((tab) => !("adminOnly" in tab) || isAdmin),
+		[isAdmin]
+	);
+
+	// An unknown tab, or an admin tab requested by a non-admin, falls back to the
+	// first tab the current user can actually see.
+	const requestedTab = searchParams.get("tab");
+	const activeTab: SettingsTabKey =
+		visibleTabs.find((tab) => tab.key === requestedTab)?.key ?? visibleTabs[0].key;
+
+	const handleTabChange = (tab: SettingsTabKey) => {
+		const updated = new URLSearchParams(searchParams);
+		if (tab === visibleTabs[0].key) {
+			updated.delete("tab");
+		} else {
+			updated.set("tab", tab);
+		}
+		setSearchParams(updated, { replace: true });
+	};
 	// Local state for demo monitors dialog
 	const [isDemoMonitorsDialogOpen, setIsDemoMonitorsDialogOpen] = useState(false);
 	const { post: postDemoMonitors, loading: isPostingDemoMonitors } = usePost();
@@ -298,6 +347,15 @@ export const SettingsPage = () => {
 
 	const onError = (errors: unknown) => {
 		logger.debug("Form validation errors", errors);
+		// The save bar lists errors by field name, so reveal the tab owning the
+		// first one rather than naming a field the user cannot see.
+		const firstField = Object.keys(errors ?? {})[0];
+		if (firstField) {
+			const target = tabForField(firstField);
+			if (visibleTabs.some((tab) => tab.key === target)) {
+				handleTabChange(target);
+			}
+		}
 	};
 
 	const languages = Object.keys(i18n.options.resources || {});
@@ -324,7 +382,26 @@ export const SettingsPage = () => {
 				component="form"
 				onSubmit={form.handleSubmit(onSubmit, onError)}
 			>
-				<Stack gap={theme.spacing(LAYOUT.MD)}>
+				{visibleTabs.length > 1 && (
+					<Tabs
+						value={activeTab}
+						onChange={(_, value: SettingsTabKey) => handleTabChange(value)}
+					>
+						{visibleTabs.map((tab) => (
+							<Tab
+								key={tab.key}
+								value={tab.key}
+								label={t(tab.labelKey)}
+							/>
+						))}
+					</Tabs>
+				)}
+
+				{/* general tab */}
+				<Stack
+					gap={theme.spacing(LAYOUT.MD)}
+					hidden={activeTab !== "general"}
+				>
 					<ConfigBox
 						title={t("pages.settings.form.timezone.title")}
 						subtitle={t("pages.settings.form.timezone.description")}
@@ -390,6 +467,360 @@ export const SettingsPage = () => {
 							</Stack>
 						}
 					/>
+					{/* URL Settings */}
+					<ConfigBox
+						title={t("pages.settings.form.url.title")}
+						subtitle={t("pages.settings.form.url.description")}
+						rightContent={
+							<FormSwitchField
+								name="showURL"
+								label={t("pages.settings.form.url.option.showURL.label")}
+								labelPlacement="start"
+							/>
+						}
+					/>
+					{/* About */}
+					<ConfigBox
+						title={t("pages.settings.form.about.title")}
+						subtitle=""
+						rightContent={
+							<Stack spacing={2}>
+								<Typography variant="body1">
+									{t("common.appName")} {__APP_VERSION__}
+								</Typography>
+								<Typography
+									variant="body2"
+									sx={{ opacity: 0.6 }}
+								>
+									{t("pages.settings.form.about.developedBy")}
+								</Typography>
+								<Link
+									href="https://github.com/bluewave-labs/checkmate"
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									https://github.com/bluewave-labs/checkmate
+								</Link>
+							</Stack>
+						}
+					/>
+				</Stack>
+
+				{/* monitoring tab */}
+				<Stack
+					gap={theme.spacing(LAYOUT.MD)}
+					hidden={activeTab !== "monitoring"}
+				>
+					{/* Global Thresholds */}
+					{isAdmin && (
+						<ConfigBox
+							title={t("pages.settings.form.thresholds.title")}
+							subtitle={t("pages.settings.form.thresholds.description")}
+							rightContent={
+								<Stack spacing={2}>
+									<FormSliderField
+										name="globalThresholds.cpu"
+										fieldLabel={t("pages.settings.form.thresholds.option.cpu.label")}
+										valueLabelDisplay="auto"
+										min={1}
+										max={100}
+									/>
+									<FormSliderField
+										name="globalThresholds.memory"
+										fieldLabel={t("pages.settings.form.thresholds.option.memory.label")}
+										valueLabelDisplay="auto"
+										min={1}
+										max={100}
+									/>
+									<FormSliderField
+										name="globalThresholds.disk"
+										fieldLabel={t("pages.settings.form.thresholds.option.disk.label")}
+										valueLabelDisplay="auto"
+										min={1}
+										max={100}
+									/>
+
+									<FormSliderField
+										name="globalThresholds.temperature"
+										fieldLabel={t(
+											"pages.settings.form.thresholds.option.temperature.label"
+										)}
+										valueLabelDisplay="auto"
+										min={1}
+										max={150}
+									/>
+								</Stack>
+							}
+						/>
+					)}
+					{/* Check Retention */}
+					{isAdmin && (
+						<ConfigBox
+							title={t("pages.settings.form.retention.title")}
+							subtitle={t("pages.settings.form.retention.description")}
+							rightContent={
+								<FormSliderField
+									name="checkTTL"
+									fieldLabel={t("pages.settings.form.retention.option.days.label")}
+									min={1}
+									max={CHECK_TTL_SENTINEL}
+									valueLabelDisplay="auto"
+									valueLabelFormat={(value: number) =>
+										value >= CHECK_TTL_SENTINEL
+											? t("pages.settings.form.retention.option.days.unlimited")
+											: `${value}`
+									}
+									formatDisplayValue={(value: number) =>
+										value >= CHECK_TTL_SENTINEL
+											? t("pages.settings.form.retention.option.days.unlimited")
+											: `${value}`
+									}
+								/>
+							}
+						/>
+					)}
+
+					{/* Demo Monitors - Admin Only */}
+					{isAdmin && (
+						<ConfigBox
+							title={t("pages.settings.form.demoMonitors.title")}
+							subtitle={t("pages.settings.form.demoMonitors.description")}
+							rightContent={
+								<Box>
+									<Button
+										variant="contained"
+										loading={isPostingDemoMonitors}
+										onClick={async () => {
+											await postDemoMonitors("/monitors/demo", {});
+										}}
+									>
+										{t("common.buttons.addDemo")}
+									</Button>
+								</Box>
+							}
+						/>
+					)}
+				</Stack>
+
+				{/* email tab */}
+				<Stack
+					gap={theme.spacing(LAYOUT.MD)}
+					hidden={activeTab !== "email"}
+				>
+					{/* Email Settings - Admin Only */}
+					{isAdmin && (
+						<ConfigBox
+							title={t("pages.settings.form.email.title")}
+							subtitle={t("pages.settings.form.email.description")}
+							leftContent={
+								<Stack gap={theme.spacing(LAYOUT.MD)}>
+									<TextLink
+										text={t("pages.settings.form.email.descriptionTransport")}
+										linkText={t("pages.settings.form.email.descriptionTransportLink")}
+										href="https://nodemailer.com/smtp/"
+										target="_blank"
+									/>
+									{(() => {
+										const address = form.watch("systemEmailAddress") || "";
+										const displayName = form.watch("systemEmailDisplayName")?.trim();
+										return (
+											<>
+												<Box
+													component="pre"
+													p={2}
+													borderRadius={theme.shape.borderRadius}
+													bgcolor={theme.palette.action.hover}
+													sx={{
+														fontFamily: theme.typography.fontFamilyMonospace,
+														overflow: "auto",
+													}}
+												>
+													<code>
+														{JSON.stringify(
+															{
+																host: form.watch("systemEmailHost") || "",
+																port: form.watch("systemEmailPort") || "",
+																secure: form.watch("systemEmailSecure") ?? false,
+																auth: {
+																	user: form.watch("systemEmailUser") || address,
+																	pass: "<your_password>",
+																},
+																name:
+																	form.watch("systemEmailConnectionHost") || "localhost",
+																pool: form.watch("systemEmailPool") ?? false,
+																tls: {
+																	rejectUnauthorized:
+																		form.watch("systemEmailRejectUnauthorized") ?? true,
+																	ignoreTLS: form.watch("systemEmailIgnoreTLS") ?? false,
+																	requireTLS:
+																		form.watch("systemEmailRequireTLS") ?? false,
+																	servername:
+																		form.watch("systemEmailTLSServername") || "",
+																},
+															},
+															null,
+															2
+														)}
+													</code>
+												</Box>
+												{address && (
+													<Box
+														component="pre"
+														p={2}
+														borderRadius={theme.shape.borderRadius}
+														bgcolor={theme.palette.action.hover}
+														sx={{
+															fontFamily: theme.typography.fontFamilyMonospace,
+															overflow: "auto",
+														}}
+													>
+														<code>
+															{`From: ${displayName ? `"${displayName}" <${address}>` : address}`}
+														</code>
+													</Box>
+												)}
+											</>
+										);
+									})()}
+								</Stack>
+							}
+							rightContent={
+								<Stack gap={theme.spacing(LAYOUT.MD)}>
+									{/* Email Host */}
+									<FormTextField
+										name="systemEmailHost"
+										fieldLabel={t("pages.settings.form.email.option.host.label")}
+										placeholder={t("pages.settings.form.email.option.host.placeholder")}
+									/>
+
+									{/* Email Port */}
+									<FormNumberField
+										name="systemEmailPort"
+										fieldLabel={t("pages.settings.form.email.option.port.label")}
+										placeholder={t("pages.settings.form.email.option.port.placeholder")}
+									/>
+
+									{/* Email Address */}
+									<FormTextField
+										name="systemEmailAddress"
+										type="email"
+										fieldLabel={t("pages.settings.form.email.option.address.label")}
+										placeholder={t(
+											"pages.settings.form.email.option.address.placeholder"
+										)}
+									/>
+
+									{/* Email Display Name (Optional) */}
+									<FormTextField
+										name="systemEmailDisplayName"
+										fieldLabel={t("pages.settings.form.email.option.displayName.label")}
+										placeholder={t(
+											"pages.settings.form.email.option.displayName.placeholder"
+										)}
+									/>
+
+									{/* Email User (Optional) */}
+									<FormTextField
+										name="systemEmailUser"
+										fieldLabel={t("pages.settings.form.email.option.user.label")}
+										placeholder={t("pages.settings.form.email.option.user.placeholder")}
+									/>
+
+									{/* Email Password with Reset Pattern */}
+									{isEmailPasswordSet && !emailPasswordHasBeenReset ? (
+										<Box>
+											<FieldLabel>
+												{t("pages.settings.form.email.option.password.labelSet")}
+											</FieldLabel>
+											<Stack
+												direction="row"
+												alignItems="center"
+												gap={theme.spacing(LAYOUT.XS)}
+											>
+												<Button
+													variant="contained"
+													color="error"
+													size="small"
+													onClick={handleResetEmailPassword}
+												>
+													{t("common.buttons.reset")}
+												</Button>
+											</Stack>
+										</Box>
+									) : (
+										<FormTextField
+											name="systemEmailPassword"
+											type="password"
+											fieldLabel={t("pages.settings.form.email.option.password.label")}
+											placeholder={t(
+												"pages.settings.form.email.option.password.placeholder"
+											)}
+										/>
+									)}
+
+									{/* TLS Servername (Optional) */}
+									<FormTextField
+										name="systemEmailTLSServername"
+										fieldLabel={t("pages.settings.form.email.option.tlsServername.label")}
+										placeholder={t(
+											"pages.settings.form.email.option.tlsServername.placeholder"
+										)}
+									/>
+
+									{/* Connection Host (Optional) */}
+									<FormTextField
+										name="systemEmailConnectionHost"
+										fieldLabel={t(
+											"pages.settings.form.email.option.connectionHost.label"
+										)}
+										placeholder={t(
+											"pages.settings.form.email.option.connectionHost.placeholder"
+										)}
+									/>
+
+									{/* Boolean Switches */}
+									<Box
+										display={"flex"}
+										flexDirection={"column"}
+										gap={theme.spacing(LAYOUT.XS)}
+									>
+										{emailSwitches.map(({ name, label }) => (
+											<FormSwitchField
+												key={name}
+												name={name}
+												label={label}
+												labelPlacement="start"
+											/>
+										))}
+									</Box>
+
+									{/* Test Email Button */}
+									<Box>
+										<Button
+											variant="contained"
+											loading={isSendingTestEmail}
+											onClick={handleSendTestEmail}
+											disabled={
+												!form.watch("systemEmailHost") ||
+												!form.watch("systemEmailPort") ||
+												!form.watch("systemEmailAddress") ||
+												!form.watch("systemEmailPassword")
+											}
+										>
+											{t("common.buttons.sendTestEmail")}
+										</Button>
+									</Box>
+								</Stack>
+							}
+						/>
+					)}
+				</Stack>
+
+				{/* integrations tab */}
+				<Stack
+					gap={theme.spacing(LAYOUT.MD)}
+					hidden={activeTab !== "integrations"}
+				>
 					{isAdmin && (
 						<ConfigBox
 							title={t("pages.settings.form.globalProxy.title")}
@@ -457,20 +888,49 @@ export const SettingsPage = () => {
 							}
 						/>
 					)}
+				</Stack>
 
-					{/* URL Settings */}
-					<ConfigBox
-						title={t("pages.settings.form.url.title")}
-						subtitle={t("pages.settings.form.url.description")}
-						rightContent={
-							<FormSwitchField
-								name="showURL"
-								label={t("pages.settings.form.url.option.showURL.label")}
-								labelPlacement="start"
-							/>
-						}
-					/>
-
+				{/* data tab */}
+				<Stack
+					gap={theme.spacing(LAYOUT.MD)}
+					hidden={activeTab !== "data"}
+				>
+					{/* Export Monitors - Admin Only */}
+					{isAdmin && (
+						<ConfigBox
+							title={t("pages.settings.form.importExportMonitors.title")}
+							subtitle={t("pages.settings.form.importExportMonitors.description")}
+							rightContent={
+								<Stack
+									gap={theme.spacing(LAYOUT.MD)}
+									direction={"row"}
+								>
+									<input
+										id="monitor-import-input"
+										type="file"
+										accept=".json"
+										style={{ display: "none" }}
+										onChange={handleFileSelect}
+									/>
+									<Button
+										variant="contained"
+										onClick={() =>
+											document.getElementById("monitor-import-input")?.click()
+										}
+										disabled={isImportingMonitors}
+									>
+										{t("common.buttons.importFromJSON")}
+									</Button>
+									<Button
+										variant="contained"
+										onClick={handleExportMonitors}
+									>
+										{t("common.buttons.exportToJSON")}
+									</Button>
+								</Stack>
+							}
+						/>
+					)}
 					{/* Clear All Stats */}
 					{isAdmin && (
 						<ConfigBox
@@ -488,380 +948,26 @@ export const SettingsPage = () => {
 						/>
 					)}
 
-					{/* Check Retention */}
+					{/* Remove All Monitors - Admin Only */}
 					{isAdmin && (
 						<ConfigBox
-							title={t("pages.settings.form.retention.title")}
-							subtitle={t("pages.settings.form.retention.description")}
+							title={t("pages.settings.form.removeMonitors.title")}
+							subtitle={t("pages.settings.form.removeMonitors.description")}
 							rightContent={
-								<FormSliderField
-									name="checkTTL"
-									fieldLabel={t("pages.settings.form.retention.option.days.label")}
-									min={1}
-									max={CHECK_TTL_SENTINEL}
-									valueLabelDisplay="auto"
-									valueLabelFormat={(value: number) =>
-										value >= CHECK_TTL_SENTINEL
-											? t("pages.settings.form.retention.option.days.unlimited")
-											: `${value}`
-									}
-									formatDisplayValue={(value: number) =>
-										value >= CHECK_TTL_SENTINEL
-											? t("pages.settings.form.retention.option.days.unlimited")
-											: `${value}`
-									}
-								/>
-							}
-						/>
-					)}
-
-					{/* Global Thresholds */}
-					{isAdmin && (
-						<ConfigBox
-							title={t("pages.settings.form.thresholds.title")}
-							subtitle={t("pages.settings.form.thresholds.description")}
-							rightContent={
-								<Stack spacing={2}>
-									<FormSliderField
-										name="globalThresholds.cpu"
-										fieldLabel={t("pages.settings.form.thresholds.option.cpu.label")}
-										valueLabelDisplay="auto"
-										min={1}
-										max={100}
-									/>
-									<FormSliderField
-										name="globalThresholds.memory"
-										fieldLabel={t("pages.settings.form.thresholds.option.memory.label")}
-										valueLabelDisplay="auto"
-										min={1}
-										max={100}
-									/>
-									<FormSliderField
-										name="globalThresholds.disk"
-										fieldLabel={t("pages.settings.form.thresholds.option.disk.label")}
-										valueLabelDisplay="auto"
-										min={1}
-										max={100}
-									/>
-
-									<FormSliderField
-										name="globalThresholds.temperature"
-										fieldLabel={t(
-											"pages.settings.form.thresholds.option.temperature.label"
-										)}
-										valueLabelDisplay="auto"
-										min={1}
-										max={150}
-									/>
-								</Stack>
+								<Box>
+									<Button
+										variant="contained"
+										color="error"
+										loading={isDeletingAllMonitors}
+										onClick={() => setIsDemoMonitorsDialogOpen(true)}
+									>
+										{t("common.buttons.removeMonitors")}
+									</Button>
+								</Box>
 							}
 						/>
 					)}
 				</Stack>
-
-				{/* Email Settings - Admin Only */}
-				{isAdmin && (
-					<ConfigBox
-						title={t("pages.settings.form.email.title")}
-						subtitle={t("pages.settings.form.email.description")}
-						leftContent={
-							<Stack gap={theme.spacing(LAYOUT.MD)}>
-								<TextLink
-									text={t("pages.settings.form.email.descriptionTransport")}
-									linkText={t("pages.settings.form.email.descriptionTransportLink")}
-									href="https://nodemailer.com/smtp/"
-									target="_blank"
-								/>
-								{(() => {
-									const address = form.watch("systemEmailAddress") || "";
-									const displayName = form.watch("systemEmailDisplayName")?.trim();
-									return (
-										<>
-											<Box
-												component="pre"
-												p={2}
-												borderRadius={theme.shape.borderRadius}
-												bgcolor={theme.palette.action.hover}
-												sx={{
-													fontFamily: theme.typography.fontFamilyMonospace,
-													overflow: "auto",
-												}}
-											>
-												<code>
-													{JSON.stringify(
-														{
-															host: form.watch("systemEmailHost") || "",
-															port: form.watch("systemEmailPort") || "",
-															secure: form.watch("systemEmailSecure") ?? false,
-															auth: {
-																user: form.watch("systemEmailUser") || address,
-																pass: "<your_password>",
-															},
-															name:
-																form.watch("systemEmailConnectionHost") || "localhost",
-															pool: form.watch("systemEmailPool") ?? false,
-															tls: {
-																rejectUnauthorized:
-																	form.watch("systemEmailRejectUnauthorized") ?? true,
-																ignoreTLS: form.watch("systemEmailIgnoreTLS") ?? false,
-																requireTLS: form.watch("systemEmailRequireTLS") ?? false,
-																servername: form.watch("systemEmailTLSServername") || "",
-															},
-														},
-														null,
-														2
-													)}
-												</code>
-											</Box>
-											{address && (
-												<Box
-													component="pre"
-													p={2}
-													borderRadius={theme.shape.borderRadius}
-													bgcolor={theme.palette.action.hover}
-													sx={{
-														fontFamily: theme.typography.fontFamilyMonospace,
-														overflow: "auto",
-													}}
-												>
-													<code>
-														{`From: ${displayName ? `"${displayName}" <${address}>` : address}`}
-													</code>
-												</Box>
-											)}
-										</>
-									);
-								})()}
-							</Stack>
-						}
-						rightContent={
-							<Stack gap={theme.spacing(LAYOUT.MD)}>
-								{/* Email Host */}
-								<FormTextField
-									name="systemEmailHost"
-									fieldLabel={t("pages.settings.form.email.option.host.label")}
-									placeholder={t("pages.settings.form.email.option.host.placeholder")}
-								/>
-
-								{/* Email Port */}
-								<FormNumberField
-									name="systemEmailPort"
-									fieldLabel={t("pages.settings.form.email.option.port.label")}
-									placeholder={t("pages.settings.form.email.option.port.placeholder")}
-								/>
-
-								{/* Email Address */}
-								<FormTextField
-									name="systemEmailAddress"
-									type="email"
-									fieldLabel={t("pages.settings.form.email.option.address.label")}
-									placeholder={t("pages.settings.form.email.option.address.placeholder")}
-								/>
-
-								{/* Email Display Name (Optional) */}
-								<FormTextField
-									name="systemEmailDisplayName"
-									fieldLabel={t("pages.settings.form.email.option.displayName.label")}
-									placeholder={t(
-										"pages.settings.form.email.option.displayName.placeholder"
-									)}
-								/>
-
-								{/* Email User (Optional) */}
-								<FormTextField
-									name="systemEmailUser"
-									fieldLabel={t("pages.settings.form.email.option.user.label")}
-									placeholder={t("pages.settings.form.email.option.user.placeholder")}
-								/>
-
-								{/* Email Password with Reset Pattern */}
-								{isEmailPasswordSet && !emailPasswordHasBeenReset ? (
-									<Box>
-										<FieldLabel>
-											{t("pages.settings.form.email.option.password.labelSet")}
-										</FieldLabel>
-										<Stack
-											direction="row"
-											alignItems="center"
-											gap={theme.spacing(LAYOUT.XS)}
-										>
-											<Button
-												variant="contained"
-												color="error"
-												size="small"
-												onClick={handleResetEmailPassword}
-											>
-												{t("common.buttons.reset")}
-											</Button>
-										</Stack>
-									</Box>
-								) : (
-									<FormTextField
-										name="systemEmailPassword"
-										type="password"
-										fieldLabel={t("pages.settings.form.email.option.password.label")}
-										placeholder={t(
-											"pages.settings.form.email.option.password.placeholder"
-										)}
-									/>
-								)}
-
-								{/* TLS Servername (Optional) */}
-								<FormTextField
-									name="systemEmailTLSServername"
-									fieldLabel={t("pages.settings.form.email.option.tlsServername.label")}
-									placeholder={t(
-										"pages.settings.form.email.option.tlsServername.placeholder"
-									)}
-								/>
-
-								{/* Connection Host (Optional) */}
-								<FormTextField
-									name="systemEmailConnectionHost"
-									fieldLabel={t("pages.settings.form.email.option.connectionHost.label")}
-									placeholder={t(
-										"pages.settings.form.email.option.connectionHost.placeholder"
-									)}
-								/>
-
-								{/* Boolean Switches */}
-								<Box
-									display={"flex"}
-									flexDirection={"column"}
-									gap={theme.spacing(LAYOUT.XS)}
-								>
-									{emailSwitches.map(({ name, label }) => (
-										<FormSwitchField
-											key={name}
-											name={name}
-											label={label}
-											labelPlacement="start"
-										/>
-									))}
-								</Box>
-
-								{/* Test Email Button */}
-								<Box>
-									<Button
-										variant="contained"
-										loading={isSendingTestEmail}
-										onClick={handleSendTestEmail}
-										disabled={
-											!form.watch("systemEmailHost") ||
-											!form.watch("systemEmailPort") ||
-											!form.watch("systemEmailAddress") ||
-											!form.watch("systemEmailPassword")
-										}
-									>
-										{t("common.buttons.sendTestEmail")}
-									</Button>
-								</Box>
-							</Stack>
-						}
-					/>
-				)}
-
-				{/* Demo Monitors - Admin Only */}
-				{isAdmin && (
-					<ConfigBox
-						title={t("pages.settings.form.demoMonitors.title")}
-						subtitle={t("pages.settings.form.demoMonitors.description")}
-						rightContent={
-							<Box>
-								<Button
-									variant="contained"
-									loading={isPostingDemoMonitors}
-									onClick={async () => {
-										await postDemoMonitors("/monitors/demo", {});
-									}}
-								>
-									{t("common.buttons.addDemo")}
-								</Button>
-							</Box>
-						}
-					/>
-				)}
-
-				{/* Remove All Monitors - Admin Only */}
-				{isAdmin && (
-					<ConfigBox
-						title={t("pages.settings.form.removeMonitors.title")}
-						subtitle={t("pages.settings.form.removeMonitors.description")}
-						rightContent={
-							<Box>
-								<Button
-									variant="contained"
-									color="error"
-									loading={isDeletingAllMonitors}
-									onClick={() => setIsDemoMonitorsDialogOpen(true)}
-								>
-									{t("common.buttons.removeMonitors")}
-								</Button>
-							</Box>
-						}
-					/>
-				)}
-
-				{/* Export Monitors - Admin Only */}
-				{isAdmin && (
-					<ConfigBox
-						title={t("pages.settings.form.importExportMonitors.title")}
-						subtitle={t("pages.settings.form.importExportMonitors.description")}
-						rightContent={
-							<Stack
-								gap={theme.spacing(LAYOUT.MD)}
-								direction={"row"}
-							>
-								<input
-									id="monitor-import-input"
-									type="file"
-									accept=".json"
-									style={{ display: "none" }}
-									onChange={handleFileSelect}
-								/>
-								<Button
-									variant="contained"
-									onClick={() => document.getElementById("monitor-import-input")?.click()}
-									disabled={isImportingMonitors}
-								>
-									{t("common.buttons.importFromJSON")}
-								</Button>
-								<Button
-									variant="contained"
-									onClick={handleExportMonitors}
-								>
-									{t("common.buttons.exportToJSON")}
-								</Button>
-							</Stack>
-						}
-					/>
-				)}
-
-				{/* About */}
-				<ConfigBox
-					title={t("pages.settings.form.about.title")}
-					subtitle=""
-					rightContent={
-						<Stack spacing={2}>
-							<Typography variant="body1">
-								{t("common.appName")} {__APP_VERSION__}
-							</Typography>
-							<Typography
-								variant="body2"
-								sx={{ opacity: 0.6 }}
-							>
-								{t("pages.settings.form.about.developedBy")}
-							</Typography>
-							<Link
-								href="https://github.com/bluewave-labs/checkmate"
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								https://github.com/bluewave-labs/checkmate
-							</Link>
-						</Stack>
-					}
-				/>
 
 				{/* Clear Stats Confirmation Dialog */}
 				<Dialog

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -58,8 +58,6 @@ const SETTINGS_TABS = [
 
 type SettingsTabKey = (typeof SETTINGS_TABS)[number]["key"];
 
-// Maps a validation error back to the tab holding it, so a failed save can
-// reveal the offending field instead of naming one on a hidden tab.
 const FIELD_TAB: Record<string, SettingsTabKey> = {
 	checkTTL: "monitoring",
 	globalThresholds: "monitoring",
@@ -74,10 +72,6 @@ const tabForField = (field: string): SettingsTabKey =>
 		? "email"
 		: (FIELD_TAB[field.split(".")[0]] ?? "general");
 
-// Error rows named the raw schema key ("systemEmailRejectUnauthorized"). Each
-// field already owns a translated label, so reuse those rather than adding
-// strings. Labels that append an explanation after a dash are trimmed to the
-// name itself.
 const FIELD_LABEL_KEY: Record<string, string> = {
 	checkTTL: "pages.settings.form.retention.option.days.label",
 	"globalThresholds.cpu": "pages.settings.form.thresholds.option.cpu.label",
@@ -104,10 +98,6 @@ const FIELD_LABEL_KEY: Record<string, string> = {
 		"pages.settings.form.email.option.rejectUnauthorized.label",
 };
 
-// react-hook-form nests errors by path, so a grouped field arrives as
-// { globalThresholds: { cpu: { message } } }. Iterating the top level alone
-// yields an entry whose own message is undefined, which renders as a bare
-// "globalThresholds" naming none of the four sliders. Walk to the leaves.
 type FieldErrorLeaf = { path: string; message?: string };
 
 const flattenFieldErrors = (errors: unknown, prefix = ""): FieldErrorLeaf[] => {
@@ -115,6 +105,9 @@ const flattenFieldErrors = (errors: unknown, prefix = ""): FieldErrorLeaf[] => {
 		return [];
 	}
 	return Object.entries(errors).flatMap(([key, value]) => {
+		if (key === "ref") {
+			return [];
+		}
 		const path = prefix ? `${prefix}.${key}` : key;
 		if (typeof value !== "object" || value === null) {
 			return [];
@@ -141,11 +134,7 @@ export const SettingsPage = () => {
 		[isAdmin]
 	);
 
-	// An unknown tab, or an admin tab requested by a non-admin, falls back to the
-	// first tab the current user can actually see.
 	const requestedTab = searchParams.get("tab");
-	// visibleTabs always contains "general" today; the constant fallback keeps a
-	// future gating change from throwing on an empty list.
 	const firstVisibleTab: SettingsTabKey = visibleTabs[0]?.key ?? SETTINGS_TABS[0].key;
 	const activeTab: SettingsTabKey =
 		visibleTabs.find((tab) => tab.key === requestedTab)?.key ?? firstVisibleTab;
@@ -160,16 +149,19 @@ export const SettingsPage = () => {
 		setSearchParams(updated, { replace: true });
 	};
 
-	// A "tab" that does not resolve -- an unknown key, or an admin tab followed by
-	// a non-admin -- leaves the URL claiming a tab the page is not showing. Drop it
-	// so the address bar matches what is rendered.
+	// Drop a "tab" param that does not resolve to a rendered tab, or that names
+	// the first tab, which is addressed with no param at all.
 	useEffect(() => {
-		if (requestedTab !== null && requestedTab !== activeTab) {
-			const updated = new URLSearchParams(searchParams);
-			updated.delete("tab");
-			setSearchParams(updated, { replace: true });
+		if (requestedTab === null) {
+			return;
 		}
-	}, [requestedTab, activeTab, searchParams, setSearchParams]);
+		if (requestedTab === activeTab && activeTab !== firstVisibleTab) {
+			return;
+		}
+		const updated = new URLSearchParams(searchParams);
+		updated.delete("tab");
+		setSearchParams(updated, { replace: true });
+	}, [requestedTab, activeTab, firstVisibleTab, searchParams, setSearchParams]);
 
 	// Local state for demo monitors dialog
 	const [isDemoMonitorsDialogOpen, setIsDemoMonitorsDialogOpen] = useState(false);
@@ -418,10 +410,6 @@ export const SettingsPage = () => {
 		logger.debug("Form validation errors", errors);
 	};
 
-	// The save bar lists errors by field name, and the offending field may sit on
-	// a tab that is not open. Submitting cannot reveal it -- the button is
-	// disabled while the form is invalid -- so each listed field switches to its
-	// own tab instead.
 	const revealField = (field: string) => {
 		const target = tabForField(field);
 		if (visibleTabs.some((tab) => tab.key === target)) {

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -1073,6 +1073,8 @@ export const SettingsPage = () => {
 				<Stack
 					direction="row"
 					justifyContent="flex-end"
+					alignItems="center"
+					gap={theme.spacing(LAYOUT.MD)}
 					sx={{
 						position: "sticky",
 						bottom: 0,
@@ -1082,10 +1084,7 @@ export const SettingsPage = () => {
 				>
 					{/* Validation Error Display */}
 					{Object.keys(form.formState.errors).length > 0 && (
-						<Alert
-							severity="error"
-							sx={{ mb: 2, flexGrow: 1, mr: 2 }}
-						>
+						<Alert severity="error">
 							<Typography
 								variant="body2"
 								sx={{ fontWeight: 600, mb: 1 }}

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -74,6 +74,60 @@ const tabForField = (field: string): SettingsTabKey =>
 		? "email"
 		: (FIELD_TAB[field.split(".")[0]] ?? "general");
 
+// Error rows named the raw schema key ("systemEmailRejectUnauthorized"). Each
+// field already owns a translated label, so reuse those rather than adding
+// strings. Labels that append an explanation after a dash are trimmed to the
+// name itself.
+const FIELD_LABEL_KEY: Record<string, string> = {
+	checkTTL: "pages.settings.form.retention.option.days.label",
+	"globalThresholds.cpu": "pages.settings.form.thresholds.option.cpu.label",
+	"globalThresholds.memory": "pages.settings.form.thresholds.option.memory.label",
+	"globalThresholds.disk": "pages.settings.form.thresholds.option.disk.label",
+	"globalThresholds.temperature":
+		"pages.settings.form.thresholds.option.temperature.label",
+	pagespeedApiKey: "pages.settings.form.pagespeed.option.apiKey.label",
+	globalProxyEnabled: "pages.settings.form.globalProxy.option.enabled.label",
+	showURL: "pages.settings.form.url.option.showURL.label",
+	systemEmailHost: "pages.settings.form.email.option.host.label",
+	systemEmailPort: "pages.settings.form.email.option.port.label",
+	systemEmailAddress: "pages.settings.form.email.option.address.label",
+	systemEmailDisplayName: "pages.settings.form.email.option.displayName.label",
+	systemEmailUser: "pages.settings.form.email.option.user.label",
+	systemEmailPassword: "pages.settings.form.email.option.password.label",
+	systemEmailTLSServername: "pages.settings.form.email.option.tlsServername.label",
+	systemEmailConnectionHost: "pages.settings.form.email.option.connectionHost.label",
+	systemEmailSecure: "pages.settings.form.email.option.secure.label",
+	systemEmailPool: "pages.settings.form.email.option.pool.label",
+	systemEmailIgnoreTLS: "pages.settings.form.email.option.ignoreTLS.label",
+	systemEmailRequireTLS: "pages.settings.form.email.option.requireTLS.label",
+	systemEmailRejectUnauthorized:
+		"pages.settings.form.email.option.rejectUnauthorized.label",
+};
+
+// react-hook-form nests errors by path, so a grouped field arrives as
+// { globalThresholds: { cpu: { message } } }. Iterating the top level alone
+// yields an entry whose own message is undefined, which renders as a bare
+// "globalThresholds" naming none of the four sliders. Walk to the leaves.
+type FieldErrorLeaf = { path: string; message?: string };
+
+const flattenFieldErrors = (errors: unknown, prefix = ""): FieldErrorLeaf[] => {
+	if (typeof errors !== "object" || errors === null) {
+		return [];
+	}
+	return Object.entries(errors).flatMap(([key, value]) => {
+		const path = prefix ? `${prefix}.${key}` : key;
+		if (typeof value !== "object" || value === null) {
+			return [];
+		}
+		const message = (value as { message?: unknown }).message;
+		if (typeof message === "string") {
+			return [{ path, message }];
+		}
+		const nested = flattenFieldErrors(value, path);
+		return nested.length > 0 ? nested : [{ path }];
+	});
+};
+
 export const SettingsPage = () => {
 	const theme = useTheme();
 	const { t, i18n } = useTranslation();
@@ -90,18 +144,33 @@ export const SettingsPage = () => {
 	// An unknown tab, or an admin tab requested by a non-admin, falls back to the
 	// first tab the current user can actually see.
 	const requestedTab = searchParams.get("tab");
+	// visibleTabs always contains "general" today; the constant fallback keeps a
+	// future gating change from throwing on an empty list.
+	const firstVisibleTab: SettingsTabKey = visibleTabs[0]?.key ?? SETTINGS_TABS[0].key;
 	const activeTab: SettingsTabKey =
-		visibleTabs.find((tab) => tab.key === requestedTab)?.key ?? visibleTabs[0].key;
+		visibleTabs.find((tab) => tab.key === requestedTab)?.key ?? firstVisibleTab;
 
 	const handleTabChange = (tab: SettingsTabKey) => {
 		const updated = new URLSearchParams(searchParams);
-		if (tab === visibleTabs[0].key) {
+		if (tab === firstVisibleTab) {
 			updated.delete("tab");
 		} else {
 			updated.set("tab", tab);
 		}
 		setSearchParams(updated, { replace: true });
 	};
+
+	// A "tab" that does not resolve -- an unknown key, or an admin tab followed by
+	// a non-admin -- leaves the URL claiming a tab the page is not showing. Drop it
+	// so the address bar matches what is rendered.
+	useEffect(() => {
+		if (requestedTab !== null && requestedTab !== activeTab) {
+			const updated = new URLSearchParams(searchParams);
+			updated.delete("tab");
+			setSearchParams(updated, { replace: true });
+		}
+	}, [requestedTab, activeTab, searchParams, setSearchParams]);
+
 	// Local state for demo monitors dialog
 	const [isDemoMonitorsDialogOpen, setIsDemoMonitorsDialogOpen] = useState(false);
 	const { post: postDemoMonitors, loading: isPostingDemoMonitors } = usePost();
@@ -1027,24 +1096,23 @@ export const SettingsPage = () => {
 								component="ul"
 								sx={{ m: 0, pl: 2 }}
 							>
-								{Object.entries(form.formState.errors).map(([field, error]) => {
-									const message =
-										typeof error === "object" && error?.message
-											? error.message
-											: "Invalid value";
+								{flattenFieldErrors(form.formState.errors).map(({ path, message }) => {
+									const labelKey = FIELD_LABEL_KEY[path];
+									// Labels read "Name - explanation"; keep the name.
+									const label = labelKey ? t(labelKey).split(" - ")[0] : path;
 									return (
-										<li key={field}>
+										<li key={path}>
 											<Typography variant="body2">
 												<Link
 													component="button"
 													type="button"
 													variant="body2"
 													color={theme.palette.error.main}
-													onClick={() => revealField(field)}
+													onClick={() => revealField(path)}
 												>
-													<strong>{field}</strong>
+													<strong>{label}</strong>
 												</Link>
-												: {message}
+												{message ? `: ${message}` : ""}
 											</Typography>
 										</li>
 									);

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -347,14 +347,16 @@ export const SettingsPage = () => {
 
 	const onError = (errors: unknown) => {
 		logger.debug("Form validation errors", errors);
-		// The save bar lists errors by field name, so reveal the tab owning the
-		// first one rather than naming a field the user cannot see.
-		const firstField = Object.keys(errors ?? {})[0];
-		if (firstField) {
-			const target = tabForField(firstField);
-			if (visibleTabs.some((tab) => tab.key === target)) {
-				handleTabChange(target);
-			}
+	};
+
+	// The save bar lists errors by field name, and the offending field may sit on
+	// a tab that is not open. Submitting cannot reveal it -- the button is
+	// disabled while the form is invalid -- so each listed field switches to its
+	// own tab instead.
+	const revealField = (field: string) => {
+		const target = tabForField(field);
+		if (visibleTabs.some((tab) => tab.key === target)) {
+			handleTabChange(target);
 		}
 	};
 
@@ -398,272 +400,229 @@ export const SettingsPage = () => {
 				)}
 
 				{/* general tab */}
-				<Stack
-					gap={theme.spacing(LAYOUT.MD)}
-					hidden={activeTab !== "general"}
-				>
-					<ConfigBox
-						title={t("pages.settings.form.timezone.title")}
-						subtitle={t("pages.settings.form.timezone.description")}
-						rightContent={
-							<Autocomplete
-								value={selectedTimezone}
-								options={timezoneOptions}
-								getOptionLabel={(option: TimezoneOption) => option.name}
-								isOptionEqualToValue={(option: TimezoneOption, value: TimezoneOption) =>
-									option.id === value.id
-								}
-								onChange={(_, newValue: TimezoneOption | null) => {
-									handleTimezoneChange(newValue);
-								}}
-								fieldLabel={t("pages.settings.form.timezone.option.timezone.label")}
-							/>
-						}
-					/>
-					<ConfigBox
-						title={t("pages.settings.form.ui.title")}
-						subtitle={t("pages.settings.form.ui.description")}
-						rightContent={
-							<Stack gap={theme.spacing(LAYOUT.MD)}>
-								<Select
-									value={mode}
-									onChange={handleModeChange}
-									fieldLabel={t("pages.settings.form.ui.option.theme.label")}
-								>
-									<MenuItem value="light">
-										{t("pages.settings.form.ui.option.theme.light")}
-									</MenuItem>
-									<MenuItem value="dark">
-										{t("pages.settings.form.ui.option.theme.dark")}
-									</MenuItem>
-								</Select>
-								<Select
-									value={language}
-									onChange={handleLanguageChange}
-									fieldLabel={t("pages.settings.form.ui.option.language.label")}
-								>
-									{languages.map((lang) => (
-										<MenuItem
-											key={lang}
-											value={lang}
-										>
-											{languageNames[lang] ?? lang}
-										</MenuItem>
-									))}
-								</Select>
-								<Select
-									value={chartType}
-									onChange={handleChartTypeChange}
-									fieldLabel={t("pages.settings.form.ui.option.chartType.label")}
-								>
-									<MenuItem value="histogram">
-										{t("pages.settings.form.ui.option.chartType.histogram")}
-									</MenuItem>
-									<MenuItem value="heatmap">
-										{t("pages.settings.form.ui.option.chartType.heatmap")}
-									</MenuItem>
-								</Select>
-								<DummyChart chartType={chartType} />
-							</Stack>
-						}
-					/>
-					{/* URL Settings */}
-					<ConfigBox
-						title={t("pages.settings.form.url.title")}
-						subtitle={t("pages.settings.form.url.description")}
-						rightContent={
-							<FormSwitchField
-								name="showURL"
-								label={t("pages.settings.form.url.option.showURL.label")}
-								labelPlacement="start"
-							/>
-						}
-					/>
-					{/* About */}
-					<ConfigBox
-						title={t("pages.settings.form.about.title")}
-						subtitle=""
-						rightContent={
-							<Stack spacing={2}>
-								<Typography variant="body1">
-									{t("common.appName")} {__APP_VERSION__}
-								</Typography>
-								<Typography
-									variant="body2"
-									sx={{ opacity: 0.6 }}
-								>
-									{t("pages.settings.form.about.developedBy")}
-								</Typography>
-								<Link
-									href="https://github.com/bluewave-labs/checkmate"
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									https://github.com/bluewave-labs/checkmate
-								</Link>
-							</Stack>
-						}
-					/>
-				</Stack>
-
-				{/* monitoring tab */}
-				<Stack
-					gap={theme.spacing(LAYOUT.MD)}
-					hidden={activeTab !== "monitoring"}
-				>
-					{/* Global Thresholds */}
-					{isAdmin && (
+				{activeTab === "general" && (
+					<Stack gap={theme.spacing(LAYOUT.MD)}>
 						<ConfigBox
-							title={t("pages.settings.form.thresholds.title")}
-							subtitle={t("pages.settings.form.thresholds.description")}
+							title={t("pages.settings.form.timezone.title")}
+							subtitle={t("pages.settings.form.timezone.description")}
 							rightContent={
-								<Stack spacing={2}>
-									<FormSliderField
-										name="globalThresholds.cpu"
-										fieldLabel={t("pages.settings.form.thresholds.option.cpu.label")}
-										valueLabelDisplay="auto"
-										min={1}
-										max={100}
-									/>
-									<FormSliderField
-										name="globalThresholds.memory"
-										fieldLabel={t("pages.settings.form.thresholds.option.memory.label")}
-										valueLabelDisplay="auto"
-										min={1}
-										max={100}
-									/>
-									<FormSliderField
-										name="globalThresholds.disk"
-										fieldLabel={t("pages.settings.form.thresholds.option.disk.label")}
-										valueLabelDisplay="auto"
-										min={1}
-										max={100}
-									/>
-
-									<FormSliderField
-										name="globalThresholds.temperature"
-										fieldLabel={t(
-											"pages.settings.form.thresholds.option.temperature.label"
-										)}
-										valueLabelDisplay="auto"
-										min={1}
-										max={150}
-									/>
-								</Stack>
-							}
-						/>
-					)}
-					{/* Check Retention */}
-					{isAdmin && (
-						<ConfigBox
-							title={t("pages.settings.form.retention.title")}
-							subtitle={t("pages.settings.form.retention.description")}
-							rightContent={
-								<FormSliderField
-									name="checkTTL"
-									fieldLabel={t("pages.settings.form.retention.option.days.label")}
-									min={1}
-									max={CHECK_TTL_SENTINEL}
-									valueLabelDisplay="auto"
-									valueLabelFormat={(value: number) =>
-										value >= CHECK_TTL_SENTINEL
-											? t("pages.settings.form.retention.option.days.unlimited")
-											: `${value}`
+								<Autocomplete
+									value={selectedTimezone}
+									options={timezoneOptions}
+									getOptionLabel={(option: TimezoneOption) => option.name}
+									isOptionEqualToValue={(option: TimezoneOption, value: TimezoneOption) =>
+										option.id === value.id
 									}
-									formatDisplayValue={(value: number) =>
-										value >= CHECK_TTL_SENTINEL
-											? t("pages.settings.form.retention.option.days.unlimited")
-											: `${value}`
-									}
+									onChange={(_, newValue: TimezoneOption | null) => {
+										handleTimezoneChange(newValue);
+									}}
+									fieldLabel={t("pages.settings.form.timezone.option.timezone.label")}
 								/>
 							}
 						/>
-					)}
-
-					{/* Demo Monitors - Admin Only */}
-					{isAdmin && (
 						<ConfigBox
-							title={t("pages.settings.form.demoMonitors.title")}
-							subtitle={t("pages.settings.form.demoMonitors.description")}
+							title={t("pages.settings.form.ui.title")}
+							subtitle={t("pages.settings.form.ui.description")}
 							rightContent={
-								<Box>
-									<Button
-										variant="contained"
-										loading={isPostingDemoMonitors}
-										onClick={async () => {
-											await postDemoMonitors("/monitors/demo", {});
-										}}
+								<Stack gap={theme.spacing(LAYOUT.MD)}>
+									<Select
+										value={mode}
+										onChange={handleModeChange}
+										fieldLabel={t("pages.settings.form.ui.option.theme.label")}
 									>
-										{t("common.buttons.addDemo")}
-									</Button>
-								</Box>
+										<MenuItem value="light">
+											{t("pages.settings.form.ui.option.theme.light")}
+										</MenuItem>
+										<MenuItem value="dark">
+											{t("pages.settings.form.ui.option.theme.dark")}
+										</MenuItem>
+									</Select>
+									<Select
+										value={language}
+										onChange={handleLanguageChange}
+										fieldLabel={t("pages.settings.form.ui.option.language.label")}
+									>
+										{languages.map((lang) => (
+											<MenuItem
+												key={lang}
+												value={lang}
+											>
+												{languageNames[lang] ?? lang}
+											</MenuItem>
+										))}
+									</Select>
+									<Select
+										value={chartType}
+										onChange={handleChartTypeChange}
+										fieldLabel={t("pages.settings.form.ui.option.chartType.label")}
+									>
+										<MenuItem value="histogram">
+											{t("pages.settings.form.ui.option.chartType.histogram")}
+										</MenuItem>
+										<MenuItem value="heatmap">
+											{t("pages.settings.form.ui.option.chartType.heatmap")}
+										</MenuItem>
+									</Select>
+									<DummyChart chartType={chartType} />
+								</Stack>
 							}
 						/>
-					)}
-				</Stack>
+						{/* URL Settings */}
+						<ConfigBox
+							title={t("pages.settings.form.url.title")}
+							subtitle={t("pages.settings.form.url.description")}
+							rightContent={
+								<FormSwitchField
+									name="showURL"
+									label={t("pages.settings.form.url.option.showURL.label")}
+									labelPlacement="start"
+								/>
+							}
+						/>
+						{/* About */}
+						<ConfigBox
+							title={t("pages.settings.form.about.title")}
+							subtitle=""
+							rightContent={
+								<Stack spacing={2}>
+									<Typography variant="body1">
+										{t("common.appName")} {__APP_VERSION__}
+									</Typography>
+									<Typography
+										variant="body2"
+										sx={{ opacity: 0.6 }}
+									>
+										{t("pages.settings.form.about.developedBy")}
+									</Typography>
+									<Link
+										href="https://github.com/bluewave-labs/checkmate"
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										https://github.com/bluewave-labs/checkmate
+									</Link>
+								</Stack>
+							}
+						/>
+					</Stack>
+				)}
+
+				{/* monitoring tab */}
+				{activeTab === "monitoring" && (
+					<Stack gap={theme.spacing(LAYOUT.MD)}>
+						{/* Global Thresholds */}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.thresholds.title")}
+								subtitle={t("pages.settings.form.thresholds.description")}
+								rightContent={
+									<Stack spacing={2}>
+										<FormSliderField
+											name="globalThresholds.cpu"
+											fieldLabel={t("pages.settings.form.thresholds.option.cpu.label")}
+											valueLabelDisplay="auto"
+											min={1}
+											max={100}
+										/>
+										<FormSliderField
+											name="globalThresholds.memory"
+											fieldLabel={t("pages.settings.form.thresholds.option.memory.label")}
+											valueLabelDisplay="auto"
+											min={1}
+											max={100}
+										/>
+										<FormSliderField
+											name="globalThresholds.disk"
+											fieldLabel={t("pages.settings.form.thresholds.option.disk.label")}
+											valueLabelDisplay="auto"
+											min={1}
+											max={100}
+										/>
+
+										<FormSliderField
+											name="globalThresholds.temperature"
+											fieldLabel={t(
+												"pages.settings.form.thresholds.option.temperature.label"
+											)}
+											valueLabelDisplay="auto"
+											min={1}
+											max={150}
+										/>
+									</Stack>
+								}
+							/>
+						)}
+						{/* Check Retention */}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.retention.title")}
+								subtitle={t("pages.settings.form.retention.description")}
+								rightContent={
+									<FormSliderField
+										name="checkTTL"
+										fieldLabel={t("pages.settings.form.retention.option.days.label")}
+										min={1}
+										max={CHECK_TTL_SENTINEL}
+										valueLabelDisplay="auto"
+										valueLabelFormat={(value: number) =>
+											value >= CHECK_TTL_SENTINEL
+												? t("pages.settings.form.retention.option.days.unlimited")
+												: `${value}`
+										}
+										formatDisplayValue={(value: number) =>
+											value >= CHECK_TTL_SENTINEL
+												? t("pages.settings.form.retention.option.days.unlimited")
+												: `${value}`
+										}
+									/>
+								}
+							/>
+						)}
+
+						{/* Demo Monitors - Admin Only */}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.demoMonitors.title")}
+								subtitle={t("pages.settings.form.demoMonitors.description")}
+								rightContent={
+									<Box>
+										<Button
+											variant="contained"
+											loading={isPostingDemoMonitors}
+											onClick={async () => {
+												await postDemoMonitors("/monitors/demo", {});
+											}}
+										>
+											{t("common.buttons.addDemo")}
+										</Button>
+									</Box>
+								}
+							/>
+						)}
+					</Stack>
+				)}
 
 				{/* email tab */}
-				<Stack
-					gap={theme.spacing(LAYOUT.MD)}
-					hidden={activeTab !== "email"}
-				>
-					{/* Email Settings - Admin Only */}
-					{isAdmin && (
-						<ConfigBox
-							title={t("pages.settings.form.email.title")}
-							subtitle={t("pages.settings.form.email.description")}
-							leftContent={
-								<Stack gap={theme.spacing(LAYOUT.MD)}>
-									<TextLink
-										text={t("pages.settings.form.email.descriptionTransport")}
-										linkText={t("pages.settings.form.email.descriptionTransportLink")}
-										href="https://nodemailer.com/smtp/"
-										target="_blank"
-									/>
-									{(() => {
-										const address = form.watch("systemEmailAddress") || "";
-										const displayName = form.watch("systemEmailDisplayName")?.trim();
-										return (
-											<>
-												<Box
-													component="pre"
-													p={2}
-													borderRadius={theme.shape.borderRadius}
-													bgcolor={theme.palette.action.hover}
-													sx={{
-														fontFamily: theme.typography.fontFamilyMonospace,
-														overflow: "auto",
-													}}
-												>
-													<code>
-														{JSON.stringify(
-															{
-																host: form.watch("systemEmailHost") || "",
-																port: form.watch("systemEmailPort") || "",
-																secure: form.watch("systemEmailSecure") ?? false,
-																auth: {
-																	user: form.watch("systemEmailUser") || address,
-																	pass: "<your_password>",
-																},
-																name:
-																	form.watch("systemEmailConnectionHost") || "localhost",
-																pool: form.watch("systemEmailPool") ?? false,
-																tls: {
-																	rejectUnauthorized:
-																		form.watch("systemEmailRejectUnauthorized") ?? true,
-																	ignoreTLS: form.watch("systemEmailIgnoreTLS") ?? false,
-																	requireTLS:
-																		form.watch("systemEmailRequireTLS") ?? false,
-																	servername:
-																		form.watch("systemEmailTLSServername") || "",
-																},
-															},
-															null,
-															2
-														)}
-													</code>
-												</Box>
-												{address && (
+				{activeTab === "email" && (
+					<Stack gap={theme.spacing(LAYOUT.MD)}>
+						{/* Email Settings - Admin Only */}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.email.title")}
+								subtitle={t("pages.settings.form.email.description")}
+								leftContent={
+									<Stack gap={theme.spacing(LAYOUT.MD)}>
+										<TextLink
+											text={t("pages.settings.form.email.descriptionTransport")}
+											linkText={t("pages.settings.form.email.descriptionTransportLink")}
+											href="https://nodemailer.com/smtp/"
+											target="_blank"
+										/>
+										{(() => {
+											const address = form.watch("systemEmailAddress") || "";
+											const displayName = form.watch("systemEmailDisplayName")?.trim();
+											return (
+												<>
 													<Box
 														component="pre"
 														p={2}
@@ -675,299 +634,343 @@ export const SettingsPage = () => {
 														}}
 													>
 														<code>
-															{`From: ${displayName ? `"${displayName}" <${address}>` : address}`}
+															{JSON.stringify(
+																{
+																	host: form.watch("systemEmailHost") || "",
+																	port: form.watch("systemEmailPort") || "",
+																	secure: form.watch("systemEmailSecure") ?? false,
+																	auth: {
+																		user: form.watch("systemEmailUser") || address,
+																		pass: "<your_password>",
+																	},
+																	name:
+																		form.watch("systemEmailConnectionHost") ||
+																		"localhost",
+																	pool: form.watch("systemEmailPool") ?? false,
+																	tls: {
+																		rejectUnauthorized:
+																			form.watch("systemEmailRejectUnauthorized") ?? true,
+																		ignoreTLS:
+																			form.watch("systemEmailIgnoreTLS") ?? false,
+																		requireTLS:
+																			form.watch("systemEmailRequireTLS") ?? false,
+																		servername:
+																			form.watch("systemEmailTLSServername") || "",
+																	},
+																},
+																null,
+																2
+															)}
 														</code>
 													</Box>
+													{address && (
+														<Box
+															component="pre"
+															p={2}
+															borderRadius={theme.shape.borderRadius}
+															bgcolor={theme.palette.action.hover}
+															sx={{
+																fontFamily: theme.typography.fontFamilyMonospace,
+																overflow: "auto",
+															}}
+														>
+															<code>
+																{`From: ${displayName ? `"${displayName}" <${address}>` : address}`}
+															</code>
+														</Box>
+													)}
+												</>
+											);
+										})()}
+									</Stack>
+								}
+								rightContent={
+									<Stack gap={theme.spacing(LAYOUT.MD)}>
+										{/* Email Host */}
+										<FormTextField
+											name="systemEmailHost"
+											fieldLabel={t("pages.settings.form.email.option.host.label")}
+											placeholder={t("pages.settings.form.email.option.host.placeholder")}
+										/>
+
+										{/* Email Port */}
+										<FormNumberField
+											name="systemEmailPort"
+											fieldLabel={t("pages.settings.form.email.option.port.label")}
+											placeholder={t("pages.settings.form.email.option.port.placeholder")}
+										/>
+
+										{/* Email Address */}
+										<FormTextField
+											name="systemEmailAddress"
+											type="email"
+											fieldLabel={t("pages.settings.form.email.option.address.label")}
+											placeholder={t(
+												"pages.settings.form.email.option.address.placeholder"
+											)}
+										/>
+
+										{/* Email Display Name (Optional) */}
+										<FormTextField
+											name="systemEmailDisplayName"
+											fieldLabel={t("pages.settings.form.email.option.displayName.label")}
+											placeholder={t(
+												"pages.settings.form.email.option.displayName.placeholder"
+											)}
+										/>
+
+										{/* Email User (Optional) */}
+										<FormTextField
+											name="systemEmailUser"
+											fieldLabel={t("pages.settings.form.email.option.user.label")}
+											placeholder={t("pages.settings.form.email.option.user.placeholder")}
+										/>
+
+										{/* Email Password with Reset Pattern */}
+										{isEmailPasswordSet && !emailPasswordHasBeenReset ? (
+											<Box>
+												<FieldLabel>
+													{t("pages.settings.form.email.option.password.labelSet")}
+												</FieldLabel>
+												<Stack
+													direction="row"
+													alignItems="center"
+													gap={theme.spacing(LAYOUT.XS)}
+												>
+													<Button
+														variant="contained"
+														color="error"
+														size="small"
+														onClick={handleResetEmailPassword}
+													>
+														{t("common.buttons.reset")}
+													</Button>
+												</Stack>
+											</Box>
+										) : (
+											<FormTextField
+												name="systemEmailPassword"
+												type="password"
+												fieldLabel={t("pages.settings.form.email.option.password.label")}
+												placeholder={t(
+													"pages.settings.form.email.option.password.placeholder"
 												)}
-											</>
-										);
-									})()}
-								</Stack>
-							}
-							rightContent={
-								<Stack gap={theme.spacing(LAYOUT.MD)}>
-									{/* Email Host */}
-									<FormTextField
-										name="systemEmailHost"
-										fieldLabel={t("pages.settings.form.email.option.host.label")}
-										placeholder={t("pages.settings.form.email.option.host.placeholder")}
-									/>
-
-									{/* Email Port */}
-									<FormNumberField
-										name="systemEmailPort"
-										fieldLabel={t("pages.settings.form.email.option.port.label")}
-										placeholder={t("pages.settings.form.email.option.port.placeholder")}
-									/>
-
-									{/* Email Address */}
-									<FormTextField
-										name="systemEmailAddress"
-										type="email"
-										fieldLabel={t("pages.settings.form.email.option.address.label")}
-										placeholder={t(
-											"pages.settings.form.email.option.address.placeholder"
+											/>
 										)}
-									/>
 
-									{/* Email Display Name (Optional) */}
-									<FormTextField
-										name="systemEmailDisplayName"
-										fieldLabel={t("pages.settings.form.email.option.displayName.label")}
-										placeholder={t(
-											"pages.settings.form.email.option.displayName.placeholder"
-										)}
-									/>
+										{/* TLS Servername (Optional) */}
+										<FormTextField
+											name="systemEmailTLSServername"
+											fieldLabel={t(
+												"pages.settings.form.email.option.tlsServername.label"
+											)}
+											placeholder={t(
+												"pages.settings.form.email.option.tlsServername.placeholder"
+											)}
+										/>
 
-									{/* Email User (Optional) */}
-									<FormTextField
-										name="systemEmailUser"
-										fieldLabel={t("pages.settings.form.email.option.user.label")}
-										placeholder={t("pages.settings.form.email.option.user.placeholder")}
-									/>
+										{/* Connection Host (Optional) */}
+										<FormTextField
+											name="systemEmailConnectionHost"
+											fieldLabel={t(
+												"pages.settings.form.email.option.connectionHost.label"
+											)}
+											placeholder={t(
+												"pages.settings.form.email.option.connectionHost.placeholder"
+											)}
+										/>
 
-									{/* Email Password with Reset Pattern */}
-									{isEmailPasswordSet && !emailPasswordHasBeenReset ? (
+										{/* Boolean Switches */}
+										<Box
+											display={"flex"}
+											flexDirection={"column"}
+											gap={theme.spacing(LAYOUT.XS)}
+										>
+											{emailSwitches.map(({ name, label }) => (
+												<FormSwitchField
+													key={name}
+													name={name}
+													label={label}
+													labelPlacement="start"
+												/>
+											))}
+										</Box>
+
+										{/* Test Email Button */}
 										<Box>
-											<FieldLabel>
-												{t("pages.settings.form.email.option.password.labelSet")}
-											</FieldLabel>
-											<Stack
-												direction="row"
-												alignItems="center"
-												gap={theme.spacing(LAYOUT.XS)}
+											<Button
+												variant="contained"
+												loading={isSendingTestEmail}
+												onClick={handleSendTestEmail}
+												disabled={
+													!form.watch("systemEmailHost") ||
+													!form.watch("systemEmailPort") ||
+													!form.watch("systemEmailAddress") ||
+													!form.watch("systemEmailPassword")
+												}
 											>
+												{t("common.buttons.sendTestEmail")}
+											</Button>
+										</Box>
+									</Stack>
+								}
+							/>
+						)}
+					</Stack>
+				)}
+
+				{/* integrations tab */}
+				{activeTab === "integrations" && (
+					<Stack gap={theme.spacing(LAYOUT.MD)}>
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.globalProxy.title")}
+								subtitle={t("pages.settings.form.globalProxy.description")}
+								rightContent={
+									proxyOptions.length > 0 ? (
+										<Stack>
+											<FormSwitchField
+												name="globalProxyEnabled"
+												labelPlacement="start"
+												label={t("pages.settings.form.globalProxy.option.enabled.label")}
+											/>
+											{globalProxyEnabled && (
+												<FormSelectField
+													fieldLabel={t(
+														"pages.settings.form.globalProxy.option.proxy.label"
+													)}
+													name="globalProxyId"
+													options={proxyOptions}
+												/>
+											)}
+										</Stack>
+									) : (
+										<TextLink
+											text={t("pages.settings.form.globalProxy.option.empty.text")}
+											linkText={t("pages.settings.form.globalProxy.option.empty.link")}
+											href="/proxies"
+										/>
+									)
+								}
+							/>
+						)}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.pagespeed.title")}
+								subtitle={t("pages.settings.form.pagespeed.description")}
+								rightContent={
+									<>
+										{(isApiKeySet === false || apiKeyHasBeenReset === true) && (
+											<FormTextField
+												name="pagespeedApiKey"
+												type="password"
+												fieldLabel={t(
+													"pages.settings.form.pagespeed.option.apiKey.label"
+												)}
+												placeholder={t(
+													"pages.settings.form.pagespeed.option.apiKey.placeholder"
+												)}
+											/>
+										)}
+
+										{isApiKeySet === true && apiKeyHasBeenReset === false && (
+											<Box>
+												<FieldLabel>
+													{t("pages.settings.form.pagespeed.option.apiKey.labelSet")}
+												</FieldLabel>
 												<Button
+													onClick={handleResetApiKey}
 													variant="contained"
 													color="error"
-													size="small"
-													onClick={handleResetEmailPassword}
 												>
 													{t("common.buttons.reset")}
 												</Button>
-											</Stack>
-										</Box>
-									) : (
-										<FormTextField
-											name="systemEmailPassword"
-											type="password"
-											fieldLabel={t("pages.settings.form.email.option.password.label")}
-											placeholder={t(
-												"pages.settings.form.email.option.password.placeholder"
-											)}
-										/>
-									)}
-
-									{/* TLS Servername (Optional) */}
-									<FormTextField
-										name="systemEmailTLSServername"
-										fieldLabel={t("pages.settings.form.email.option.tlsServername.label")}
-										placeholder={t(
-											"pages.settings.form.email.option.tlsServername.placeholder"
+											</Box>
 										)}
-									/>
-
-									{/* Connection Host (Optional) */}
-									<FormTextField
-										name="systemEmailConnectionHost"
-										fieldLabel={t(
-											"pages.settings.form.email.option.connectionHost.label"
-										)}
-										placeholder={t(
-											"pages.settings.form.email.option.connectionHost.placeholder"
-										)}
-									/>
-
-									{/* Boolean Switches */}
-									<Box
-										display={"flex"}
-										flexDirection={"column"}
-										gap={theme.spacing(LAYOUT.XS)}
-									>
-										{emailSwitches.map(({ name, label }) => (
-											<FormSwitchField
-												key={name}
-												name={name}
-												label={label}
-												labelPlacement="start"
-											/>
-										))}
-									</Box>
-
-									{/* Test Email Button */}
-									<Box>
-										<Button
-											variant="contained"
-											loading={isSendingTestEmail}
-											onClick={handleSendTestEmail}
-											disabled={
-												!form.watch("systemEmailHost") ||
-												!form.watch("systemEmailPort") ||
-												!form.watch("systemEmailAddress") ||
-												!form.watch("systemEmailPassword")
-											}
-										>
-											{t("common.buttons.sendTestEmail")}
-										</Button>
-									</Box>
-								</Stack>
-							}
-						/>
-					)}
-				</Stack>
-
-				{/* integrations tab */}
-				<Stack
-					gap={theme.spacing(LAYOUT.MD)}
-					hidden={activeTab !== "integrations"}
-				>
-					{isAdmin && (
-						<ConfigBox
-							title={t("pages.settings.form.globalProxy.title")}
-							subtitle={t("pages.settings.form.globalProxy.description")}
-							rightContent={
-								proxyOptions.length > 0 ? (
-									<Stack>
-										<FormSwitchField
-											name="globalProxyEnabled"
-											labelPlacement="start"
-											label={t("pages.settings.form.globalProxy.option.enabled.label")}
-										/>
-										{globalProxyEnabled && (
-											<FormSelectField
-												fieldLabel={t(
-													"pages.settings.form.globalProxy.option.proxy.label"
-												)}
-												name="globalProxyId"
-												options={proxyOptions}
-											/>
-										)}
-									</Stack>
-								) : (
-									<TextLink
-										text={t("pages.settings.form.globalProxy.option.empty.text")}
-										linkText={t("pages.settings.form.globalProxy.option.empty.link")}
-										href="/proxies"
-									/>
-								)
-							}
-						/>
-					)}
-					{isAdmin && (
-						<ConfigBox
-							title={t("pages.settings.form.pagespeed.title")}
-							subtitle={t("pages.settings.form.pagespeed.description")}
-							rightContent={
-								<>
-									{(isApiKeySet === false || apiKeyHasBeenReset === true) && (
-										<FormTextField
-											name="pagespeedApiKey"
-											type="password"
-											fieldLabel={t("pages.settings.form.pagespeed.option.apiKey.label")}
-											placeholder={t(
-												"pages.settings.form.pagespeed.option.apiKey.placeholder"
-											)}
-										/>
-									)}
-
-									{isApiKeySet === true && apiKeyHasBeenReset === false && (
-										<Box>
-											<FieldLabel>
-												{t("pages.settings.form.pagespeed.option.apiKey.labelSet")}
-											</FieldLabel>
-											<Button
-												onClick={handleResetApiKey}
-												variant="contained"
-												color="error"
-											>
-												{t("common.buttons.reset")}
-											</Button>
-										</Box>
-									)}
-								</>
-							}
-						/>
-					)}
-				</Stack>
+									</>
+								}
+							/>
+						)}
+					</Stack>
+				)}
 
 				{/* data tab */}
-				<Stack
-					gap={theme.spacing(LAYOUT.MD)}
-					hidden={activeTab !== "data"}
-				>
-					{/* Export Monitors - Admin Only */}
-					{isAdmin && (
-						<ConfigBox
-							title={t("pages.settings.form.importExportMonitors.title")}
-							subtitle={t("pages.settings.form.importExportMonitors.description")}
-							rightContent={
-								<Stack
-									gap={theme.spacing(LAYOUT.MD)}
-									direction={"row"}
-								>
-									<input
-										id="monitor-import-input"
-										type="file"
-										accept=".json"
-										style={{ display: "none" }}
-										onChange={handleFileSelect}
-									/>
-									<Button
-										variant="contained"
-										onClick={() =>
-											document.getElementById("monitor-import-input")?.click()
-										}
-										disabled={isImportingMonitors}
+				{activeTab === "data" && (
+					<Stack gap={theme.spacing(LAYOUT.MD)}>
+						{/* Export Monitors - Admin Only */}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.importExportMonitors.title")}
+								subtitle={t("pages.settings.form.importExportMonitors.description")}
+								rightContent={
+									<Stack
+										gap={theme.spacing(LAYOUT.MD)}
+										direction={"row"}
 									>
-										{t("common.buttons.importFromJSON")}
-									</Button>
-									<Button
-										variant="contained"
-										onClick={handleExportMonitors}
-									>
-										{t("common.buttons.exportToJSON")}
-									</Button>
-								</Stack>
-							}
-						/>
-					)}
-					{/* Clear All Stats */}
-					{isAdmin && (
-						<ConfigBox
-							title={t("pages.settings.form.stats.title")}
-							subtitle={t("pages.settings.form.stats.description")}
-							rightContent={
-								<Button
-									variant="contained"
-									color="error"
-									onClick={() => setIsStatsDialogOpen(true)}
-								>
-									{t("common.buttons.clear")}
-								</Button>
-							}
-						/>
-					)}
-
-					{/* Remove All Monitors - Admin Only */}
-					{isAdmin && (
-						<ConfigBox
-							title={t("pages.settings.form.removeMonitors.title")}
-							subtitle={t("pages.settings.form.removeMonitors.description")}
-							rightContent={
-								<Box>
+										<input
+											id="monitor-import-input"
+											type="file"
+											accept=".json"
+											style={{ display: "none" }}
+											onChange={handleFileSelect}
+										/>
+										<Button
+											variant="contained"
+											onClick={() =>
+												document.getElementById("monitor-import-input")?.click()
+											}
+											disabled={isImportingMonitors}
+										>
+											{t("common.buttons.importFromJSON")}
+										</Button>
+										<Button
+											variant="contained"
+											onClick={handleExportMonitors}
+										>
+											{t("common.buttons.exportToJSON")}
+										</Button>
+									</Stack>
+								}
+							/>
+						)}
+						{/* Clear All Stats */}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.stats.title")}
+								subtitle={t("pages.settings.form.stats.description")}
+								rightContent={
 									<Button
 										variant="contained"
 										color="error"
-										loading={isDeletingAllMonitors}
-										onClick={() => setIsDemoMonitorsDialogOpen(true)}
+										onClick={() => setIsStatsDialogOpen(true)}
 									>
-										{t("common.buttons.removeMonitors")}
+										{t("common.buttons.clear")}
 									</Button>
-								</Box>
-							}
-						/>
-					)}
-				</Stack>
+								}
+							/>
+						)}
+
+						{/* Remove All Monitors - Admin Only */}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.removeMonitors.title")}
+								subtitle={t("pages.settings.form.removeMonitors.description")}
+								rightContent={
+									<Box>
+										<Button
+											variant="contained"
+											color="error"
+											loading={isDeletingAllMonitors}
+											onClick={() => setIsDemoMonitorsDialogOpen(true)}
+										>
+											{t("common.buttons.removeMonitors")}
+										</Button>
+									</Box>
+								}
+							/>
+						)}
+					</Stack>
+				)}
 
 				{/* Clear Stats Confirmation Dialog */}
 				<Dialog
@@ -1032,7 +1035,16 @@ export const SettingsPage = () => {
 									return (
 										<li key={field}>
 											<Typography variant="body2">
-												<strong>{field}:</strong> {message}
+												<Link
+													component="button"
+													type="button"
+													variant="body2"
+													color={theme.palette.error.main}
+													onClick={() => revealField(field)}
+												>
+													<strong>{field}</strong>
+												</Link>
+												: {message}
 											</Typography>
 										</li>
 									);

--- a/client/src/locales/ar.json
+++ b/client/src/locales/ar.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "عام",
+				"monitoring": "المراقبة",
+				"email": "البريد الإلكتروني",
+				"integrations": "التكاملات",
+				"data": "البيانات"
+			},
 			"form": {
 				"timezone": {
 					"title": "المنطقة الزمنية للعرض",

--- a/client/src/locales/ca.json
+++ b/client/src/locales/ca.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "General",
+				"monitoring": "Monitoratge",
+				"email": "Correu electrònic",
+				"integrations": "Integracions",
+				"data": "Dades"
+			},
 			"form": {
 				"timezone": {
 					"title": "Zona horària de visualització",

--- a/client/src/locales/cs.json
+++ b/client/src/locales/cs.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Obecné",
+				"monitoring": "Monitorování",
+				"email": "E-mail",
+				"integrations": "Integrace",
+				"data": "Data"
+			},
 			"form": {
 				"timezone": {
 					"title": "Zobrazované časové pásmo",

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Allgemein",
+				"monitoring": "Überwachung",
+				"email": "E-Mail",
+				"integrations": "Integrationen",
+				"data": "Daten"
+			},
 			"form": {
 				"timezone": {
 					"title": "Anzeigesprache Zeitzone",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1333,6 +1333,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "General",
+				"monitoring": "Monitoring",
+				"email": "Email",
+				"integrations": "Integrations",
+				"data": "Data"
+			},
 			"form": {
 				"timezone": {
 					"title": "Display timezone",
@@ -1390,7 +1397,7 @@
 					}
 				},
 				"url": {
-					"title": "Monitor IP/URL on Status Page",
+					"title": "Monitor IP/URL on status page",
 					"description": "Display the IP address or URL of monitor on the public Status page. If it's disabled, only the monitor name will be shown to protect sensitive information.",
 					"option": {
 						"showURL": {
@@ -1422,7 +1429,7 @@
 					}
 				},
 				"thresholds": {
-					"title": "Global Thresholds",
+					"title": "Global thresholds",
 					"description": "Set global CPU, Memory, Disk, and Temperature thresholds for infrastructure monitoring. These apply to all hardware monitors unless overridden.",
 					"option": {
 						"cpu": {

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "General",
+				"monitoring": "Monitorización",
+				"email": "Correo electrónico",
+				"integrations": "Integraciones",
+				"data": "Datos"
+			},
 			"form": {
 				"timezone": {
 					"title": "Zona horaria de visualización",

--- a/client/src/locales/fi.json
+++ b/client/src/locales/fi.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Yleiset",
+				"monitoring": "Valvonta",
+				"email": "Sähköposti",
+				"integrations": "Integraatiot",
+				"data": "Tiedot"
+			},
 			"form": {
 				"timezone": {
 					"title": "Näytettävä aikavyöhyke",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Général",
+				"monitoring": "Surveillance",
+				"email": "E-mail",
+				"integrations": "Intégrations",
+				"data": "Données"
+			},
 			"form": {
 				"timezone": {
 					"title": "Fuseau horaire d'affichage",

--- a/client/src/locales/it.json
+++ b/client/src/locales/it.json
@@ -1237,6 +1237,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Generale",
+				"monitoring": "Monitoraggio",
+				"email": "Email",
+				"integrations": "Integrazioni",
+				"data": "Dati"
+			},
 			"form": {
 				"timezone": {
 					"title": "Fuso orario di visualizzazione",

--- a/client/src/locales/ja.json
+++ b/client/src/locales/ja.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "一般",
+				"monitoring": "監視",
+				"email": "メール",
+				"integrations": "連携",
+				"data": "データ"
+			},
 			"form": {
 				"timezone": {
 					"title": "表示タイムゾーン",

--- a/client/src/locales/pl.json
+++ b/client/src/locales/pl.json
@@ -1207,6 +1207,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Ogólne",
+				"monitoring": "Monitorowanie",
+				"email": "E-mail",
+				"integrations": "Integracje",
+				"data": "Dane"
+			},
 			"form": {
 				"about": {
 					"developedBy": "Opracowane przez Bluewave Labs",

--- a/client/src/locales/pt-BR.json
+++ b/client/src/locales/pt-BR.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Geral",
+				"monitoring": "Monitoramento",
+				"email": "E-mail",
+				"integrations": "Integrações",
+				"data": "Dados"
+			},
 			"form": {
 				"timezone": {
 					"title": "Fuso horário de exibição",

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Общие",
+				"monitoring": "Мониторинг",
+				"email": "Электронная почта",
+				"integrations": "Интеграции",
+				"data": "Данные"
+			},
 			"form": {
 				"timezone": {
 					"title": "Часовой пояс отображения",

--- a/client/src/locales/th.json
+++ b/client/src/locales/th.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "ทั่วไป",
+				"monitoring": "การตรวจสอบ",
+				"email": "อีเมล",
+				"integrations": "การเชื่อมต่อ",
+				"data": "ข้อมูล"
+			},
 			"form": {
 				"timezone": {
 					"title": "เขตเวลาที่แสดง",

--- a/client/src/locales/tr.json
+++ b/client/src/locales/tr.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Genel",
+				"monitoring": "İzleme",
+				"email": "E-posta",
+				"integrations": "Entegrasyonlar",
+				"data": "Veri"
+			},
 			"form": {
 				"timezone": {
 					"title": "Görüntüleme saat dilimi",

--- a/client/src/locales/uk.json
+++ b/client/src/locales/uk.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Загальні",
+				"monitoring": "Моніторинг",
+				"email": "Електронна пошта",
+				"integrations": "Інтеграції",
+				"data": "Дані"
+			},
 			"form": {
 				"timezone": {
 					"title": "Часовий пояс відображення",

--- a/client/src/locales/vi.json
+++ b/client/src/locales/vi.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "Chung",
+				"monitoring": "Giám sát",
+				"email": "Email",
+				"integrations": "Tích hợp",
+				"data": "Dữ liệu"
+			},
 			"form": {
 				"timezone": {
 					"title": "Múi giờ hiển thị",

--- a/client/src/locales/zh-CN.json
+++ b/client/src/locales/zh-CN.json
@@ -1142,6 +1142,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "常规",
+				"monitoring": "监控",
+				"email": "邮件",
+				"integrations": "集成",
+				"data": "数据"
+			},
 			"form": {
 				"timezone": {
 					"title": "显示时区",

--- a/client/src/locales/zh-TW.json
+++ b/client/src/locales/zh-TW.json
@@ -1141,6 +1141,13 @@
 			}
 		},
 		"settings": {
+			"tabs": {
+				"general": "一般",
+				"monitoring": "監控",
+				"email": "郵件",
+				"integrations": "整合",
+				"data": "資料"
+			},
 			"form": {
 				"timezone": {
 					"title": "顯示時區",


### PR DESCRIPTION
The settings page rendered all 13 `ConfigBox` sections in one column, so finding anything meant scrolling past everything else.

## Grouping

| Tab | Sections |
|---|---|
| General | Display timezone, appearance, status page URL, about |
| Monitoring | Global thresholds, check retention, demo monitors |
| Email | Email settings |
| Integrations | Global proxy, PageSpeed API key |
| Data | Import / export, monitor history, system reset |

**No visual changes.** Every `ConfigBox` moved verbatim with its props, children and `isAdmin` guard. The only edit inside a section is Prettier rewrapping one arrow function whose indentation depth changed.

## Reading the diff

GitHub reports **+694 / −501**, which overstates this change: **69% of the added lines are identical content at a different indentation depth**, from sections moving inside tab panels and conditional guards.

**`git diff -w` (or GitHub's "Hide whitespace" toggle) collapses it to +358 / −165.** Reviewing with whitespace hidden is strongly recommended.

The substantive change is ~200 new lines: the `SETTINGS_TABS` array and derived type, the field→tab and field→label maps, the error flattener, tab state and URL sync, the `<Tabs>` block, five panel guards, and 9 lines of i18n. Of the 19 removed lines, most are Prettier rewrapping lines that crossed the 90-char limit once indentation deepened.

## Notes

**Nine of the thirteen sections are admin-gated**, so a non-admin has four sections in General alone. Tabs are built from a filtered array rather than conditional JSX, keeping indices correct as admin-only tabs drop out, and the bar is hidden entirely when only one tab is visible — a non-admin sees a plain page rather than four empty tabs.

**The active tab lives in the URL** as `?tab=<key>`, following the `useSearchParams` pattern in `StatusPage/Status`, so reloads and shared links land in the right place. An unknown tab, or an admin tab requested by a non-admin, falls back to the first visible tab.

**Both confirmation dialogs and the sticky save bar stay outside the panels** — the dialogs would unmount mid-request otherwise, and the save bar serves the whole form.

**Validation errors are reachable.** The save bar lists errors by field name, and the offending field may sit on a closed tab. Submitting cannot reveal it, since the button is disabled while the form is invalid, so each field named in the alert is now a button that switches to its own tab.

Two titles are corrected to sentence case while their sections move: `Global Thresholds` and `Monitor IP/URL on Status Page`.

## Review already applied

A self-review caught that the first attempt used `<Stack hidden={...}>`, which does not hide: `hidden` only carries the user-agent `[hidden] { display: none }` rule, and MUI's `Stack` sets `display: flex` in an author-level class, which wins. All five panels rendered at once. Panels are now conditionally rendered, matching `Pages/Account`. That also removed four phantom gaps a non-admin would have seen, since `BasePage`'s `Stack spacing` keys its sibling margins on DOM position rather than visibility.

## Verification

`tsc --noEmit` clean, `npm run build` clean, ESLint 0 errors on the changed file (the 4 remaining `sx` warnings are pre-existing on `develop`, in the save bar).

**Not verified in a browser** — no dev server or database was available in this environment, so tab switching, the URL parameter and the error-reveal behaviour are unexercised at runtime and worth a manual pass.

## Testing

- Admin sees five tabs; a non-admin sees no tab bar and four sections
- Deep-link `?tab=integrations` as both roles; unknown values fall back to General
- Edit a field on one tab, switch tabs, save — the edit persists
- Both confirmation dialogs still open, cancel and confirm
- Clicking a field name in the validation alert jumps to its tab
- Narrow viewport: five tabs scroll horizontally

https://claude.ai/code/session_01AbYLvwpEaZFXktHVcqrFRd
