### PR TITLE
Localize formatDuration output

### DIFF
--- a/client/src/Components/design-elements/MonitorStatus.tsx
+++ b/client/src/Components/design-elements/MonitorStatus.tsx
@@ -8,8 +8,11 @@ import { typographyLevels } from "@/Utils/Theme/Palette";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { LAYOUT } from "@/Utils/Theme/constants";
 import { formatDuration } from "@/Utils/TimeUtils";
+import { useTranslation } from "react-i18next";
+
 export const MonitorStatus = ({ monitor }: { monitor: Monitor }) => {
 	const theme = useTheme();
+	const { t, i18n } = useTranslation();
 	const isSmall = useMediaQuery(theme.breakpoints.down("md"));
 
 	if (!monitor) {
@@ -52,7 +55,12 @@ export const MonitorStatus = ({ monitor }: { monitor: Monitor }) => {
 					<>
 						<Dot />
 						<Typography>
-							Checking every {formatDuration(monitor?.interval, true)}
+							{t("pages.common.monitors.statBoxes.checkingEvery", {
+								interval: formatDuration(monitor.interval, {
+									long: true,
+									locale: i18n.resolvedLanguage,
+								}),
+							})}
 						</Typography>
 					</>
 				)}

--- a/client/src/Components/monitors/MonitorStatBoxes.tsx
+++ b/client/src/Components/monitors/MonitorStatBoxes.tsx
@@ -21,7 +21,7 @@ export const MonitorStatBoxes = ({
 	domainExpiry,
 }: MonitorStatBoxesProps) => {
 	const theme = useTheme();
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	if (!monitorStats || !monitor) {
 		return null;
 	}
@@ -29,13 +29,16 @@ export const MonitorStatBoxes = ({
 	const timeOfLastFailure = monitorStats?.timeOfLastFailure || 0;
 	const timeSinceLastFailure = timeOfLastFailure > 0 ? Date.now() - timeOfLastFailure : 0;
 
-	// Determine time since last check
 	const timeOfLastCheck = monitorStats?.lastCheckTimestamp || 0;
-	const timeSinceLastCheck = Date.now() - timeOfLastCheck || 0;
 
 	const streakTime = formatDuration(timeSinceLastFailure);
-
-	const lastCheckTime = formatDuration(timeSinceLastCheck);
+	const lastCheckTime = timeOfLastCheck
+		? formatDuration(Date.now() - timeOfLastCheck, {
+				long: true,
+				relative: true,
+				locale: i18n.resolvedLanguage,
+			})
+		: t("common.labels.na");
 	const isActive =
 		monitor?.status === "up" ||
 		monitor?.status === "paused" ||

--- a/client/src/Utils/TimeUtils.ts
+++ b/client/src/Utils/TimeUtils.ts
@@ -104,9 +104,46 @@ export const formatMs = (ms: number, hasSpace: boolean = true): string => {
 	return formatted;
 };
 
-export const formatDuration = (ms: number, verbose: boolean = false, hasSpace = true) => {
-	if (verbose) {
-		return prettyMilliseconds(ms, { verbose: true });
+type DurationUnit = "day" | "hour" | "minute" | "second";
+
+interface FormatDurationOptions {
+	long?: boolean;
+	relative?: boolean;
+	hasSpace?: boolean;
+	locale?: string;
+}
+
+const DURATION_UNITS: Array<{ unit: DurationUnit; milliseconds: number }> = [
+	{ unit: "day", milliseconds: MS_PER_DAY },
+	{ unit: "hour", milliseconds: MS_PER_HOUR },
+	{ unit: "minute", milliseconds: MS_PER_MINUTE },
+	{ unit: "second", milliseconds: MS_PER_SECOND },
+];
+
+const getDurationUnit = (ms: number) =>
+	DURATION_UNITS.find(({ milliseconds }) => Math.abs(ms) >= milliseconds) ??
+	DURATION_UNITS[DURATION_UNITS.length - 1];
+
+export const formatDuration = (
+	ms: number,
+	{ long = false, relative = false, hasSpace = true, locale }: FormatDurationOptions = {}
+): string => {
+	if (long || relative) {
+		const { unit, milliseconds } = getDurationUnit(ms);
+		const value = Math.sign(ms) * Math.floor(Math.abs(ms) / milliseconds);
+
+		if (relative) {
+			return new Intl.RelativeTimeFormat(locale, {
+				numeric: "always",
+				style: long ? "long" : "narrow",
+			}).format(-value, unit);
+		}
+
+		return new Intl.NumberFormat(locale, {
+			style: "unit",
+			unit,
+			unitDisplay: "long",
+		}).format(value);
 	}
 
 	const formatted = prettyMilliseconds(ms, {

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -448,6 +448,7 @@
 				},
 				"statBoxes": {
 					"activeFor": "Aktiv seit",
+					"checkingEvery": "Check alle {{interval}}",
 					"certificateExpiry": "Zertifikatablauf",
 					"lastCheck": "Letzter Check",
 					"lastResponseTime": "Letzte Antwortzeit",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -545,6 +545,7 @@
 				},
 				"statBoxes": {
 					"activeFor": "Active for",
+					"checkingEvery": "Checking every {{interval}}",
 					"certificateExpiry": "Certificate expiry",
 					"domainExpiry": "Domain expiry",
 					"lastCheck": "Last check",


### PR DESCRIPTION
Closes #3891

## Summary

- Add options for localized long and relative `formatDuration` output.
- Use `Intl.NumberFormat` and `Intl.RelativeTimeFormat`.
- Apply the localized formatter to monitor intervals and last-check times.

Day.js uses fuzzy relative durations, formatting values such as 8 seconds as “a few seconds,” and its locales generally do not define numeric seconds. The Intl APIs provide localized numeric units and relative wording and are supported by current browsers and Node.js.

## Before and After

Note that the screenshots show two additional differences besides just the localization:
- "Active for" times have been shortened in the current dev branch unrelated to the changes in this PR
- This PR introduces both a plain `long` (just showing the number and long form unit word) and a relative option (showing the number, unit word + "ago") however, both of them round down to the highest unit (only minutes instead of minutes and seconds) which is the only way to get the nicer relative localizations out of the box.

Also domains are blurred just for the screenshots.

### English
<img width="514" height="163" alt="grafik" src="https://github.com/user-attachments/assets/98da983b-be1f-40ae-ba2c-57db6f88c156" />
<img width="436" height="165" alt="grafik" src="https://github.com/user-attachments/assets/117cc960-1507-452a-adcf-e8ba279b72fe" />


### German
<img width="512" height="152" alt="grafik" src="https://github.com/user-attachments/assets/41b2550d-cac6-4b4e-9b73-473153ab717d" />
<img width="407" height="157" alt="grafik" src="https://github.com/user-attachments/assets/1a065b5e-99c1-4325-9cd7-2af840c28545" />

## Additionally

- We could also show a relative time for the certificate (and domain) expiry.
- Show the long, nicer form for the "Active for" duration.