### PR TITLE
fix: return the created monitor from createMonitor

### DIFF
--- a/server/src/domain/monitors/monitor.service.ts
+++ b/server/src/domain/monitors/monitor.service.ts
@@ -60,7 +60,7 @@ const computeRestartsInRange = (aggregate: DockerContainerStatsBucket[]): number
 
 export interface IMonitorService {
 	// create
-	createMonitor(teamId: string, userId: string, body: Partial<Monitor>): Promise<void>;
+	createMonitor(teamId: string, userId: string, body: Partial<Monitor>): Promise<Monitor>;
 	createMonitors(monitors: Array<Monitor>): Promise<Monitor[] | null>;
 	addDemoMonitors(args: { userId: string; teamId: string }): Promise<Monitor[]>;
 
@@ -180,7 +180,7 @@ export class MonitorService implements IMonitorService {
 		this.incidentsRepository = incidentsRepository;
 	}
 
-	createMonitor = async (teamId: string, userId: string, body: Monitor): Promise<void> => {
+	createMonitor = async (teamId: string, userId: string, body: Monitor): Promise<Monitor> => {
 		// proxyId is only needed in custom mode
 		if (body.proxyMode !== "custom") {
 			delete body.proxyId;
@@ -191,6 +191,7 @@ export class MonitorService implements IMonitorService {
 		}
 
 		this.scheduler.addJob(monitor.id, monitor);
+		return monitor;
 	};
 
 	createMonitors = async (monitors: Array<Monitor>): Promise<Monitor[] | null> => {

--- a/server/test/unit/services/monitorService.test.ts
+++ b/server/test/unit/services/monitorService.test.ts
@@ -122,16 +122,17 @@ const createService = (
 
 describe("MonitorService", () => {
 	describe("createMonitor", () => {
-		it("creates a monitor and adds a job", async () => {
+		it("creates a monitor, adds a job and returns the created document", async () => {
 			const monitorsRepository = createMonitorsRepositoryMock();
 			const monitor = makeMonitor();
 			(monitorsRepository.create as jest.Mock).mockResolvedValue(monitor);
 			const { service, jobQueue } = createService({ monitorsRepository });
 
-			await service.createMonitor(TEAM_ID, USER_ID, monitor as any);
+			const result = await service.createMonitor(TEAM_ID, USER_ID, monitor as any);
 
 			expect(monitorsRepository.create).toHaveBeenCalledWith(monitor, TEAM_ID, USER_ID);
 			expect(jobQueue.addJob).toHaveBeenCalledWith(MONITOR_ID, monitor);
+			expect(result).toBe(monitor);
 		});
 
 		it("strips a stray proxyId when proxyMode is not custom", async () => {


### PR DESCRIPTION
## Describe your changes

`createMonitor` was typed `Promise<void>` and never returned the document, so the controller sent `data: null` on every successful `POST /monitors`. It now returns the created monitor and the interface type matches. The existing unit test asserts the return value.

## Write your issue number after "Fixes "

Fixes #3917

- [x] I deployed the application locally.
- [x] I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] i18n (no visible strings).
- [x] I have not included any files that are not related to my pull request.
- [x] I didn't use any hardcoded values.
- [ ] Theme references (no UI).
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in the server directory.
- [ ] Screenshot or video (no UI change).
