### PR TITLE
feat: add MySqlProvider for MariaDB/MySQL monitoring (draft)

### DIFF
--- a/server/src/domain/monitors/monitor.type.ts
+++ b/server/src/domain/monitors/monitor.type.ts
@@ -32,7 +32,20 @@ export const HttpStatusCodes = [
 export const HttpStatusCodeSet = new Set(HttpStatusCodes);
 export type HttpStatusCode = number;
 
-export const MonitorTypes = ["http", "ping", "pagespeed", "hardware", "docker", "port", "game", "grpc", "websocket", "dns", "unknown"] as const;
+export const MonitorTypes = [
+	"http",
+	"ping",
+	"pagespeed",
+	"hardware",
+	"docker",
+	"port",
+	"game",
+	"grpc",
+	"websocket",
+	"dns",
+	"mysql",
+	"unknown",
+] as const;
 export type MonitorType = (typeof MonitorTypes)[number];
 
 export const PageSpeedStrategies = ["desktop", "mobile"] as const;
@@ -103,6 +116,11 @@ export interface Monitor {
 	selectedDisks: string[];
 	gameId?: string;
 	grpcServiceName?: string;
+	// mysql monitors: the password reuses the existing `secret` field, matching how
+	// HttpProvider uses it for bearer auth.
+	dbUser?: string;
+	dbName?: string;
+	dbQuery?: string;
 	strategy?: PageSpeedStrategy;
 	group: string | null;
 	geoCheckEnabled?: boolean;

--- a/server/src/service/network/MySqlProvider.ts
+++ b/server/src/service/network/MySqlProvider.ts
@@ -1,0 +1,178 @@
+import { IStatusProvider } from "@/service/network/IStatusProvider.js";
+import { IAdvancedMatcher } from "@/service/network/AdvancedMatcher.js";
+import { MySqlStatusPayload, MonitorStatusResponse } from "@/types/network.js";
+import { Monitor, MonitorType } from "@/domain/monitors/monitor.type.js";
+import { AppError } from "@/utils/AppError.js";
+import { timeRequest } from "@/service/network/utils.js";
+import { NETWORK_ERROR } from "@/types/network.js";
+
+const SERVICE_NAME = "MySqlProvider";
+const TIMEOUT_MS = 10000;
+const DEFAULT_PORT = 3306;
+const DEFAULT_QUERY = "SELECT 1";
+
+export interface MySqlConnectionConfig {
+	host: string;
+	port: number;
+	user?: string;
+	password?: string;
+	database?: string;
+	connectTimeout: number;
+}
+
+export interface MySqlConnection {
+	query(sql: string): Promise<unknown>;
+	end(): Promise<void>;
+	destroy?(): void;
+}
+
+/**
+ * Structural type rather than an import of mysql2, so the provider stays unit-testable
+ * with a fake and the concrete driver is injected by the registry.
+ */
+export interface MySqlDriver {
+	createConnection(config: MySqlConnectionConfig): Promise<MySqlConnection>;
+}
+
+export class MySqlProvider implements IStatusProvider<MySqlStatusPayload> {
+	readonly type = "mysql";
+
+	constructor(
+		private driver: MySqlDriver,
+		private advancedMatcher: IAdvancedMatcher
+	) {}
+
+	supports(type: MonitorType): boolean {
+		return type === "mysql";
+	}
+
+	async handle(monitor: Monitor): Promise<MonitorStatusResponse<MySqlStatusPayload>> {
+		try {
+			const { url } = monitor;
+			if (!url) {
+				throw new Error("URL is required for MySQL monitoring");
+			}
+
+			const query = monitor.dbQuery?.trim() || DEFAULT_QUERY;
+
+			const { response, responseTime, error } = await timeRequest(async () => {
+				return this.runQuery(monitor, query);
+			});
+
+			if (error) {
+				const errorMessage = error instanceof Error ? error.message : "MySQL check failed";
+				return {
+					monitorId: monitor.id,
+					teamId: monitor.teamId,
+					type: monitor.type,
+					status: false,
+					code: NETWORK_ERROR,
+					message: errorMessage,
+					responseTime: responseTime,
+					timings: undefined,
+					payload: { rowCount: 0 },
+				};
+			}
+
+			const payload: MySqlStatusPayload = response ?? { rowCount: 0 };
+			// A query that runs proves the server is answering; advanced matching lets the
+			// monitor additionally assert on the value it returned.
+			const matchResult = this.advancedMatcher.validate<string | null | undefined>(payload.value, monitor);
+
+			return {
+				monitorId: monitor.id,
+				teamId: monitor.teamId,
+				type: monitor.type,
+				status: matchResult.ok,
+				code: matchResult.ok ? 200 : NETWORK_ERROR,
+				message: matchResult.ok ? "MySQL check successful" : matchResult.message,
+				responseTime: responseTime,
+				timings: undefined,
+				payload,
+			};
+		} catch (err: unknown) {
+			if (err instanceof AppError) throw err;
+			const originalMessage = err instanceof Error ? err.message : String(err);
+			throw new AppError({
+				message: originalMessage || "Error performing MySQL check",
+				status: 500,
+				service: SERVICE_NAME,
+				method: "handle",
+				details: { url: monitor.url, port: monitor.port, database: monitor.dbName },
+			});
+		}
+	}
+
+	/**
+	 * Races the connect-and-query against a hard timeout. The connection is closed through
+	 * the promise itself rather than a local variable, so a connection that finishes opening
+	 * after the timeout has already fired is still closed — leaking those is the problem a
+	 * port check has today.
+	 */
+	private async runQuery(monitor: Monitor, query: string): Promise<MySqlStatusPayload> {
+		let connectionPromise: Promise<MySqlConnection> | undefined;
+		let timer: NodeJS.Timeout | undefined;
+
+		try {
+			const work = (async () => {
+				connectionPromise = this.driver.createConnection({
+					host: monitor.url,
+					port: monitor.port ?? DEFAULT_PORT,
+					user: monitor.dbUser,
+					password: monitor.secret,
+					database: monitor.dbName,
+					connectTimeout: TIMEOUT_MS,
+				});
+
+				const connection = await connectionPromise;
+				const result = await connection.query(query);
+				return this.toPayload(result);
+			})();
+
+			const timeout = new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error("MySQL check timed out")), TIMEOUT_MS);
+			});
+
+			return await Promise.race([work, timeout]);
+		} finally {
+			if (timer) clearTimeout(timer);
+			if (connectionPromise) {
+				void connectionPromise
+					.then(async (connection) => {
+						try {
+							await connection.end();
+						} catch {
+							connection.destroy?.();
+						}
+					})
+					.catch(() => {
+						// createConnection rejected; there is nothing to close.
+					});
+			}
+		}
+	}
+
+	/**
+	 * mysql2 resolves to [rows, fields]. Reduce that to a row count plus the first column of
+	 * the first row, which is what a health query like `SELECT 1` or `SELECT status FROM ...`
+	 * is actually asserting on.
+	 */
+	private toPayload(result: unknown): MySqlStatusPayload {
+		const rows = Array.isArray(result) ? result[0] : result;
+		if (!Array.isArray(rows)) {
+			return { rowCount: 0 };
+		}
+
+		const firstRow = rows[0];
+		if (firstRow === undefined) {
+			return { rowCount: 0 };
+		}
+
+		const raw = firstRow !== null && typeof firstRow === "object" ? Object.values(firstRow as Record<string, unknown>)[0] : firstRow;
+
+		return {
+			rowCount: rows.length,
+			value: raw === null || raw === undefined ? null : String(raw),
+		};
+	}
+}

