### PR TITLE
feat(maintenance): show monitor tags in maintenance selector

### DIFF
--- a/client/src/Pages/Maintenance/create/index.tsx
+++ b/client/src/Pages/Maintenance/create/index.tsx
@@ -1,7 +1,8 @@
 import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
 import { logger } from "@/Utils/logger";
 import { SPACING, LAYOUT } from "@/Utils/Theme/constants";
-import { BasePage, ConfigBox } from "@/Components/design-elements";
+import { BasePage, ColoredLabel, ConfigBox } from "@/Components/design-elements";
 import { Button } from "@/Components/inputs";
 
 import { useTheme } from "@mui/material";
@@ -15,6 +16,7 @@ import { useGet, usePost, usePatch } from "@/Hooks/UseApi";
 import { mutate } from "swr";
 import { useParams, useNavigate } from "react-router-dom";
 import type { Monitor } from "@/Types/Monitor";
+import type { Tag } from "@/Types/Tag";
 import { useForm, FormProvider } from "react-hook-form";
 import { useEffect } from "react";
 import { zodResolver } from "@hookform/resolvers/zod/dist/zod.js";
@@ -41,6 +43,7 @@ const CreateMaintenanceWindowPage = () => {
 	);
 
 	const { data: monitors } = useGet<Monitor[]>("/monitors/team");
+	const { data: tags } = useGet<Tag[]>("/tags/team");
 
 	const { post, loading: isPosting } = usePost();
 	const { patch, loading: isPatching } = usePatch();
@@ -203,6 +206,26 @@ const CreateMaintenanceWindowPage = () => {
 								"pages.maintenanceWindow.form.startTime.monitors.option.addMonitors.label"
 							)}
 							options={monitors ?? []}
+							renderOptionContent={(monitor) => (
+								<Stack
+									direction="row"
+									alignItems="center"
+									gap={theme.spacing(2)}
+									flexWrap="wrap"
+								>
+									<Typography>{monitor.name}</Typography>
+									{monitor.tags.map((tagId) => {
+										const tag = tags?.find(({ id }) => id === tagId);
+										return tag ? (
+											<ColoredLabel
+												key={tag.id}
+												text={tag.name}
+												color={tag.color}
+											/>
+										) : null;
+									})}
+								</Stack>
+							)}
 						/>
 					}
 				/>


### PR DESCRIPTION
## Describe your changes

This PR extends the monitor tag visibility introduced for status page selectors in #3863 to the Create/Edit Maintenance workflow, where the **Add monitors** dropdown remained name-only.

- Fetches team tags through the existing `/tags/team` endpoint.
- Displays existing tags beside monitor names using the shared `ColoredLabel` component.
- Preserves the existing monitor selection and removal behavior.
- Keeps monitors without tags unchanged.
- Requires no backend, dependency, or user-facing string changes.

## Validation

- Deployed the application locally with MongoDB running in Docker.
- Verified in the Create Maintenance page that a tagged monitor displays its colored tag in the **Add monitors** dropdown and untagged monitors remain unchanged.
- Passed ESLint and Prettier checks on the changed file.
- Passed the client production build.
- Passed server lint and production build.
- Passed all server tests: 84 suites and 1,524 tests.
- Completed an independent code review with no actionable findings.

## Write your issue number after "Fixes "

Fixes #3904

Related to #3862 and #3863.

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings. No new user-facing strings were introduced.
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed.
- [x] I didn't use any hardcoded values.
- [x] I made sure font sizes, color choices, and spacing are referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats the code.
- [x] I took a screenshot or a video and attached it to this PR because it includes a UI change.



<img width="1056" height="855" alt="Create Maintenance Monitor" src="https://github.com/user-attachments/assets/e637a927-abaa-4cef-a245-4c5bbca35740" />
