### PR TITLE
fix(api): enforce RBAC role checks on maintenance windows, notifications, and check deletion

### DIFF
--- a/server/src/api/routes/checkRoutes.ts
+++ b/server/src/api/routes/checkRoutes.ts
@@ -9,6 +9,6 @@ export const createCheckRoutes = (checkController: ICheckController): Router => 
 	router.get("/team", checkController.getChecksByTeam);
 	router.delete("/team", isAllowed(["admin", "superadmin"]), checkController.deleteChecksByTeamId);
 	router.get("/:monitorId", checkController.getChecksByMonitor);
-	router.delete("/:monitorId", checkController.deleteChecks);
+	router.delete("/:monitorId", isAllowed(["admin", "superadmin"]), checkController.deleteChecks);
 	return router;
 };

--- a/server/src/api/routes/maintenanceWindowRoutes.ts
+++ b/server/src/api/routes/maintenanceWindowRoutes.ts
@@ -1,15 +1,16 @@
 import { IMaintenanceWindowController } from "@/api/controllers/maintenanceWindowController.js";
+import { isAllowed } from "@/api/middleware/isAllowed.js";
 import { Router } from "express";
 
 export const createMaintenanceWindowRoutes = (maintenanceWindowController: IMaintenanceWindowController): Router => {
 	const router = Router();
-	router.post("/", maintenanceWindowController.createMaintenanceWindows);
+	router.post("/", isAllowed(["admin", "superadmin"]), maintenanceWindowController.createMaintenanceWindows);
 	router.get("/team/", maintenanceWindowController.getMaintenanceWindowsByTeamId);
 
 	router.get("/monitor/:monitorId", maintenanceWindowController.getMaintenanceWindowsByMonitorId);
 
 	router.get("/:id", maintenanceWindowController.getMaintenanceWindowById);
-	router.patch("/:id", maintenanceWindowController.editMaintenanceWindow);
-	router.delete("/:id", maintenanceWindowController.deleteMaintenanceWindow);
+	router.patch("/:id", isAllowed(["admin", "superadmin"]), maintenanceWindowController.editMaintenanceWindow);
+	router.delete("/:id", isAllowed(["admin", "superadmin"]), maintenanceWindowController.deleteMaintenanceWindow);
 	return router;
 };

--- a/server/src/api/routes/notificationRoutes.ts
+++ b/server/src/api/routes/notificationRoutes.ts
@@ -1,14 +1,15 @@
 import { INotificationController } from "@/api/controllers/notificationController.js";
+import { isAllowed } from "@/api/middleware/isAllowed.js";
 import { Router } from "express";
 
 export const createNotificationRoutes = (notificationController: INotificationController): Router => {
 	const router = Router();
-	router.post("/", notificationController.createNotification);
-	router.post("/test/all", notificationController.testAllNotifications);
-	router.post("/test", notificationController.testNotification);
+	router.post("/", isAllowed(["admin", "superadmin"]), notificationController.createNotification);
+	router.post("/test/all", isAllowed(["admin", "superadmin"]), notificationController.testAllNotifications);
+	router.post("/test", isAllowed(["admin", "superadmin"]), notificationController.testNotification);
 	router.get("/team", notificationController.getNotificationsByTeamId);
 	router.get("/:id", notificationController.getNotificationById);
-	router.delete("/:id", notificationController.deleteNotification);
-	router.patch("/:id", notificationController.editNotification);
+	router.delete("/:id", isAllowed(["admin", "superadmin"]), notificationController.deleteNotification);
+	router.patch("/:id", isAllowed(["admin", "superadmin"]), notificationController.editNotification);
 	return router;
 };

--- a/server/test/unit/middleware/isAllowed.test.ts
+++ b/server/test/unit/middleware/isAllowed.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import type { NextFunction, Request, Response } from "express";
+import { isAllowed } from "../../../src/api/middleware/isAllowed.ts";
+import { AppError } from "../../../src/utils/AppError.ts";
+
+describe("isAllowed middleware", () => {
+	it("calls next() without error when user has an allowed role", () => {
+		const middleware = isAllowed(["admin", "superadmin"]);
+		const req = {
+			user: {
+				userId: "user-1",
+				teamId: "team-1",
+				email: "admin@example.com",
+				role: ["admin"],
+			},
+		} as unknown as Request;
+		const res = {} as Response;
+		const next = jest.fn() as unknown as NextFunction;
+
+		middleware(req, res, next);
+
+		expect(next).toHaveBeenCalledWith();
+	});
+
+	it("calls next(error) with 403 when user does not have an allowed role", () => {
+		const middleware = isAllowed(["admin", "superadmin"]);
+		const req = {
+			user: {
+				userId: "user-2",
+				teamId: "team-1",
+				email: "user@example.com",
+				role: ["user"],
+			},
+		} as unknown as Request;
+		const res = {} as Response;
+		const next = jest.fn() as unknown as NextFunction;
+
+		middleware(req, res, next);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		const error = (next as unknown as jest.Mock).mock.calls[0][0] as AppError;
+		expect(error).toBeInstanceOf(AppError);
+		expect(error.status).toBe(403);
+		expect(error.message).toBe("Unauthorized");
+	});
+
+	it("calls next(error) with 403 when req.user is undefined", () => {
+		const middleware = isAllowed(["admin", "superadmin"]);
+		const req = {} as Request;
+		const res = {} as Response;
+		const next = jest.fn() as unknown as NextFunction;
+
+		middleware(req, res, next);
+
+		expect(next).toHaveBeenCalledTimes(1);
+		const error = (next as unknown as jest.Mock).mock.calls[0][0] as AppError;
+		expect(error).toBeInstanceOf(AppError);
+		expect(error.status).toBe(403);
+		expect(error.message).toBe("Unauthorized");
+	});
+
+	it("calls next() when user has multiple roles and at least one matches", () => {
+		const middleware = isAllowed(["admin", "superadmin"]);
+		const req = {
+			user: {
+				userId: "user-3",
+				teamId: "team-1",
+				email: "multi@example.com",
+				role: ["user", "admin"],
+			},
+		} as unknown as Request;
+		const res = {} as Response;
+		const next = jest.fn() as unknown as NextFunction;
+
+		middleware(req, res, next);
+
+		expect(next).toHaveBeenCalledWith();
+	});
+});


### PR DESCRIPTION
## Describe your changes

Added the missing isAllowed(["admin", "superadmin"]) authorizations middleware to mutating API endpoints across several route groups to prevent unauthorized modification or deletion by accounts with the `user` role:

- **`maintenanceWindowRoutes.ts`**: Added isAllowed(["admin", "superadmin"]) to POST /, PATCH /:id, and DELETE /:id requests.
- **`notificationRoutes.ts`**: Added isAllowed(["admin", "superadmin"]) to POST /, POST /test/all,POST /test, PATCH /:id, and DELETE /:id.
- **`checkRoutes.ts`**: Added isAllowed(["admin", "superadmin"]) to DELETE /:monitorId.
- **Unit Tests (`isAllowed.test.ts`)**: Added unit tests for the isAllowed middleware to verify access granting for authorized roles, 403 AppError rejection for unauthorized roles, and unauthenticated request handling.

## Write your issue number after "Fixes "

Fixes #3916

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.