--- a/server/src/types/network.ts
+++ b/server/src/types/network.ts
@@ -24,7 +24,8 @@ export interface MonitorStatusResponse<
 		| DockerStatusPayload
 		| GameStatusPayload
 		| GrpcStatusPayload
-		| WebSocketStatusPayload,
+		| WebSocketStatusPayload
+		| MySqlStatusPayload,
 > {
 	monitorId: string;
 	teamId: string;
@@ -147,6 +148,13 @@ export interface WebSocketStatusPayload {
 	connected: boolean;
 }
 
+export interface MySqlStatusPayload {
+	rowCount: number;
+	// First column of the first row, stringified. Feeds advanced matching so a monitor can
+	// assert on a value rather than only on the query succeeding.
+	value?: string | null;
+}
+
 export interface DNSStatusPayload {
 	hostname: string;
 	dnsServer: string;
@@ -166,6 +174,7 @@ export interface MonitorPayloadMap {
 	grpc: GrpcStatusPayload;
 	websocket: WebSocketStatusPayload;
 	dns: DNSStatusPayload;
+	mysql: MySqlStatusPayload;
 	unknown: unknown;
 }
 

--- a/server/test/unit/providers/network/mySqlProvider.test.ts
+++ b/server/test/unit/providers/network/mySqlProvider.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { MySqlProvider } from "../../../../src/service/network/MySqlProvider.ts";
+import type { MySqlConnection, MySqlConnectionConfig } from "../../../../src/service/network/MySqlProvider.ts";
+import { testStatusProviderContract } from "../../../helpers/statusProviderContract.ts";
+import { NETWORK_ERROR } from "../../../../src/types/network.ts";
+import type { Monitor } from "../../../../src/domain/monitors/monitor.type.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeMonitor = (overrides?: Partial<Monitor>): Monitor =>
+	({
+		id: "mon-1",
+		teamId: "team-1",
+		type: "mysql",
+		url: "db.example.com",
+		port: 3306,
+		dbUser: "checkmate",
+		secret: "hunter2",
+		dbName: "app",
+		useAdvancedMatching: false,
+		...overrides,
+	}) as Monitor;
+
+// mysql2 resolves to [rows, fields]
+const rowsResult = (rows: unknown[]) => [rows, []];
+
+const passingMatcher = () => ({ validate: jest.fn(() => ({ ok: true, message: "Success" })) }) as any;
+const failingMatcher = (message = "Value mismatch") => ({ validate: jest.fn(() => ({ ok: false, message })) }) as any;
+
+const createDriver = (
+	opts: {
+		result?: unknown;
+		connectError?: Error;
+		queryError?: Error;
+		connectDelayMs?: number;
+		endError?: Error;
+	} = {}
+) => {
+	const end = jest.fn(async () => {
+		if (opts.endError) throw opts.endError;
+	});
+	const destroy = jest.fn();
+	const query = jest.fn(async () => {
+		if (opts.queryError) throw opts.queryError;
+		return opts.result ?? rowsResult([{ "1": 1 }]);
+	});
+
+	const connection: MySqlConnection = { query, end, destroy } as any;
+	const configs: MySqlConnectionConfig[] = [];
+
+	const createConnection = jest.fn(async (config: MySqlConnectionConfig) => {
+		configs.push(config);
+		if (opts.connectDelayMs) {
+			await new Promise((resolve) => setTimeout(resolve, opts.connectDelayMs));
+		}
+		if (opts.connectError) throw opts.connectError;
+		return connection;
+	});
+
+	return { driver: { createConnection } as any, createConnection, query, end, destroy, configs };
+};
+
+const createProvider = (driverOpts = {}, matcher = passingMatcher()) => {
+	const d = createDriver(driverOpts);
+	return { provider: new MySqlProvider(d.driver, matcher), ...d, matcher };
+};
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+testStatusProviderContract("MySqlProvider", {
+	create: () => createProvider().provider,
+	supportedType: "mysql",
+	unsupportedType: "http",
+	makeMonitor: () => makeMonitor(),
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("MySqlProvider", () => {
+	describe("successful checks", () => {
+		it("returns up when the query succeeds", async () => {
+			const { provider } = createProvider();
+
+			const result = await provider.handle(makeMonitor());
+
+			expect(result).toEqual(
+				expect.objectContaining({
+					monitorId: "mon-1",
+					teamId: "team-1",
+					type: "mysql",
+					status: true,
+					code: 200,
+					message: "MySQL check successful",
+				})
+			);
+		});
+
+		it("defaults to SELECT 1 when no query is configured", async () => {
+			const { provider, query } = createProvider();
+			await provider.handle(makeMonitor());
+			expect(query).toHaveBeenCalledWith("SELECT 1");
+		});
+
+		it("runs a configured query instead of the default", async () => {
+			const { provider, query } = createProvider();
+			await provider.handle(makeMonitor({ dbQuery: "SELECT status FROM health LIMIT 1" }));
+			expect(query).toHaveBeenCalledWith("SELECT status FROM health LIMIT 1");
+		});
+
+		it("ignores a whitespace-only query and falls back to the default", async () => {
+			const { provider, query } = createProvider();
+			await provider.handle(makeMonitor({ dbQuery: "   " }));
+			expect(query).toHaveBeenCalledWith("SELECT 1");
+		});
+
+		it("passes connection settings from the monitor, with the password from secret", async () => {
+			const { provider, configs } = createProvider();
+			await provider.handle(makeMonitor());
+			expect(configs[0]).toEqual(
+				expect.objectContaining({
+					host: "db.example.com",
+					port: 3306,
+					user: "checkmate",
+					password: "hunter2",
+					database: "app",
+				})
+			);
+		});
+
+		it("defaults to port 3306 when the monitor has no port", async () => {
+			const { provider, configs } = createProvider();
+			await provider.handle(makeMonitor({ port: undefined }));
+			expect(configs[0].port).toBe(3306);
+		});
+
+		it("reports the response time", async () => {
+			const { provider } = createProvider();
+			const result = await provider.handle(makeMonitor());
+			expect(typeof result.responseTime).toBe("number");
+		});
+	});
+
+	describe("payload extraction", () => {
+		it("extracts the first column of the first row", async () => {
+			const { provider } = createProvider({ result: rowsResult([{ status: "healthy" }]) });
+			const result = await provider.handle(makeMonitor());
+			expect(result.payload).toEqual({ rowCount: 1, value: "healthy" });
+		});
+
+		it("counts every returned row", async () => {
+			const { provider } = createProvider({ result: rowsResult([{ id: 1 }, { id: 2 }, { id: 3 }]) });
+			const result = await provider.handle(makeMonitor());
+			expect(result.payload).toEqual(expect.objectContaining({ rowCount: 3, value: "1" }));
+		});
+
+		it("stringifies non-string values", async () => {
+			const { provider } = createProvider({ result: rowsResult([{ n: 42 }]) });
+			const result = await provider.handle(makeMonitor());
+			expect(result.payload).toEqual({ rowCount: 1, value: "42" });
+		});
+
+		it("represents a SQL NULL as null rather than the string 'null'", async () => {
+			const { provider } = createProvider({ result: rowsResult([{ v: null }]) });
+			const result = await provider.handle(makeMonitor());
+			expect(result.payload).toEqual({ rowCount: 1, value: null });
+		});
+
+		it("handles an empty result set", async () => {
+			const { provider } = createProvider({ result: rowsResult([]) });
+			const result = await provider.handle(makeMonitor());
+			expect(result.payload).toEqual({ rowCount: 0 });
+		});
+
+		it("handles a driver returning a non-array result", async () => {
+			const { provider } = createProvider({ result: { affectedRows: 0 } });
+			const result = await provider.handle(makeMonitor());
+			expect(result.payload).toEqual({ rowCount: 0 });
+		});
+	});
+
+	describe("advanced matching", () => {
+		it("marks the monitor down when the matcher rejects the value", async () => {
+			const { provider } = createProvider({ result: rowsResult([{ status: "degraded" }]) }, failingMatcher("Value mismatch"));
+
+			const result = await provider.handle(makeMonitor({ useAdvancedMatching: true, expectedValue: "healthy" }));
+
+			expect(result.status).toBe(false);
+			expect(result.code).toBe(NETWORK_ERROR);
+			expect(result.message).toBe("Value mismatch");
+		});
+
+		it("hands the extracted value to the matcher", async () => {
+			const matcher = passingMatcher();
+			const { provider } = createProvider({ result: rowsResult([{ status: "healthy" }]) }, matcher);
+
+			const monitor = makeMonitor({ useAdvancedMatching: true, expectedValue: "healthy" });
+			await provider.handle(monitor);
+
+			expect(matcher.validate).toHaveBeenCalledWith("healthy", monitor);
+		});
+
+		it("still reports the payload when matching fails", async () => {
+			const { provider } = createProvider({ result: rowsResult([{ status: "degraded" }]) }, failingMatcher());
+			const result = await provider.handle(makeMonitor({ useAdvancedMatching: true }));
+			expect(result.payload).toEqual({ rowCount: 1, value: "degraded" });
+		});
+	});
+
+	describe("failures", () => {
+		it("returns down when the connection is refused", async () => {
+			const { provider } = createProvider({ connectError: new Error("ECONNREFUSED") });
+
+			const result = await provider.handle(makeMonitor());
+
+			expect(result).toEqual(
+				expect.objectContaining({
+					status: false,
+					code: NETWORK_ERROR,
+					message: "ECONNREFUSED",
+					payload: { rowCount: 0 },
+				})
+			);
+		});
+
+		it("returns down when the query fails", async () => {
+			const { provider } = createProvider({ queryError: new Error("ER_NO_SUCH_TABLE") });
+			const result = await provider.handle(makeMonitor());
+			expect(result.status).toBe(false);
+			expect(result.message).toBe("ER_NO_SUCH_TABLE");
+		});
+
+		it("throws an AppError when the monitor has no url", async () => {
+			const { provider } = createProvider();
+			await expect(provider.handle(makeMonitor({ url: "" }))).rejects.toMatchObject({
+				service: "MySqlProvider",
+				method: "handle",
+				status: 500,
+			});
+		});
+	});
+
+	// The whole point of this monitor type is that port-pinging 3306 leaves connections
+	// open until the server blocks the host, so the provider must never leak one.
+	describe("connection cleanup", () => {
+		it("closes the connection after a successful query", async () => {
+			const { provider, end } = createProvider();
+			await provider.handle(makeMonitor());
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(end).toHaveBeenCalledTimes(1);
+		});
+
+		it("closes the connection after a failed query", async () => {
+			const { provider, end } = createProvider({ queryError: new Error("boom") });
+			await provider.handle(makeMonitor());
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(end).toHaveBeenCalledTimes(1);
+		});
+
+		it("destroys the connection when a graceful close fails", async () => {
+			const { provider, destroy } = createProvider({ endError: new Error("already gone") });
+			await provider.handle(makeMonitor());
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(destroy).toHaveBeenCalled();
+		});
+
+		it("does not attempt to close when the connection never opened", async () => {
+			const { provider, end, destroy } = createProvider({ connectError: new Error("ECONNREFUSED") });
+			await provider.handle(makeMonitor());
+			await new Promise((resolve) => setImmediate(resolve));
+			expect(end).not.toHaveBeenCalled();
+			expect(destroy).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("timeout", () => {
+		it("gives up on a hung connection", async () => {
+			jest.useFakeTimers();
+			try {
+				const { provider } = createProvider({ connectDelayMs: 30_000 });
+
+				const pending = provider.handle(makeMonitor());
+				await jest.advanceTimersByTimeAsync(10_000);
+				const result = await pending;
+
+				expect(result.status).toBe(false);
+				expect(result.message).toBe("MySQL check timed out");
+			} finally {
+				jest.useRealTimers();
+			}
+		});
+
+		// The connection that was still opening when we gave up must not be left dangling —
+		// that is precisely the leak this monitor type exists to avoid.
+		it("closes a connection that finishes opening after the timeout fired", async () => {
+			jest.useFakeTimers();
+			try {
+				const { provider, end } = createProvider({ connectDelayMs: 30_000 });
+
+				const pending = provider.handle(makeMonitor());
+				await jest.advanceTimersByTimeAsync(10_000);
+				await pending;
+				expect(end).not.toHaveBeenCalled();
+
+				await jest.advanceTimersByTimeAsync(25_000);
+				expect(end).toHaveBeenCalledTimes(1);
+			} finally {
+				jest.useRealTimers();
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes

Draft for #3864, opened so the provider is reviewable while the open questions on the issue are decided.

Adds `MySqlProvider` for MySQL/MariaDB checks. It runs a real query (default `SELECT 1`, configurable) instead of pinging port 3306, and feeds the first column of the first row into the existing `AdvancedMatcher`. Connections are closed through the connection promise, so one that finishes opening after the timeout still gets closed.

The driver is a small structural interface rather than an import of `mysql2`, so no dependency is added yet. Schema, validation and registry wiring are left out until we settle the `mysql2` dependency and the secrets convention on the issue. Password reuses `Monitor.secret`; `dbUser`, `dbName` and `dbQuery` are new.

29 unit tests cover it.

## Write your issue number after "Fixes "

Refs #3864

- [ ] I deployed the application locally. (Not wired into the registry yet, nothing to run.)
- [x] I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] I have added i18n support to visible strings (no UI in this PR).
- [x] I have not included any files that are not related to my pull request.
- [x] I didn't use any hardcoded values.
- [ ] Theme references (no UI in this PR).
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in the server directory.
- [ ] Screenshot or video (no UI change).
