### PR TITLE
refactor: improves type consistency and removes duplicated monitor-related definitions

### DIFF
--- a/client/src/Components/design-elements/StatusLabel.tsx
+++ b/client/src/Components/design-elements/StatusLabel.tsx
@@ -3,7 +3,7 @@ import { BaseBox } from "@/Components/design-elements";
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
 
-import type { MonitorStatus } from "@/Types/Monitor";
+import { MonitorStatus } from "@/Types/Monitor";
 import type { SxProps } from "@mui/material/styles";
 import {
 	getDockerStatePalette,
@@ -24,17 +24,17 @@ export const StatusLabel = ({ status, sx }: { status: MonitorStatus; sx?: SxProp
 	const palette = getStatusPalette(status);
 
 	const determineStatus = (status: MonitorStatus): string => {
-		if (status === "up") {
+		if (status === MonitorStatus.Up) {
 			return t("pages.common.monitors.status.up");
-		} else if (status === "down") {
+		} else if (status === MonitorStatus.Down) {
 			return t("pages.common.monitors.status.down");
-		} else if (status === "breached") {
+		} else if (status === MonitorStatus.Breached) {
 			return t("pages.common.monitors.status.breached");
-		} else if (status === "maintenance") {
+		} else if (status === MonitorStatus.Maintenance) {
 			return t("pages.common.monitors.status.maintenance");
-		} else if (status === "paused") {
+		} else if (status === MonitorStatus.Paused) {
 			return t("pages.common.monitors.status.paused");
-		} else if (status === "initializing") {
+		} else if (status === MonitorStatus.Initializing) {
 			return t("pages.common.monitors.status.initializing");
 		}
 

--- a/client/src/Components/monitors/ControlsFilter.tsx
+++ b/client/src/Components/monitors/ControlsFilter.tsx
@@ -4,6 +4,7 @@ import { ColoredLabel } from "@/Components/design-elements";
 import MenuItem from "@mui/material/MenuItem";
 import useMediaQuery from "@mui/material/useMediaQuery";
 
+import { MonitorStatus } from "@/Types/Monitor";
 import type { MonitorType } from "@/Types/Monitor";
 import type { Tag } from "@/Types/Tag";
 import { Typography, useTheme } from "@mui/material";
@@ -18,8 +19,8 @@ const typeDisplayNames: Record<string, string> = {
 	grpc: "gRPC",
 	websocket: "WebSocket",
 };
-const statuses = ["up", "down"];
-const states = ["active", "paused"];
+const statuses = [MonitorStatus.Up, MonitorStatus.Down];
+const states = ["active", MonitorStatus.Paused];
 
 export const ControlsFilter = ({
 	showTypes = true,

--- a/client/src/Components/monitors/MonitorStatBoxes.tsx
+++ b/client/src/Components/monitors/MonitorStatBoxes.tsx
@@ -2,6 +2,7 @@ import Stack from "@mui/material/Stack";
 import { StatBox } from "@/Components/design-elements";
 
 import { useTheme } from "@mui/material/styles";
+import { MonitorStatus } from "@/Types/Monitor";
 import type { MonitorStats, Monitor } from "@/Types/Monitor";
 import { getStatusPalette } from "@/Utils/MonitorUtils";
 import { useTranslation } from "react-i18next";
@@ -37,11 +38,11 @@ export const MonitorStatBoxes = ({
 
 	const lastCheckTime = formatDuration(timeSinceLastCheck);
 	const isActive =
-		monitor?.status === "up" ||
-		monitor?.status === "paused" ||
-		monitor?.status === "maintenance" ||
-		monitor?.status === "initializing" ||
-		monitor?.status === "breached";
+		monitor?.status === MonitorStatus.Up ||
+		monitor?.status === MonitorStatus.Paused ||
+		monitor?.status === MonitorStatus.Maintenance ||
+		monitor?.status === MonitorStatus.Initializing ||
+		monitor?.status === MonitorStatus.Breached;
 	const palette = getStatusPalette(monitor?.status);
 
 	return (

--- a/client/src/Hooks/useMonitorListController.ts
+++ b/client/src/Hooks/useMonitorListController.ts
@@ -4,6 +4,7 @@ import { useBulkMonitorActions } from "@/Hooks/useBulkMonitorActions";
 import useDebounce from "@/Hooks/useDebounce";
 import type { RootState } from "@/store";
 import {
+	MonitorStatus,
 	type MonitorsWithChecksResponse,
 	SelectableMonitorTypes,
 	type Monitor,
@@ -45,14 +46,14 @@ export const useMonitorListController = (config: MonitorListConfig) => {
 	// Status: pass "up"/"down" directly to the API
 	// State: "active" -> true, "paused" -> false
 	const toFilterStatus = useMemo(() => {
-		if (selectedStatus === "up") return "up";
-		if (selectedStatus === "down") return "down";
+		if (selectedStatus === MonitorStatus.Up) return MonitorStatus.Up;
+		if (selectedStatus === MonitorStatus.Down) return MonitorStatus.Down;
 		return undefined;
 	}, [selectedStatus]);
 
 	const toFilterActive = useMemo(() => {
 		if (selectedState === "active") return "true";
-		if (selectedState === "paused") return "false";
+		if (selectedState === MonitorStatus.Paused) return "false";
 		return undefined;
 	}, [selectedState]);
 

--- a/client/src/Pages/Checks/Components/ChecksTable.tsx
+++ b/client/src/Pages/Checks/Components/ChecksTable.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/Components/design-elements";
 import Box from "@mui/material/Box";
 import type { Header } from "@/Components/design-elements/Table";
+import { MonitorStatus } from "@/Types/Monitor";
 import type { Monitor } from "@/Types/Monitor";
 import { useTranslation } from "react-i18next";
 import { formatDateWithTz } from "@/Utils/TimeUtils";
@@ -49,7 +50,11 @@ export const ChecksTable = ({
 				id: "status",
 				content: "Status",
 				render: (row) => {
-					return <StatusLabel status={row.status === true ? "up" : "down"} />;
+					return (
+						<StatusLabel
+							status={row.status === true ? MonitorStatus.Up : MonitorStatus.Down}
+						/>
+					);
 				},
 			},
 			{

--- a/client/src/Pages/Checks/index.tsx
+++ b/client/src/Pages/Checks/index.tsx
@@ -15,6 +15,7 @@ import { useTranslation } from "react-i18next";
 import { useState, useMemo } from "react";
 import { useParams } from "react-router-dom";
 import { useGet } from "@/Hooks/UseApi";
+import { MonitorStatus } from "@/Types/Monitor";
 import type { Monitor } from "@/Types/Monitor";
 import type { ChecksSummary, ChecksResponse } from "@/Types/Check";
 import type { DateRange } from "@/Types/Query";
@@ -25,7 +26,9 @@ const Checks = () => {
 
 	const [selectedMonitor, setSelectedMonitor] = useState<string>(monitorId || "0");
 	const [dateRange, setDateRange] = useState<DateRange>("recent");
-	const [statusFilter, setStatusFilter] = useState<string>("down");
+	const [statusFilter, setStatusFilter] = useState<MonitorStatus | "all">(
+		MonitorStatus.Down
+	);
 	const [page, setPage] = useState<number>(0);
 	const [rowsPerPage, setRowsPerPage] = useState<number>(10);
 
@@ -162,8 +165,12 @@ const Checks = () => {
 						}}
 					>
 						<MenuItem value="all">{t("pages.checks.selects.status.all")}</MenuItem>
-						<MenuItem value="up">{t("pages.checks.selects.status.up")}</MenuItem>
-						<MenuItem value="down">{t("pages.checks.selects.status.down")}</MenuItem>
+						<MenuItem value={MonitorStatus.Up}>
+							{t("pages.checks.selects.status.up")}
+						</MenuItem>
+						<MenuItem value={MonitorStatus.Down}>
+							{t("pages.checks.selects.status.down")}
+						</MenuItem>
 					</Select>
 				</Stack>
 				<HeaderTimeRange

--- a/client/src/Pages/StatusPage/Status/themes/shared/overallStatus.tsx
+++ b/client/src/Pages/StatusPage/Status/themes/shared/overallStatus.tsx
@@ -8,7 +8,8 @@ import {
 	ShieldAlert,
 	Wrench,
 } from "lucide-react";
-import type { Monitor, MonitorStatus } from "@/Types/Monitor";
+import { MonitorStatus } from "@/Types/Monitor";
+import type { Monitor } from "@/Types/Monitor";
 import type { StatusPageThemeTokens } from "../tokens";
 
 export type OverallTone = "up" | "warn" | "down";
@@ -57,87 +58,87 @@ export const resolveOverallStatus = (
 	const noneOf = (...statuses: MonitorStatus[]) =>
 		monitors.every((m) => !statuses.includes(m.status));
 
-	if (allOf("up")) {
+	if (allOf(MonitorStatus.Up)) {
 		return { tone: "up", message: allUpMessage, icon: <CircleCheck size={size} /> };
 	}
-	if (allOf("breached")) {
+	if (allOf(MonitorStatus.Breached)) {
 		return {
 			tone: "down",
 			message: t("pages.statusPages.statusBar.allBreached"),
 			icon: <ShieldAlert size={size} />,
 		};
 	}
-	if (allOf("maintenance")) {
+	if (allOf(MonitorStatus.Maintenance)) {
 		return {
 			tone: "warn",
 			message: t("pages.statusPages.statusBar.allMaintenance"),
 			icon: <Wrench size={size} />,
 		};
 	}
-	if (allOf("down")) {
+	if (allOf(MonitorStatus.Down)) {
 		return {
 			tone: "down",
 			message: t("pages.statusPages.statusBar.allDown"),
 			icon: <CircleX size={size} />,
 		};
 	}
-	if (allOf("paused")) {
+	if (allOf(MonitorStatus.Paused)) {
 		return {
 			tone: "warn",
 			message: t("pages.statusPages.statusBar.allPaused"),
 			icon: <PauseCircle size={size} />,
 		};
 	}
-	if (allOf("initializing")) {
+	if (allOf(MonitorStatus.Initializing)) {
 		return {
 			tone: "warn",
 			message: t("pages.statusPages.statusBar.allInitializing"),
 			icon: <Loader size={size} />,
 		};
 	}
-	if (someOf("breached") && someOf("down")) {
+	if (someOf(MonitorStatus.Breached) && someOf(MonitorStatus.Down)) {
 		return {
 			tone: "down",
 			message: t("pages.statusPages.statusBar.breachedAndDown"),
 			icon: <ShieldAlert size={size} />,
 		};
 	}
-	if (someOf("breached")) {
+	if (someOf(MonitorStatus.Breached)) {
 		return {
 			tone: "down",
 			message: t("pages.statusPages.statusBar.breached"),
 			icon: <ShieldAlert size={size} />,
 		};
 	}
-	if (someOf("maintenance") && someOf("down")) {
+	if (someOf(MonitorStatus.Maintenance) && someOf(MonitorStatus.Down)) {
 		return {
 			tone: "down",
 			message: t("pages.statusPages.statusBar.maintenanceAndDown"),
 			icon: <Wrench size={size} />,
 		};
 	}
-	if (someOf("maintenance") && noneOf("down")) {
+	if (someOf(MonitorStatus.Maintenance) && noneOf(MonitorStatus.Down)) {
 		return {
 			tone: "warn",
 			message: t("pages.statusPages.statusBar.maintenance"),
 			icon: <Wrench size={size} />,
 		};
 	}
-	if (someOf("down")) {
+	if (someOf(MonitorStatus.Down)) {
 		return {
 			tone: "warn",
 			message: t("pages.statusPages.statusBar.degraded"),
 			icon: <AlertTriangle size={size} />,
 		};
 	}
-	if (someOf("paused")) {
+	if (someOf(MonitorStatus.Paused)) {
 		return {
 			tone: "warn",
 			message: t("pages.statusPages.statusBar.partiallyPaused"),
 			icon: <PauseCircle size={size} />,
 		};
 	}
-	if (someOf("initializing")) {
+	if (someOf(MonitorStatus.Initializing)) {
 		return {
 			tone: "up",
 			message: t("pages.statusPages.statusBar.initializing"),
@@ -152,16 +153,20 @@ export const resolveOverallStatus = (
 };
 
 export const statusBadgeKey: Record<MonitorStatus, string> = {
-	up: "pages.statusPages.monitorsList.status.up",
-	down: "pages.statusPages.monitorsList.status.down",
-	breached: "pages.statusPages.monitorsList.status.breached",
-	maintenance: "pages.statusPages.monitorsList.status.maintenance",
-	paused: "pages.statusPages.monitorsList.status.paused",
-	initializing: "pages.statusPages.monitorsList.status.initializing",
+	[MonitorStatus.Up]: "pages.statusPages.monitorsList.status.up",
+	[MonitorStatus.Down]: "pages.statusPages.monitorsList.status.down",
+	[MonitorStatus.Breached]: "pages.statusPages.monitorsList.status.breached",
+	[MonitorStatus.Maintenance]: "pages.statusPages.monitorsList.status.maintenance",
+	[MonitorStatus.Paused]: "pages.statusPages.monitorsList.status.paused",
+	[MonitorStatus.Initializing]: "pages.statusPages.monitorsList.status.initializing",
 };
 
 export const monoFirstChar = (s?: string): string =>
 	(s?.trim().charAt(0) || "?").toUpperCase();
 
 export const monitorBadgeTone = (status: MonitorStatus): OverallTone =>
-	status === "up" ? "up" : status === "down" || status === "breached" ? "down" : "warn";
+	status === MonitorStatus.Up
+		? MonitorStatus.Up
+		: status === MonitorStatus.Down || status === MonitorStatus.Breached
+			? MonitorStatus.Down
+			: "warn";

--- a/client/src/Pages/Uptime/Details/Components/ChecksTable.tsx
+++ b/client/src/Pages/Uptime/Details/Components/ChecksTable.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/Components/design-elements";
 import Box from "@mui/material/Box";
 import type { Header } from "@/Components/design-elements";
+import { MonitorStatus } from "@/Types/Monitor";
 import type { Check } from "@/Types/Check";
 
 import { useNavigate } from "react-router";
@@ -38,7 +39,11 @@ export const ChecksTable = ({
 			id: "status",
 			content: t("common.table.headers.status"),
 			render: (row) => {
-				return <StatusLabel status={row.status === true ? "up" : "down"} />;
+				return (
+					<StatusLabel
+						status={row.status === true ? MonitorStatus.Up : MonitorStatus.Down}
+					/>
+				);
 			},
 		},
 		{

--- a/client/src/Pages/Uptime/Details/Components/GeoChecksTable.tsx
+++ b/client/src/Pages/Uptime/Details/Components/GeoChecksTable.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/Components/design-elements";
 import Box from "@mui/material/Box";
 import type { Header } from "@/Components/design-elements";
+import { MonitorStatus } from "@/Types/Monitor";
 import type { FlatGeoCheck } from "@/Types/GeoCheck";
 import { useTranslation } from "react-i18next";
 import { formatDateWithTz, formatMs } from "@/Utils/TimeUtils";
@@ -35,7 +36,7 @@ export const GeoChecksTable = ({
 			id: "status",
 			content: t("common.table.headers.status"),
 			render: (row) => {
-				const status = row.status ? "up" : "down";
+				const status = row.status ? MonitorStatus.Up : MonitorStatus.Down;
 				return <StatusLabel status={status} />;
 			},
 		},

--- a/client/src/Types/Check.ts
+++ b/client/src/Types/Check.ts
@@ -1,17 +1,11 @@
+import type { MonitorType } from "@/Types/Monitor";
+
 export const CHECK_TTL_SENTINEL = 366;
 
 export interface CheckMetadata {
 	monitorId: string;
 	teamId: string;
-	type:
-		| "http"
-		| "ping"
-		| "pagespeed"
-		| "hardware"
-		| "docker"
-		| "port"
-		| "game"
-		| "unknown";
+	type: MonitorType;
 }
 
 export interface CheckCpuInfo {
@@ -238,16 +232,6 @@ export interface ChecksResponse {
 	checks: Check[];
 	checksCount: number;
 }
-
-export type MonitorType =
-	| "http"
-	| "ping"
-	| "pagespeed"
-	| "hardware"
-	| "docker"
-	| "port"
-	| "game"
-	| "unknown";
 
 export interface ChecksQueryResult {
 	checksCount: number;

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -88,6 +88,16 @@ export const supportsGeoCheck = (type: MonitorType | undefined): boolean => {
 	return GeoCheckSupportedTypes.includes(type);
 };
 
+export const MonitorStatuses = [
+	"up",
+	"down",
+	"paused",
+	"initializing",
+	"maintenance",
+	"breached",
+] as const;
+export type MonitorStatus = (typeof MonitorStatuses)[number];
+
 export const MonitorStatus = {
 	Up: "up",
 	Down: "down",
@@ -95,8 +105,7 @@ export const MonitorStatus = {
 	Initializing: "initializing",
 	Maintenance: "maintenance",
 	Breached: "breached",
-} as const;
-export type MonitorStatus = (typeof MonitorStatus)[keyof typeof MonitorStatus];
+} as const satisfies Record<string, MonitorStatus>;
 
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";

--- a/client/src/Types/Monitor.ts
+++ b/client/src/Types/Monitor.ts
@@ -88,15 +88,15 @@ export const supportsGeoCheck = (type: MonitorType | undefined): boolean => {
 	return GeoCheckSupportedTypes.includes(type);
 };
 
-export const MonitorStatuses = [
-	"up",
-	"down",
-	"paused",
-	"initializing",
-	"maintenance",
-	"breached",
-] as const;
-export type MonitorStatus = (typeof MonitorStatuses)[number];
+export const MonitorStatus = {
+	Up: "up",
+	Down: "down",
+	Paused: "paused",
+	Initializing: "initializing",
+	Maintenance: "maintenance",
+	Breached: "breached",
+} as const;
+export type MonitorStatus = (typeof MonitorStatus)[keyof typeof MonitorStatus];
 
 export const MonitorMatchMethods = ["equal", "include", "regex"] as const;
 export type MonitorMatchMethod = (typeof MonitorMatchMethods)[number] | "";

--- a/client/src/Utils/MonitorUtils.ts
+++ b/client/src/Utils/MonitorUtils.ts
@@ -1,4 +1,5 @@
-import type { MonitorStatus, MonitorType } from "@/Types/Monitor";
+import { MonitorStatus } from "@/Types/Monitor";
+import type { MonitorType } from "@/Types/Monitor";
 import type { PaletteKey } from "@/Utils/Theme/Theme";
 import type { ValueType } from "@/Components/design-elements/StatusLabel";
 import type {
@@ -25,13 +26,13 @@ export const getMonitorPath = (type: MonitorType): string => {
 };
 
 export const getStatusPalette = (status: MonitorStatus): PaletteKey => {
-	if (status === "up") {
+	if (status === MonitorStatus.Up) {
 		return "success";
 	}
-	if (status === "down") {
+	if (status === MonitorStatus.Down) {
 		return "error";
 	}
-	if (status === "breached") {
+	if (status === MonitorStatus.Breached) {
 		return "error";
 	}
 	return "warning";
@@ -60,11 +61,11 @@ export const getDockerStatePalette = (state: DockerContainerState): PaletteKey =
 };
 
 export const getStatusColor = (status: MonitorStatus, theme: any): string => {
-	if (status === "up") {
+	if (status === MonitorStatus.Up) {
 		return theme.palette.success.light;
 	}
 
-	if (status === "down") {
+	if (status === MonitorStatus.Down) {
 		return theme.palette.error.light;
 	}
 


### PR DESCRIPTION
## Describe your changes

This PR improves type consistency and removes duplicated monitor-related definitions.

Changes:

- Replaced the `MonitorStatuses` tuple with a `MonitorStatus` constant object and updated status comparisons to use named constants such as `MonitorStatus.Up` and `MonitorStatus.Down` instead of string literals.

- Also removed the duplicated `MonitorType` definition from `Check.ts` and now use the shared `MonitorType` from `Types/Monitor.ts` as the single source of truth, including support for `grpc`, `websocket`, and `dns`.

These changes improve maintainability and type consistency without changing any functionality or UI.

## Please ensure all items are checked off before requesting a review.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-review and tested my code.
- [ ] I have included the issue # in the PR. (No related issue)
- [x] I have added i18n support to visible strings (no new visible strings were added).
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed.
- [x] I didn't use any hardcoded values.
- [x] I made sure font sizes, color choices, etc. are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific change.
- [x] I ran `npm run format` in server and client directories.
- [x] I took a screenshot or a video and attached it to this PR if there is a UI change. (No UI changes)