### PR TITLE
feat(sidebar): reorder Docker and Pagespeed menu items

### DIFF
--- a/client/src/Components/sidebar/Menu.tsx
+++ b/client/src/Components/sidebar/Menu.tsx
@@ -32,9 +32,9 @@ export const getMenu = (t: Function) => {
 					icon: <Icon icon={Globe} />,
 				},
 				{
-					name: t("components.sidebar.menu.pagespeed"),
-					path: "pagespeed",
-					icon: <Icon icon={Gauge} />,
+					name: t("components.sidebar.menu.docker"),
+					path: "docker",
+					icon: <Icon icon={Container} />,
 				},
 				{
 					name: t("components.sidebar.menu.infrastructure"),
@@ -42,9 +42,9 @@ export const getMenu = (t: Function) => {
 					icon: <Icon icon={Link} />,
 				},
 				{
-					name: t("components.sidebar.menu.docker"),
-					path: "docker",
-					icon: <Icon icon={Container} />,
+					name: t("components.sidebar.menu.pagespeed"),
+					path: "pagespeed",
+					icon: <Icon icon={Gauge} />,
 				},
 			],
 		},


### PR DESCRIPTION
## Describe your changes

Swapped the positions of Docker and Pagespeed in the sidebar monitoring section. Docker now appears before Infrastructure, and Pagespeed comes last.

Before changes:
<img width="245" height="233" alt="Screenshot 2026-09-06 at 8 48 38 AM" src="https://github.com/user-attachments/assets/85083006-9582-4d22-8fcd-a2f1f2e84800" />

After changes:
<img width="251" height="235" alt="Screenshot 2026-09-06 at 8 36 58 AM" src="https://github.com/user-attachments/assets/668e6dcc-6d36-4442-b2e3-906ffa6c0375" />

- [x] I deployed the application locally.
- [x] I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR. (no issue related)
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):
- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.
