### PR TITLE
feat: first class docker monitoring, Monitor and Host Details pages

### DIFF
--- a/client/src/Components/design-elements/Breadcrumb.tsx
+++ b/client/src/Components/design-elements/Breadcrumb.tsx
@@ -83,12 +83,17 @@ export const Breadcrumb = ({
 	const basePage = segments[0] || t("common.breadcrumbs.home");
 
 	const secondSegment = segments[1];
+	const thirdSegment = segments[2];
 	const isActionPage = secondSegment && actionSegments.includes(secondSegment);
 	const isDetailsPage = secondSegment && isId(secondSegment);
-	const hasSubPage = isActionPage || isDetailsPage;
+	// page/section/:id routes such as docker/host/:monitorId
+	const isSectionDetailsPage = Boolean(
+		secondSegment && !isId(secondSegment) && thirdSegment && isId(thirdSegment)
+	);
+	const hasSubPage = isActionPage || isDetailsPage || isSectionDetailsPage;
 
 	const getSubPageLabel = (): string => {
-		if (isActionPage) {
+		if (isActionPage || isSectionDetailsPage) {
 			return secondSegment.charAt(0).toUpperCase() + secondSegment.slice(1);
 		}
 		return t("common.breadcrumbs.details");

--- a/client/src/Components/design-elements/StatusLabel.tsx
+++ b/client/src/Components/design-elements/StatusLabel.tsx
@@ -1,12 +1,19 @@
 import Box from "@mui/material/Box";
 import { BaseBox } from "@/Components/design-elements";
 import Typography from "@mui/material/Typography";
+import Stack from "@mui/material/Stack";
 
 import type { MonitorStatus } from "@/Types/Monitor";
 import type { SxProps } from "@mui/material/styles";
-import { getStatusPalette, getValuePalette } from "@/Utils/MonitorUtils";
+import {
+	getDockerStatePalette,
+	getStatusPalette,
+	getValuePalette,
+} from "@/Utils/MonitorUtils";
 import { useTheme } from "@mui/material/styles";
 import { useTranslation } from "react-i18next";
+import type { DockerContainerState } from "@/Types/Check";
+import { SPACING } from "@/Utils/Theme/constants";
 
 export const ValueTypes = ["positive", "negative", "neutral"] as const;
 export type ValueType = (typeof ValueTypes)[number];
@@ -108,5 +115,38 @@ export const ColoredLabel = ({ text, color }: { text: string; color: string }) =
 		>
 			<Typography>{text}</Typography>
 		</BaseBox>
+	);
+};
+
+export const DockerStateLabel = ({
+	state,
+	name,
+	image,
+}: {
+	state: DockerContainerState;
+	name: string;
+	image: string;
+}) => {
+	const palette = getDockerStatePalette(state);
+	const theme = useTheme();
+
+	return (
+		<Stack
+			direction="row"
+			gap={SPACING.LG}
+			alignItems={"center"}
+		>
+			<Box
+				width={7}
+				height={7}
+				bgcolor={theme.palette[palette].light}
+				borderRadius="50%"
+				marginRight="5px"
+			/>
+			<Stack>
+				<Typography>{name}</Typography>
+				<Typography variant="body2">{image}</Typography>
+			</Stack>
+		</Stack>
 	);
 };

--- a/client/src/Components/monitors/ControlsFilter.tsx
+++ b/client/src/Components/monitors/ControlsFilter.tsx
@@ -9,12 +9,11 @@ import type { Tag } from "@/Types/Tag";
 import { Typography, useTheme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
-const types = ["http", "ping", "port", "docker", "game", "grpc", "websocket"];
+const types = ["http", "ping", "port", "game", "grpc", "websocket"];
 const typeDisplayNames: Record<string, string> = {
 	http: "HTTP",
 	ping: "Ping",
 	port: "Port",
-	docker: "Docker",
 	game: "Game",
 	grpc: "gRPC",
 	websocket: "WebSocket",

--- a/client/src/Components/sidebar/Menu.tsx
+++ b/client/src/Components/sidebar/Menu.tsx
@@ -19,6 +19,7 @@ import {
 	Users,
 	Tag,
 	Waypoints,
+	Container,
 } from "lucide-react";
 export const getMenu = (t: Function) => {
 	return [
@@ -36,6 +37,11 @@ export const getMenu = (t: Function) => {
 			name: t("components.sidebar.menu.infrastructure"),
 			path: "infrastructure",
 			icon: <Icon icon={Link} />,
+		},
+		{
+			name: t("components.sidebar.menu.docker"),
+			path: "docker",
+			icon: <Icon icon={Container} />,
 		},
 		{
 			name: t("components.sidebar.menu.notifications"),

--- a/client/src/Features/UI/uiSlice.ts
+++ b/client/src/Features/UI/uiSlice.ts
@@ -8,7 +8,8 @@ type TableName =
 	| "maintenance"
 	| "infrastructure"
 	| "logs"
-	| "pagespeed";
+	| "pagespeed"
+	| "docker";
 
 interface TableState {
 	rowsPerPage: number;
@@ -24,6 +25,7 @@ interface UIState {
 	team: TableState;
 	maintenance: TableState;
 	infrastructure: TableState;
+	docker: TableState;
 	logs: TableState;
 	sidebar: SidebarState;
 	mode: ThemeMode;
@@ -54,6 +56,9 @@ const initialState: UIState = {
 		rowsPerPage: 5,
 	},
 	infrastructure: {
+		rowsPerPage: 5,
+	},
+	docker: {
 		rowsPerPage: 5,
 	},
 	logs: {

--- a/client/src/Pages/Docker/Details/index.tsx
+++ b/client/src/Pages/Docker/Details/index.tsx
@@ -1,5 +1,0 @@
-const DockerDetails = () => {
-	return null;
-};
-
-export default DockerDetails;

--- a/client/src/Pages/Docker/Details/index.tsx
+++ b/client/src/Pages/Docker/Details/index.tsx
@@ -1,0 +1,5 @@
+const DockerDetails = () => {
+	return null;
+};
+
+export default DockerDetails;

--- a/client/src/Pages/Docker/Details/index.tsx
+++ b/client/src/Pages/Docker/Details/index.tsx
@@ -1,0 +1,5 @@
+const DockerDetailsPage = () => {
+	return null;
+};
+
+export default DockerDetailsPage;

--- a/client/src/Pages/Docker/HostDetails/Components/DockerContainersTable.tsx
+++ b/client/src/Pages/Docker/HostDetails/Components/DockerContainersTable.tsx
@@ -1,0 +1,120 @@
+import Box from "@mui/material/Box";
+import Typography from "@mui/material/Typography";
+import { DockerStateLabel, Table } from "@/Components/design-elements";
+// Hooks
+import { useTranslation } from "react-i18next";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useTheme } from "@mui/material/styles";
+import { useNavigate } from "react-router-dom";
+
+// Types
+import type { Header } from "@/Components/design-elements/Table";
+import type { DockerContainerInfo } from "@/Types/Check";
+
+// Utils
+import { formatPercentage } from "@/Utils/FormatUtils";
+
+interface DockerContainersTableProps {
+	containers: DockerContainerInfo[];
+	onRowClick?: (container: DockerContainerInfo) => void;
+}
+
+export const DockerContainersTable = ({ containers }: DockerContainersTableProps) => {
+	const { t } = useTranslation();
+	const theme = useTheme();
+	const isSmall = useMediaQuery(theme.breakpoints.down("md"));
+	const navigate = useNavigate();
+
+	const getHeaders = () => {
+		// const renderSortIcon = (isActive: boolean) => (
+		// 	<Box
+		// 		width={16}
+		// 		display="inline-flex"
+		// 		justifyContent="center"
+		// 	>
+		// 		{isActive ? (
+		// 			sortOrder === "asc" ? (
+		// 				<ArrowUp size={16} />
+		// 			) : (
+		// 				<ArrowDown size={16} />
+		// 			)
+		// 		) : null}
+		// 	</Box>
+		// );
+		const headers: Header<DockerContainerInfo>[] = [
+			{
+				id: "container",
+				content: "Containers",
+				render: (row) => {
+					return (
+						<DockerStateLabel
+							state={row.state}
+							name={row.name}
+							image={row.image}
+						/>
+					);
+				},
+			},
+			{
+				id: "status",
+				content: "Status",
+				render: (row) => {
+					return <Typography>{row.state}</Typography>;
+				},
+			},
+			{
+				id: "health",
+				content: "Health",
+				render: (row) => {
+					return <Typography>{row.health}</Typography>;
+				},
+			},
+			{
+				id: "cpu",
+				content: "CPU",
+				render: (row) => {
+					return <Typography>{formatPercentage(row.cpuPct ?? 0)}</Typography>;
+				},
+			},
+			{
+				id: "memory",
+				content: "Memory",
+				render: (row) => {
+					return <Typography>{formatPercentage(row.memoryPct ?? 0)}</Typography>;
+				},
+			},
+			{
+				id: "restarts",
+				content: "Restarts",
+				render: (row) => {
+					return <Typography>{row.restartCount}</Typography>;
+				},
+			},
+		];
+		return headers;
+	};
+
+	let headers = getHeaders();
+
+	if (isSmall) {
+		headers = headers.filter((h) => h.id !== "histogram");
+	}
+
+	console.log(JSON.stringify(containers, null, 2));
+	return (
+		<Box>
+			<Table
+				headers={headers}
+				data={containers}
+				onRowClick={(row) => {
+					navigate(`/docker/container/${row.id}`);
+				}}
+				// getRowSx={(row) => ({
+				// 	backgroundColor: isRowSelected(row.id)
+				// 		? theme.palette.action.selected
+				// 		: "inherit",
+				// })}
+			/>
+		</Box>
+	);
+};

--- a/client/src/Pages/Docker/HostDetails/Components/DockerContainersTable.tsx
+++ b/client/src/Pages/Docker/HostDetails/Components/DockerContainersTable.tsx
@@ -44,7 +44,7 @@ export const DockerContainersTable = ({ containers }: DockerContainersTableProps
 		const headers: Header<DockerContainerInfo>[] = [
 			{
 				id: "container",
-				content: "Containers",
+				content: t("pages.docker.host.table.headers.container"),
 				render: (row) => {
 					return (
 						<DockerStateLabel
@@ -57,35 +57,35 @@ export const DockerContainersTable = ({ containers }: DockerContainersTableProps
 			},
 			{
 				id: "status",
-				content: "Status",
+				content: t("common.table.headers.status"),
 				render: (row) => {
 					return <Typography>{row.state}</Typography>;
 				},
 			},
 			{
 				id: "health",
-				content: "Health",
+				content: t("pages.docker.host.table.headers.health"),
 				render: (row) => {
 					return <Typography>{row.health}</Typography>;
 				},
 			},
 			{
 				id: "cpu",
-				content: "CPU",
+				content: t("pages.docker.host.table.headers.cpu"),
 				render: (row) => {
 					return <Typography>{formatPercentage(row.cpuPct ?? 0)}</Typography>;
 				},
 			},
 			{
 				id: "memory",
-				content: "Memory",
+				content: t("pages.docker.host.table.headers.memory"),
 				render: (row) => {
 					return <Typography>{formatPercentage(row.memoryPct ?? 0)}</Typography>;
 				},
 			},
 			{
 				id: "restarts",
-				content: "Restarts",
+				content: t("pages.docker.host.table.headers.restarts"),
 				render: (row) => {
 					return <Typography>{row.restartCount}</Typography>;
 				},

--- a/client/src/Pages/Docker/HostDetails/Components/StatBoxes.tsx
+++ b/client/src/Pages/Docker/HostDetails/Components/StatBoxes.tsx
@@ -1,0 +1,48 @@
+import Stack from "@mui/material/Stack";
+import { StatBox } from "@/Components/design-elements";
+
+// Types
+import type { DockerStats } from "@/Types/Monitor";
+
+// Hooks
+import { useTheme } from "@mui/material";
+import { useTranslation } from "react-i18next";
+
+// Utils
+import prettyBytes from "pretty-bytes";
+
+export const DockerStatusBoxes = ({ stats }: { stats: DockerStats | undefined }) => {
+	const { t } = useTranslation();
+	const theme = useTheme();
+
+	if (!stats) return null;
+
+	const { total, running, stopped, unhealthy } = stats.latest?.summary ?? {};
+
+	return (
+		<Stack
+			direction="row"
+			gap={theme.spacing(8)}
+			flexWrap={"wrap"}
+		>
+			<StatBox
+				title={"Containers"}
+				subtitle={String(total)}
+			/>
+			<StatBox
+				title={"Running"}
+				subtitle={String(running)}
+			/>
+
+			<StatBox
+				title={"Stopped"}
+				subtitle={String(stopped)}
+			/>
+
+			<StatBox
+				title={"Unhealthy"}
+				subtitle={String(unhealthy)}
+			/>
+		</Stack>
+	);
+};

--- a/client/src/Pages/Docker/HostDetails/Components/StatBoxes.tsx
+++ b/client/src/Pages/Docker/HostDetails/Components/StatBoxes.tsx
@@ -9,7 +9,6 @@ import { useTheme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 
 // Utils
-import prettyBytes from "pretty-bytes";
 
 export const DockerStatusBoxes = ({ stats }: { stats: DockerStats | undefined }) => {
 	const { t } = useTranslation();
@@ -26,21 +25,21 @@ export const DockerStatusBoxes = ({ stats }: { stats: DockerStats | undefined })
 			flexWrap={"wrap"}
 		>
 			<StatBox
-				title={"Containers"}
+				title={t("pages.docker.host.statBoxes.containers")}
 				subtitle={String(total)}
 			/>
 			<StatBox
-				title={"Running"}
+				title={t("pages.docker.host.statBoxes.running")}
 				subtitle={String(running)}
 			/>
 
 			<StatBox
-				title={"Stopped"}
+				title={t("pages.docker.host.statBoxes.stopped")}
 				subtitle={String(stopped)}
 			/>
 
 			<StatBox
-				title={"Unhealthy"}
+				title={t("pages.docker.host.statBoxes.unhealthy")}
 				subtitle={String(unhealthy)}
 			/>
 		</Stack>

--- a/client/src/Pages/Docker/HostDetails/index.tsx
+++ b/client/src/Pages/Docker/HostDetails/index.tsx
@@ -1,0 +1,52 @@
+import { BasePage } from "@/Components/design-elements";
+import { HeaderMonitorControls, MonitorStatBoxes } from "@/Components/monitors";
+import { DockerStatusBoxes } from "@/Pages/Docker/HostDetails/Components/StatBoxes";
+
+// Types
+import type { DockerDetailsResponse } from "@/Types/Monitor";
+
+// Hooks
+import { useGet } from "@/Hooks/UseApi";
+import { useIsAdmin } from "@/Hooks/useIsAdmin";
+import { useParams } from "react-router-dom";
+import { DockerContainersTable } from "@/Pages/Docker/HostDetails/Components/DockerContainersTable";
+
+const DockerHostDetailsPage = () => {
+	const { monitorId } = useParams<{ monitorId: string }>();
+	const isAdmin = useIsAdmin();
+
+	// The containers list renders the latest check only, so no date range is
+	// offered; the endpoint's dateRange param only shapes the aggregate buckets.
+	const monitorDetailsUrl = monitorId ? `/monitors/docker/details/${monitorId}` : null;
+
+	const { data: monitorDetailsData, refetch: refetchMonitor } =
+		useGet<DockerDetailsResponse>(
+			monitorDetailsUrl,
+			{},
+			{ refreshInterval: 10000, keepPreviousData: true }
+		);
+
+	const monitor = monitorDetailsData?.monitor;
+	const monitorStats = monitorDetailsData?.monitorStats ?? null;
+	const stats = monitorDetailsData?.stats;
+	const containers = stats?.latest?.containers ?? [];
+
+	return (
+		<BasePage>
+			<HeaderMonitorControls
+				path="docker"
+				monitor={monitor}
+				isAdmin={isAdmin}
+				refetch={refetchMonitor}
+			/>
+			<MonitorStatBoxes
+				monitor={monitor}
+				monitorStats={monitorStats}
+			/>
+			<DockerStatusBoxes stats={stats} />
+			<DockerContainersTable containers={containers} />
+		</BasePage>
+	);
+};
+
+export default DockerHostDetailsPage;

--- a/client/src/Pages/Docker/Monitors/Components/DockerMonitorsTable.tsx
+++ b/client/src/Pages/Docker/Monitors/Components/DockerMonitorsTable.tsx
@@ -1,0 +1,347 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import {
+	Table,
+	Pagination,
+	StatusLabel,
+	ColoredLabel,
+} from "@/Components/design-elements";
+import { SPACING } from "@/Utils/Theme/constants";
+import type { Header } from "@/Components/design-elements/Table";
+import { ActionsMenu, type ActionMenuItem } from "@/Components/actions-menu";
+import { ArrowUp, ArrowDown } from "lucide-react";
+
+import { useTranslation } from "react-i18next";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useTheme } from "@mui/material/styles";
+import { useNavigate } from "react-router-dom";
+import { usePost } from "@/Hooks/UseApi";
+
+import type { Monitor } from "@/Types/Monitor";
+import type { Tag } from "@/Types/Tag";
+import type { DockerContainerSummary } from "@/Types/Check";
+import { Checkbox } from "@/Components/inputs";
+
+const summaryOf = (monitor: Monitor): DockerContainerSummary | undefined => {
+	const recentChecks = monitor.recentChecks ?? [];
+	return recentChecks[recentChecks.length - 1]?.containerSummary;
+};
+
+interface DockerMonitorsTableProps {
+	monitors: Monitor[];
+	tags: Tag[];
+	refetch: () => void;
+	setSelectedMonitor: (monitor: Monitor | null) => void;
+	sortField: string;
+	setSortField: (field: string) => void;
+	sortOrder: "asc" | "desc";
+	setSortOrder: (order: "asc" | "desc") => void;
+	count: number;
+	page: number;
+	setPage: (page: number) => void;
+	rowsPerPage: number;
+	setRowsPerPage: (rowsPerPage: number) => void;
+	selectedRows?: string[];
+	onSelectionChange?: (selected: string[]) => void;
+}
+
+export const DockerMonitorsTable = ({
+	monitors,
+	tags,
+	refetch,
+	setSelectedMonitor,
+	sortField,
+	setSortField,
+	sortOrder,
+	setSortOrder,
+	count,
+	page,
+	setPage,
+	rowsPerPage,
+	setRowsPerPage,
+	selectedRows = [],
+	onSelectionChange,
+}: DockerMonitorsTableProps) => {
+	const { t } = useTranslation();
+	const theme = useTheme();
+	const isSmall = useMediaQuery(theme.breakpoints.down("md"));
+	const navigate = useNavigate();
+	const { post } = usePost<Record<string, never>, Monitor>();
+
+	const selectedSet = new Set(selectedRows);
+	const isAllSelected =
+		monitors.length > 0 && monitors.every((m) => selectedSet.has(m.id));
+	const isSomeSelected = selectedRows.length > 0 && !isAllSelected;
+
+	const handleSelectAll = (checked: boolean) => {
+		onSelectionChange?.(checked ? monitors.map((m) => m.id) : []);
+	};
+
+	const handleSelectRow = (id: string, checked: boolean) => {
+		if (!onSelectionChange) return;
+		onSelectionChange(
+			checked ? [...selectedRows, id] : selectedRows.filter((rowId) => rowId !== id)
+		);
+	};
+
+	const isRowSelected = (id: string) => selectedSet.has(id);
+
+	const handlePageChange = (
+		_e: React.MouseEvent<HTMLButtonElement> | null,
+		newPage: number
+	) => {
+		setPage(newPage);
+	};
+
+	const handleRowsPerPageChange = (
+		e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+	) => {
+		const value = Number(e.target.value);
+		setPage(0);
+		setRowsPerPage(value);
+	};
+
+	const handleSort = (e: React.MouseEvent, field: string) => {
+		e.preventDefault();
+		e.stopPropagation();
+		if (sortField === field) {
+			const newOrder = sortOrder === "asc" ? "desc" : "asc";
+			setSortOrder(newOrder);
+		} else {
+			setSortField(field);
+			setSortOrder("asc");
+		}
+		refetch();
+	};
+
+	const getActions = (monitor: Monitor): ActionMenuItem[] => {
+		return [
+			{
+				id: 2,
+				label: t("pages.common.monitors.actions.details"),
+				action: () => {
+					navigate(`${monitor.id}`);
+				},
+			},
+			{
+				id: 3,
+				label: t("pages.common.monitors.actions.incidents"),
+				action: () => {
+					navigate(`/incidents?monitorId=${monitor.id}`);
+				},
+			},
+			{
+				id: 4,
+				label: t("pages.common.monitors.actions.configure"),
+				action: () => {
+					navigate(`/docker/configure/${monitor.id}`);
+				},
+			},
+			{
+				id: 6,
+				label:
+					monitor.isActive === false
+						? t("common.buttons.resume")
+						: t("common.buttons.pause"),
+				action: async () => {
+					await post(`/monitors/pause/${monitor.id}`, {});
+					refetch();
+				},
+				closeMenu: true,
+			},
+			{
+				id: 7,
+				label: (
+					<Typography color={theme.palette.error.main}>
+						{t("common.buttons.delete")}
+					</Typography>
+				),
+				action: () => {
+					setSelectedMonitor(monitor);
+				},
+				closeMenu: true,
+			},
+		];
+	};
+
+	const getHeaders = () => {
+		const renderSortIcon = (isActive: boolean) => (
+			<Box
+				width={16}
+				display="inline-flex"
+				justifyContent="center"
+			>
+				{isActive ? (
+					sortOrder === "asc" ? (
+						<ArrowUp size={16} />
+					) : (
+						<ArrowDown size={16} />
+					)
+				) : null}
+			</Box>
+		);
+		const headers: Header<Monitor>[] = [
+			{
+				id: "selection",
+				content: (
+					<Checkbox
+						aria-label={t("pages.common.monitors.actions.selectAll")}
+						indeterminate={isSomeSelected}
+						checked={isAllSelected}
+						onChange={(e) => handleSelectAll(e.target.checked)}
+					/>
+				),
+				hideMobileLabel: true,
+				render: (row) => (
+					<Checkbox
+						aria-label={t("pages.common.monitors.actions.selectMonitor", {
+							name: row.name,
+						})}
+						checked={isRowSelected(row.id)}
+						onChange={(e) => {
+							handleSelectRow(row.id, e.target.checked);
+						}}
+						onClick={(e) => e.stopPropagation()}
+					/>
+				),
+				onClick: (e) => e?.stopPropagation(),
+			},
+			{
+				id: "name",
+				align: "left",
+				mobileLabel: t("pages.docker.table.headers.host"),
+				content: (
+					<Typography
+						component="div"
+						display="inline-flex"
+						alignItems="center"
+						gap={theme.spacing(4)}
+						onClick={(e) => handleSort(e, "name")}
+						sx={{ cursor: "pointer" }}
+					>
+						{t("pages.docker.table.headers.host")}
+						{renderSortIcon(sortField === "name")}
+					</Typography>
+				),
+				render: (row) => {
+					return (
+						<Stack>
+							<Typography variant="body2">{row.name}</Typography>
+							<Typography
+								variant="caption"
+								color={theme.palette.text.secondary}
+							>
+								{row.url}
+							</Typography>
+						</Stack>
+					);
+				},
+			},
+			{
+				id: "status",
+				mobileLabel: t("common.table.headers.status"),
+				content: (
+					<Stack
+						gap={theme.spacing(4)}
+						direction={"row"}
+						justifyContent={"center"}
+						alignItems={"center"}
+						onClick={(e) => handleSort(e, "status")}
+						sx={{ cursor: "pointer" }}
+					>
+						<Box width={theme.spacing(8)} />
+						{t("common.table.headers.status")}
+						{renderSortIcon(sortField === "status")}
+					</Stack>
+				),
+				render: (row) => {
+					return <StatusLabel status={row.status} />;
+				},
+			},
+			{
+				id: "containers",
+				content: t("pages.docker.table.headers.containers"),
+				render: (row) => {
+					const summary = summaryOf(row);
+					return (
+						<Typography variant="body2">
+							{summary
+								? t("pages.docker.table.containersRunning", {
+										running: summary.running,
+										total: summary.total,
+									})
+								: "—"}
+						</Typography>
+					);
+				},
+			},
+			{
+				id: "tags",
+				content: t("common.table.headers.tags"),
+				render: (row) => {
+					if (row.tags.length === 0) return "-";
+					return (
+						<Stack
+							justifyContent={"center"}
+							direction={isSmall ? "column" : "row"}
+							gap={theme.spacing(SPACING.LG)}
+						>
+							{row.tags.map((tagId) => {
+								const fullTag = tags.find((t) => t.id === tagId);
+								if (!fullTag) return null;
+								return (
+									<ColoredLabel
+										key={fullTag.id}
+										text={fullTag.name}
+										color={fullTag.color}
+									/>
+								);
+							})}
+						</Stack>
+					);
+				},
+			},
+
+			{
+				id: "actions",
+				content: t("common.table.headers.actions"),
+				render: (row) => {
+					return <ActionsMenu items={getActions(row)} />;
+				},
+			},
+		];
+		return headers;
+	};
+
+	let headers = getHeaders();
+
+	if (isSmall) {
+		headers = headers.filter((h) => h.id !== "histogram");
+	}
+	return (
+		<Box>
+			<Table
+				headers={headers}
+				data={monitors}
+				onRowClick={(row) => {
+					navigate(`/docker/${row.id}`);
+				}}
+				getRowSx={(row) => ({
+					backgroundColor: isRowSelected(row.id)
+						? theme.palette.action.selected
+						: "inherit",
+				})}
+			/>
+			<Pagination
+				component="div"
+				count={count}
+				page={page}
+				rowsPerPage={rowsPerPage}
+				onPageChange={handlePageChange}
+				onRowsPerPageChange={handleRowsPerPageChange}
+				itemsOnPage={monitors.length}
+			/>
+		</Box>
+	);
+};

--- a/client/src/Pages/Docker/Monitors/Components/DockerMonitorsTable.tsx
+++ b/client/src/Pages/Docker/Monitors/Components/DockerMonitorsTable.tsx
@@ -325,7 +325,7 @@ export const DockerMonitorsTable = ({
 				headers={headers}
 				data={monitors}
 				onRowClick={(row) => {
-					navigate(`/docker/${row.id}`);
+					navigate(`/docker/host/${row.id}`);
 				}}
 				getRowSx={(row) => ({
 					backgroundColor: isRowSelected(row.id)

--- a/client/src/Pages/Docker/Monitors/index.tsx
+++ b/client/src/Pages/Docker/Monitors/index.tsx
@@ -1,0 +1,44 @@
+import { MonitorListPage } from "@/Components/monitors";
+import { DockerMonitorsTable } from "@/Pages/Docker/Monitors/Components/DockerMonitorsTable";
+import { useMonitorListController } from "@/Hooks/useMonitorListController";
+
+const DockerMonitorsPage = () => {
+	const c = useMonitorListController({
+		types: ["docker"],
+		checksLimit: 25,
+		refreshInterval: 5000,
+		rowsPerPageTable: "docker",
+		rowsPerPageDefault: 10,
+	});
+
+	return (
+		<MonitorListPage
+			headerKey="docker"
+			page="docker"
+			actionLink="/docker/create"
+			controller={c}
+			bulkActions
+			showTypeFilter={false}
+		>
+			<DockerMonitorsTable
+				monitors={c.monitors || []}
+				tags={c.tags || []}
+				refetch={c.refetch}
+				setSelectedMonitor={c.setSelectedMonitor}
+				count={c.count || 0}
+				page={c.page}
+				setPage={c.setPage}
+				rowsPerPage={c.rowsPerPage}
+				sortField={c.sortField}
+				setSortField={c.setSortField}
+				sortOrder={c.sortOrder}
+				setSortOrder={c.setSortOrder}
+				setRowsPerPage={c.handleSetRowsPerPage}
+				selectedRows={c.selectedRows}
+				onSelectionChange={c.setSelectedRows}
+			/>
+		</MonitorListPage>
+	);
+};
+
+export default DockerMonitorsPage;

--- a/client/src/Routes/index.tsx
+++ b/client/src/Routes/index.tsx
@@ -23,7 +23,7 @@ import InfrastructureDetails from "@/Pages/Infrastructure/Details";
 // Docker
 import Docker from "@/Pages/Docker/Monitors";
 import DockerHostDetails from "@/Pages/Docker/HostDetails";
-import DockerDetails from "../../..";
+import DockerDetails from "@/Pages/Docker/Details";
 
 // Checks
 import Checks from "@/Pages/Checks";

--- a/client/src/Routes/index.tsx
+++ b/client/src/Routes/index.tsx
@@ -20,6 +20,10 @@ import PageSpeedDetails from "@/Pages/PageSpeed/Details/";
 import Infrastructure from "@/Pages/Infrastructure/Monitors";
 import InfrastructureDetails from "@/Pages/Infrastructure/Details";
 
+// Docker
+import Docker from "@/Pages/Docker/Monitors";
+import DockerDetails from "@/Pages/Docker/Details";
+
 // Checks
 import Checks from "@/Pages/Checks";
 
@@ -138,6 +142,22 @@ const Routes = () => {
 				<Route
 					path="infrastructure/:monitorId"
 					element={<InfrastructureDetails />}
+				/>
+				<Route
+					path="docker"
+					element={<Docker />}
+				/>
+				<Route
+					path="docker/create"
+					element={<CreateMonitor />}
+				/>
+				<Route
+					path="/docker/configure/:monitorId"
+					element={<CreateMonitor />}
+				/>
+				<Route
+					path="docker/:monitorId"
+					element={<DockerDetails />}
 				/>
 				<Route
 					path="checks/:monitorId?"

--- a/client/src/Routes/index.tsx
+++ b/client/src/Routes/index.tsx
@@ -22,7 +22,8 @@ import InfrastructureDetails from "@/Pages/Infrastructure/Details";
 
 // Docker
 import Docker from "@/Pages/Docker/Monitors";
-import DockerDetails from "@/Pages/Docker/Details";
+import DockerHostDetails from "@/Pages/Docker/HostDetails";
+import DockerDetails from "../../..";
 
 // Checks
 import Checks from "@/Pages/Checks";
@@ -158,6 +159,10 @@ const Routes = () => {
 				<Route
 					path="docker/:monitorId"
 					element={<DockerDetails />}
+				/>
+				<Route
+					path="docker/host/:monitorId"
+					element={<DockerHostDetails />}
 				/>
 				<Route
 					path="checks/:monitorId?"

--- a/client/src/Types/Check.ts
+++ b/client/src/Types/Check.ts
@@ -119,6 +119,14 @@ export interface CheckTimings {
 	};
 }
 
+// Mirrors DockerContainerSummary in server/src/types/network.ts.
+export interface DockerContainerSummary {
+	total: number;
+	running: number;
+	stopped: number;
+	unhealthy: number;
+}
+
 export interface Check {
 	id: string;
 	metadata: CheckMetadata;
@@ -133,6 +141,7 @@ export interface Check {
 	host?: CheckHostInfo;
 	errors?: CheckErrorInfo[];
 	capture?: CheckCaptureInfo;
+	containerSummary?: DockerContainerSummary;
 	net?: CheckNetworkInterfaceInfo[];
 	accessibility?: number;
 	bestPractices?: number;
@@ -287,6 +296,7 @@ export type CheckSnapshot = Pick<
 	memory?: SnapshotMemoryInfo;
 	disk?: SnapshotDiskInfo[];
 	host?: SnapshotHostInfo;
+	containerSummary?: DockerContainerSummary;
 };
 export interface HasResponseTime {
 	responseTime: number;

--- a/client/src/Types/Check.ts
+++ b/client/src/Types/Check.ts
@@ -127,6 +127,38 @@ export interface DockerContainerSummary {
 	unhealthy: number;
 }
 
+// Mirrors DockerContainerStates in server/src/types/network.ts.
+export const DockerContainerStates = [
+	"created",
+	"running",
+	"paused",
+	"restarting",
+	"removing",
+	"exited",
+	"dead",
+] as const;
+export type DockerContainerState = (typeof DockerContainerStates)[number];
+
+// Mirrors DockerHealthStatuses in server/src/types/network.ts.
+export const DockerHealthStatuses = ["healthy", "unhealthy", "starting", "none"] as const;
+export type DockerHealthStatus = (typeof DockerHealthStatuses)[number];
+
+// Mirrors DockerContainerInfo in server/src/types/network.ts.
+export interface DockerContainerInfo {
+	id: string;
+	name: string;
+	image: string;
+	state: DockerContainerState;
+	status: string;
+	health: DockerHealthStatus;
+	cpuPct?: number; // fraction of one core; exceeds 1 when using multiple cores
+	memoryUsedBytes?: number;
+	memoryLimitBytes?: number;
+	memoryPct?: number; // 0-1 fraction of the memory limit
+	restartCount?: number;
+	startedAt?: string;
+}
+
 export interface Check {
 	id: string;
 	metadata: CheckMetadata;

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -3,6 +3,8 @@ import type {
 	CheckSnapshot,
 	GroupedUptimeCheck,
 	DailyCheckBucket,
+	DockerContainerInfo,
+	DockerContainerSummary,
 } from "@/Types/Check";
 import type { PageSpeedGroupedCheck } from "@/Types/Check";
 import type { GeoContinent } from "@/Types/GeoCheck";
@@ -265,6 +267,41 @@ export interface HardwareStats {
 export interface HardwareDetailsResponse {
 	monitor: Monitor;
 	stats: HardwareStats;
+	monitorStats: MonitorStats | null;
+}
+
+// Mirrors DockerStatsBucket in server/src/domain/checks/check.type.ts.
+export interface DockerStatsBucket {
+	_id: string;
+	avgResponseTime: number | null;
+	upCount: number;
+	totalCount: number;
+	avgRunning: number | null;
+	avgTotal: number | null;
+	avgUnhealthy: number | null;
+}
+
+// Mirrors DockerStats in server/src/domain/checks/check.type.ts.
+export interface DockerStats {
+	aggregateData: {
+		totalChecks: number;
+	};
+	upChecks: {
+		totalChecks: number;
+	};
+	aggregate: DockerStatsBucket[];
+	latest: {
+		containers: DockerContainerInfo[];
+		summary?: DockerContainerSummary;
+		checkedAt: string;
+	} | null;
+}
+
+// Response of GET /monitors/docker/details/{monitorId}; mirrors
+// dockerDetailsResponseSchema in server/src/api/validation/monitorValidation.ts.
+export interface DockerDetailsResponse {
+	monitor: Monitor;
+	stats: DockerStats;
 	monitorStats: MonitorStats | null;
 }
 

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -30,7 +30,6 @@ export type MonitorType = (typeof MonitorTypes)[number];
 export const SelectableMonitorTypes = [
 	"http",
 	"ping",
-	"docker",
 	"port",
 	"game",
 	"grpc",

--- a/client/src/Utils/MonitorUtils.ts
+++ b/client/src/Utils/MonitorUtils.ts
@@ -12,7 +12,7 @@ export const getMonitorPath = (type: MonitorType): string => {
 		websocket: "uptime",
 		dns: "uptime",
 		unknown: "uptime",
-		docker: "uptime",
+		docker: "docker",
 		hardware: "infrastructure",
 		pagespeed: "pagespeed",
 	};

--- a/client/src/Utils/MonitorUtils.ts
+++ b/client/src/Utils/MonitorUtils.ts
@@ -1,6 +1,8 @@
 import type { MonitorStatus, MonitorType } from "@/Types/Monitor";
 import type { PaletteKey } from "@/Utils/Theme/Theme";
 import type { ValueType } from "@/Components/design-elements/StatusLabel";
+import type { DockerContainerState } from "@/Types/Check";
+import type { Doc } from "zod/v4/core";
 
 export const getMonitorPath = (type: MonitorType): string => {
 	const pathMap: Record<MonitorType, string> = {
@@ -39,6 +41,19 @@ export const getValuePalette = (value: ValueType): PaletteKey => {
 		neutral: "warning",
 	};
 	return paletteMap[value];
+};
+
+export const getDockerStatePalette = (state: DockerContainerState): PaletteKey => {
+	const paletteMap: Record<DockerContainerState, PaletteKey> = {
+		paused: "warning",
+		created: "warning",
+		running: "success",
+		restarting: "warning",
+		removing: "warning",
+		exited: "error",
+		dead: "error",
+	};
+	return paletteMap[state];
 };
 
 export const getStatusColor = (status: MonitorStatus, theme: any): string => {

--- a/client/src/Utils/MonitorUtils.ts
+++ b/client/src/Utils/MonitorUtils.ts
@@ -2,7 +2,6 @@ import type { MonitorStatus, MonitorType } from "@/Types/Monitor";
 import type { PaletteKey } from "@/Utils/Theme/Theme";
 import type { ValueType } from "@/Components/design-elements/StatusLabel";
 import type { DockerContainerState } from "@/Types/Check";
-import type { Doc } from "zod/v4/core";
 
 export const getMonitorPath = (type: MonitorType): string => {
 	const pathMap: Record<MonitorType, string> = {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -941,6 +941,23 @@
 					"containers": "Containers"
 				},
 				"containersRunning": "{{running}} of {{total}} running"
+			},
+			"host": {
+				"statBoxes": {
+					"containers": "Containers",
+					"running": "Running",
+					"stopped": "Stopped",
+					"unhealthy": "Unhealthy"
+				},
+				"table": {
+					"headers": {
+						"container": "Containers",
+						"health": "Health",
+						"cpu": "CPU",
+						"memory": "Memory",
+						"restarts": "Restarts"
+					}
+				}
 			}
 		},
 		"infrastructure": {

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -203,6 +203,7 @@
 				"uptime": "Uptime",
 				"pagespeed": "Pagespeed",
 				"infrastructure": "Infrastructure",
+				"docker": "Docker",
 				"notifications": "Notifications",
 				"tags": "Tags",
 				"proxies": "Proxies",
@@ -916,6 +917,24 @@
 			"header": {
 				"title": "Incidents",
 				"description": "When monitors go down or recover, incidents appear here with timing, monitor details and resolution history."
+			}
+		},
+		"docker": {
+			"header": {
+				"title": "Docker monitors",
+				"description": "Monitor your Docker hosts and every container running on them."
+			},
+			"fallback": {
+				"title": "No Docker monitors yet",
+				"description": "Add a Docker host to monitor its containers.",
+				"actionButton": "Create a monitor"
+			},
+			"table": {
+				"headers": {
+					"host": "Host",
+					"containers": "Containers"
+				},
+				"containersRunning": "{{running}} of {{total}} running"
 			}
 		},
 		"infrastructure": {

--- a/server/src/service/network/DockerProvider.ts
+++ b/server/src/service/network/DockerProvider.ts
@@ -100,7 +100,7 @@ export class DockerProvider implements IStatusProvider<DockerStatusPayload> {
 		const systemDelta = stats.cpu_stats.system_cpu_usage - (stats.precpu_stats.system_cpu_usage ?? 0);
 		const onlineCpus = stats.cpu_stats.online_cpus ?? stats.cpu_stats.cpu_usage.percpu_usage?.length ?? 1;
 		if (!(systemDelta > 0) || cpuDelta < 0) return 0;
-		return (cpuDelta / systemDelta) * onlineCpus * 100;
+		return (cpuDelta / systemDelta) * onlineCpus;
 	}
 
 	private computeMemory(stats: Dockerode.ContainerStats): Pick<DockerContainerInfo, "memoryUsedBytes" | "memoryLimitBytes" | "memoryPct"> {
@@ -111,7 +111,7 @@ export class DockerProvider implements IStatusProvider<DockerStatusPayload> {
 		return {
 			memoryUsedBytes,
 			memoryLimitBytes,
-			memoryPct: memoryLimitBytes > 0 ? (memoryUsedBytes / memoryLimitBytes) * 100 : 0,
+			memoryPct: memoryLimitBytes > 0 ? memoryUsedBytes / memoryLimitBytes : 0,
 		};
 	}
 

--- a/server/src/types/network.ts
+++ b/server/src/types/network.ts
@@ -117,10 +117,10 @@ export interface DockerContainerInfo {
 	state: DockerContainerState;
 	status: string;
 	health: DockerHealthStatus;
-	cpuPct?: number;
+	cpuPct?: number; // fraction of one core (docker stats convention / 100); exceeds 1 when using multiple cores
 	memoryUsedBytes?: number;
 	memoryLimitBytes?: number;
-	memoryPct?: number;
+	memoryPct?: number; // 0-1 fraction of the memory limit
 	restartCount?: number;
 	startedAt?: string; // ISO date
 }

--- a/server/test/unit/providers/network/dockerProvider.test.ts
+++ b/server/test/unit/providers/network/dockerProvider.test.ts
@@ -324,10 +324,10 @@ describe("DockerProvider", () => {
 			const result = await provider.handle(makeMonitor());
 			const container = result.payload?.containers[0];
 
-			expect(container?.cpuPct).toBeCloseTo(80);
+			expect(container?.cpuPct).toBeCloseTo(0.8);
 			expect(container?.memoryUsedBytes).toBe(200 * 1024 * 1024);
 			expect(container?.memoryLimitBytes).toBe(1024 * 1024 * 1024);
-			expect(container?.memoryPct).toBeCloseTo(19.53125);
+			expect(container?.memoryPct).toBeCloseTo(0.1953125);
 		});
 
 		it("falls back to the cgroup v1 cache field for page cache", async () => {
@@ -351,7 +351,7 @@ describe("DockerProvider", () => {
 
 			const result = await provider.handle(makeMonitor());
 
-			expect(result.payload?.containers[0]?.cpuPct).toBeCloseTo(40);
+			expect(result.payload?.containers[0]?.cpuPct).toBeCloseTo(0.4);
 		});
 
 		it("returns 0 cpu when the system delta is not positive", async () => {


### PR DESCRIPTION
This PR begins the implementation of the client side of Docker monitoring.  It contains the monitors list page and the host details page

## Changes

  - [x] Add a Docker monitors list page 
  - [x] Add a Docker host details page
  - [x] Add container state and health labels to StatusLabel
  - [x] Add docker container and details response types to client
  - [x] Update breadcrumbs to display intermediate details page properly
  - [x] Store cpu and memory percentages as raw