### PR TITLE
feat: add Apprise notification channel

### DIFF
--- a/client/src/Hooks/useNotificationForm.ts
+++ b/client/src/Hooks/useNotificationForm.ts
@@ -19,6 +19,7 @@ function buildDefaults(data: Notification | null): NotificationFormData {
 		homeserverUrl: data?.homeserverUrl || "",
 		roomId: data?.roomId || "",
 		topic: data?.topic || "",
+		appriseUrls: data?.appriseUrls || "",
 	};
 }
 

--- a/client/src/Pages/Notifications/create/index.tsx
+++ b/client/src/Pages/Notifications/create/index.tsx
@@ -127,6 +127,7 @@ const NotificationsCreatePage = () => {
 					watchedType !== "telegram" &&
 					watchedType !== "pushover" &&
 					watchedType !== "twilio" &&
+					watchedType !== "apprise" &&
 					watchedType !== "ntfy" && (
 						<ConfigBox
 							title={addressConfig.title}
@@ -155,6 +156,31 @@ const NotificationsCreatePage = () => {
 									name="topic"
 									fieldLabel={t("pages.notifications.form.ntfy.optionTopic")}
 									placeholder={t("pages.notifications.form.ntfy.placeholderTopic")}
+								/>
+							</Stack>
+						}
+					/>
+				)}
+				{watchedType === "apprise" && (
+					<ConfigBox
+						title={t("pages.notifications.form.apprise.title")}
+						subtitle={t("pages.notifications.form.apprise.description")}
+						rightContent={
+							<Stack spacing={theme.spacing(8)}>
+								<FormTextField
+									name="address"
+									fieldLabel={t("pages.notifications.form.apprise.optionServerUrl")}
+									placeholder={t("pages.notifications.form.apprise.placeholderServerUrl")}
+								/>
+								<FormTextField
+									name="topic"
+									fieldLabel={t("pages.notifications.form.apprise.optionConfigKey")}
+									placeholder={t("pages.notifications.form.apprise.placeholderConfigKey")}
+								/>
+								<FormTextField
+									name="appriseUrls"
+									fieldLabel={t("pages.notifications.form.apprise.optionUrls")}
+									placeholder={t("pages.notifications.form.apprise.placeholderUrls")}
 								/>
 							</Stack>
 						}

--- a/client/src/Types/Notification.ts
+++ b/client/src/Types/Notification.ts
@@ -11,6 +11,7 @@ export const NotificationChannels = [
 	"pushover",
 	"twilio",
 	"ntfy",
+	"apprise",
 ] as const;
 export type NotificationChannel = (typeof NotificationChannels)[number];
 
@@ -28,6 +29,7 @@ export interface Notification {
 	accountSid?: string;
 	twilioPhoneNumber?: string;
 	topic?: string;
+	appriseUrls?: string;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/client/src/Validation/notifications.ts
+++ b/client/src/Validation/notifications.ts
@@ -84,6 +84,23 @@ const ntfySchema = baseSchema.extend({
 	topic: z.string().min(1, "Topic is required"),
 });
 
+const appriseSchema = baseSchema
+	.extend({
+		type: z.literal("apprise"),
+		address: z.string().min(1, "Server URL is required").url("Please enter a valid URL"),
+		topic: z.string().optional(),
+		appriseUrls: z.string().optional(),
+	})
+	.superRefine((data, ctx) => {
+		if (!data.topic?.trim() && !data.appriseUrls?.trim()) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["topic"],
+				message: "A configuration key or at least one Apprise URL is required",
+			});
+		}
+	});
+
 export const notificationSchema = z.discriminatedUnion("type", [
 	emailSchema,
 	slackSchema,
@@ -97,6 +114,7 @@ export const notificationSchema = z.discriminatedUnion("type", [
 	pushoverSchema,
 	twilioSchema,
 	ntfySchema,
+	appriseSchema,
 ]);
 
 export type NotificationFormData = z.infer<typeof notificationSchema>;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1330,7 +1330,8 @@
 						"telegram": "Telegram",
 						"pushover": "Pushover",
 						"twilio": "Twilio",
-						"ntfy": "ntfy"
+						"ntfy": "ntfy",
+						"apprise": "Apprise"
 					}
 				},
 				"telegram": {
@@ -1368,6 +1369,16 @@
 					"placeholderServerUrl": "https://ntfy.sh",
 					"optionTopic": "Topic",
 					"placeholderTopic": "checkmate-alerts"
+				},
+				"apprise": {
+					"title": "Apprise configuration",
+					"description": "Send alerts through an Apprise API server to any service Apprise supports. Use a configuration key saved on the server, or list Apprise URLs directly.",
+					"optionServerUrl": "Apprise API server URL",
+					"placeholderServerUrl": "https://apprise.example.com",
+					"optionConfigKey": "Configuration key (optional)",
+					"placeholderConfigKey": "checkmate",
+					"optionUrls": "Apprise URLs (optional, comma-separated)",
+					"placeholderUrls": "tgram://bot-token/chat-id, mailto://user:pass@example.com"
 				}
 			},
 			"table": {

--- a/server/openapi/routes/notification.ts
+++ b/server/openapi/routes/notification.ts
@@ -87,6 +87,16 @@ const notificationVariantMeta: Record<string, { component: string; example: Reco
 			accessToken: "tk_your-ntfy-access-token",
 		},
 	},
+	apprise: {
+		component: "AppriseNotification",
+		example: {
+			notificationName: "Apprise",
+			type: "apprise",
+			address: "https://apprise.example.com",
+			topic: "checkmate",
+			appriseUrls: "",
+		},
+	},
 };
 
 const decoratedVariants = createNotificationBodyValidation.options.map((variant) => {

--- a/server/src/api/validation/notificationValidation.ts
+++ b/server/src/api/validation/notificationValidation.ts
@@ -39,6 +39,14 @@ const refineNtfyAuth = (body: { ntfyAuthType?: string; ntfyUsername?: string; ac
 	}
 };
 
+// Apprise posts to a server-side configuration key when one is set, otherwise to
+// the Apprise URLs given inline. Saving neither would create a channel with nowhere to send.
+const refineAppriseTarget = (body: { topic?: string; appriseUrls?: string }, ctx: z.RefinementCtx) => {
+	if (!body.topic?.trim() && !body.appriseUrls?.trim()) {
+		ctx.addIssue({ code: "custom", path: ["topic"], message: "A configuration key or at least one Apprise URL is required" });
+	}
+};
+
 export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 	// Email notification
 	z.object({
@@ -144,6 +152,16 @@ export const createNotificationBodyValidation = z.discriminatedUnion("type", [
 			accessToken: z.union([z.string(), z.literal("")]).optional(),
 		})
 		.superRefine(refineNtfyAuth),
+	// Apprise notification
+	z
+		.object({
+			notificationName: z.string().min(1, "Notification name is required"),
+			type: z.literal("apprise"),
+			address: z.url({ message: "Please enter a valid Apprise API server URL" }),
+			topic: z.union([z.string(), z.literal("")]).optional(),
+			appriseUrls: z.union([z.string(), z.literal("")]).optional(),
+		})
+		.superRefine(refineAppriseTarget),
 ]);
 
 export const testNotificationBodyValidation = createNotificationBodyValidation;

--- a/server/src/config/services.shared.ts
+++ b/server/src/config/services.shared.ts
@@ -35,6 +35,7 @@ import { TelegramProvider } from "@/domain/notifications/providers/telegram.js";
 import { PushoverProvider } from "@/domain/notifications/providers/pushover.js";
 import { TwilioProvider } from "@/domain/notifications/providers/twilio.js";
 import { NtfyProvider } from "@/domain/notifications/providers/ntfy.js";
+import { AppriseProvider } from "@/domain/notifications/providers/apprise.js";
 
 // Repository interfaces
 import { ISettingsRepository } from "@/domain/app-settings/app-settings-repository.interface.js";
@@ -180,6 +181,7 @@ export const buildShared = async ({
 	const pushoverProvider = new PushoverProvider(logger);
 	const twilioProvider = new TwilioProvider(logger);
 	const ntfyProvider = new NtfyProvider(logger);
+	const appriseProvider = new AppriseProvider(logger);
 
 	const notificationProviders: NotificationProviderRegistry = {
 		webhook: webhookProvider,
@@ -194,6 +196,7 @@ export const buildShared = async ({
 		pushover: pushoverProvider,
 		twilio: twilioProvider,
 		ntfy: ntfyProvider,
+		apprise: appriseProvider,
 	};
 
 	const notificationsService = new NotificationsService({

--- a/server/src/domain/notifications/notification.model.ts
+++ b/server/src/domain/notifications/notification.model.ts
@@ -39,6 +39,7 @@ const NotificationSchema = new Schema<NotificationDocument>(
 				"pushover",
 				"twilio",
 				"ntfy",
+				"apprise",
 			] as NotificationChannel[],
 			required: true,
 		},
@@ -56,6 +57,7 @@ const NotificationSchema = new Schema<NotificationDocument>(
 		topic: { type: String },
 		ntfyAuthType: { type: String, enum: NtfyAuthTypes },
 		ntfyUsername: { type: String },
+		appriseUrls: { type: String },
 	},
 	{
 		timestamps: true,

--- a/server/src/domain/notifications/notification.repository.mongo.ts
+++ b/server/src/domain/notifications/notification.repository.mongo.ts
@@ -28,6 +28,7 @@ class MongoNotificationsRepository implements INotificationsRepository {
 			accountSid: doc.accountSid ?? undefined,
 			twilioPhoneNumber: doc.twilioPhoneNumber ?? undefined,
 			topic: doc.topic ?? undefined,
+			appriseUrls: doc.appriseUrls ?? undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/domain/notifications/notification.type.ts
+++ b/server/src/domain/notifications/notification.type.ts
@@ -11,6 +11,7 @@ export const NotificationChannels = [
 	"pushover",
 	"twilio",
 	"ntfy",
+	"apprise",
 ] as const;
 export type NotificationChannel = (typeof NotificationChannels)[number];
 
@@ -35,6 +36,7 @@ export interface Notification {
 	topic?: string;
 	ntfyAuthType?: NtfyAuthType;
 	ntfyUsername?: string;
+	appriseUrls?: string;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/domain/notifications/providers/apprise.ts
+++ b/server/src/domain/notifications/providers/apprise.ts
@@ -1,0 +1,148 @@
+const SERVICE_NAME = "AppriseProvider";
+import type { Notification } from "@/domain/notifications/notification.type.js";
+import { NotificationProvider } from "@/domain/notifications/providers/INotificationProvider.js";
+import type { NotificationMessage } from "@/domain/notifications/notification.type.js";
+import { getTestMessage } from "@/domain/notifications/providers/utils.js";
+import got from "got";
+
+type AppriseType = "info" | "success" | "warning" | "failure";
+
+interface AppriseTarget {
+	url: string;
+	urls?: string;
+}
+
+/**
+ * Sends through an Apprise API server (https://github.com/caronc/apprise-api).
+ * `address` is the server URL. A configuration key stored in `topic` posts to
+ * /notify/{key}; otherwise the Apprise URLs in `appriseUrls` are posted to /notify.
+ */
+export class AppriseProvider extends NotificationProvider {
+	async sendTestAlert(notification: Partial<Notification>): Promise<boolean> {
+		const target = this.resolveTarget(notification, "sendTestAlert");
+		if (!target) {
+			return false;
+		}
+
+		try {
+			await got.post(target.url, {
+				json: this.buildPayload(target, "Checkmate test notification", getTestMessage(), "info"),
+				...this.gotRequestOptions(),
+			});
+			return true;
+		} catch (error) {
+			const err = error as Error;
+			this.logger.warn({
+				message: "Apprise test alert failed",
+				service: SERVICE_NAME,
+				method: "sendTestAlert",
+				stack: err?.stack,
+			});
+			return false;
+		}
+	}
+
+	async sendMessage(notification: Notification, message: NotificationMessage): Promise<boolean> {
+		const target = this.resolveTarget(notification, "sendMessage");
+		if (!target) {
+			return false;
+		}
+
+		try {
+			await got.post(target.url, {
+				json: this.buildPayload(target, message.content.title, this.buildText(message), this.mapType(message.severity)),
+				...this.gotRequestOptions(),
+			});
+			this.logger.info({
+				message: "Apprise notification sent",
+				service: SERVICE_NAME,
+				method: "sendMessage",
+			});
+			return true;
+		} catch (error) {
+			const err = error as Error;
+			this.logger.warn({
+				message: "Apprise alert failed",
+				service: SERVICE_NAME,
+				method: "sendMessage",
+				stack: err?.stack,
+			});
+			return false;
+		}
+	}
+
+	private resolveTarget(notification: Partial<Notification>, method: string): AppriseTarget | null {
+		const base = notification.address?.trim().replace(/\/+$/, "");
+		if (!base) {
+			return null;
+		}
+
+		const key = notification.topic?.trim();
+		if (key) {
+			return { url: `${base}/notify/${encodeURIComponent(key)}` };
+		}
+
+		const urls = notification.appriseUrls?.trim();
+		if (urls) {
+			return { url: `${base}/notify`, urls };
+		}
+
+		this.logger.warn({
+			message: "Apprise notification needs a configuration key or at least one Apprise URL",
+			service: SERVICE_NAME,
+			method,
+		});
+		return null;
+	}
+
+	private buildPayload(target: AppriseTarget, title: string, body: string, type: AppriseType): Record<string, string> {
+		const payload: Record<string, string> = { title, body, type, format: "text" };
+		if (target.urls) {
+			payload.urls = target.urls;
+		}
+		return payload;
+	}
+
+	private buildText(message: NotificationMessage): string {
+		const lines = [
+			message.content.summary,
+			"",
+			"Monitor Details:",
+			`- Name: ${message.monitor.name}`,
+			`- URL: ${message.monitor.url}`,
+			`- Type: ${message.monitor.type}`,
+			`- Status: ${message.monitor.status}`,
+		];
+
+		if (message.content.details && message.content.details.length > 0) {
+			lines.push("", "Additional Information:");
+			message.content.details.forEach((detail) => lines.push(`- ${detail}`));
+		}
+
+		if (message.content.thresholds && message.content.thresholds.length > 0) {
+			lines.push("", "Threshold Breaches:");
+			message.content.thresholds.forEach((breach) => {
+				lines.push(`- ${breach.metric.toUpperCase()}: ${breach.formattedValue} (threshold: ${breach.threshold}${breach.unit})`);
+			});
+		}
+
+		if (message.content.incident) {
+			lines.push("", `${message.clientHost}/infrastructure/${message.monitor.id}`);
+		}
+
+		return lines.join("\n");
+	}
+
+	private mapType(severity: NotificationMessage["severity"]): AppriseType {
+		switch (severity) {
+			case "critical":
+				return "failure";
+			case "warning":
+				return "warning";
+			case "success":
+				return "success";
+			default:
+				return "info";
+		}
+	}
+}

--- a/server/test/unit/providers/notifications/appriseProvider.test.ts
+++ b/server/test/unit/providers/notifications/appriseProvider.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
+import { createMockLogger } from "../../../helpers/createMockLogger.ts";
+import { makeNotification, makeMessage, makeMessageWithThresholds, makeMessageWithIncident } from "../../../helpers/notificationMessage.ts";
+import { testNotificationProviderContract } from "../../../helpers/notificationProviderContract.ts";
+
+const mockGotPost = jest.fn().mockResolvedValue({});
+jest.unstable_mockModule("got", () => ({ default: { post: mockGotPost } }));
+
+const { AppriseProvider } = await import("../../../../src/domain/notifications/providers/apprise.ts");
+
+const createProvider = () => {
+	const logger = createMockLogger();
+	return { provider: new AppriseProvider(logger as any), logger };
+};
+
+const makeAppriseNotification = (overrides = {}) =>
+	makeNotification({
+		address: "https://apprise.example.com/",
+		topic: "checkmate",
+		appriseUrls: "",
+		...overrides,
+	});
+
+const postedJson = () => mockGotPost.mock.calls[0][1].json;
+
+testNotificationProviderContract("AppriseProvider", {
+	create: () => {
+		mockGotPost.mockResolvedValue({});
+		return createProvider().provider;
+	},
+	makeNotification: () => makeAppriseNotification(),
+});
+
+describe("AppriseProvider", () => {
+	beforeEach(() => mockGotPost.mockReset().mockResolvedValue({}));
+
+	describe("sendTestAlert", () => {
+		it("posts the test message to the configuration key", async () => {
+			expect(await createProvider().provider.sendTestAlert(makeAppriseNotification())).toBe(true);
+			expect(mockGotPost).toHaveBeenCalledWith(
+				"https://apprise.example.com/notify/checkmate",
+				expect.objectContaining({
+					json: expect.objectContaining({ title: "Checkmate test notification", type: "info", format: "text" }),
+				})
+			);
+		});
+
+		it("returns false when address is missing", async () => {
+			expect(await createProvider().provider.sendTestAlert(makeAppriseNotification({ address: "" }))).toBe(false);
+			expect(mockGotPost).not.toHaveBeenCalled();
+		});
+
+		it("returns false and logs on error", async () => {
+			mockGotPost.mockRejectedValue(new Error("fail"));
+			const { provider, logger } = createProvider();
+			expect(await provider.sendTestAlert(makeAppriseNotification())).toBe(false);
+			expect(logger.warn).toHaveBeenCalled();
+		});
+	});
+
+	describe("sendMessage", () => {
+		it("posts the alert to the configuration key with a mapped type", async () => {
+			const { provider } = createProvider();
+			expect(await provider.sendMessage(makeAppriseNotification() as any, makeMessage())).toBe(true);
+			expect(mockGotPost).toHaveBeenCalledWith(
+				"https://apprise.example.com/notify/checkmate",
+				expect.objectContaining({
+					json: expect.objectContaining({
+						title: "Monitor Down: Test Monitor",
+						body: expect.stringContaining("Monitor Details"),
+						type: "failure",
+						format: "text",
+					}),
+				})
+			);
+			expect(postedJson().urls).toBeUndefined();
+		});
+
+		it("posts Apprise URLs to the stateless endpoint when no key is set", async () => {
+			const { provider } = createProvider();
+			const notification = makeAppriseNotification({ topic: "", appriseUrls: "tgram://token/chat, mailto://user:pass@example.com" });
+			expect(await provider.sendMessage(notification as any, makeMessage())).toBe(true);
+			expect(mockGotPost.mock.calls[0][0]).toBe("https://apprise.example.com/notify");
+			expect(postedJson().urls).toBe("tgram://token/chat, mailto://user:pass@example.com");
+		});
+
+		it("prefers the configuration key when both are set", async () => {
+			const { provider } = createProvider();
+			await provider.sendMessage(makeAppriseNotification({ appriseUrls: "tgram://token/chat" }) as any, makeMessage());
+			expect(mockGotPost.mock.calls[0][0]).toBe("https://apprise.example.com/notify/checkmate");
+			expect(postedJson().urls).toBeUndefined();
+		});
+
+		it("url-encodes the configuration key", async () => {
+			const { provider } = createProvider();
+			await provider.sendMessage(makeAppriseNotification({ topic: "ops alerts" }) as any, makeMessage());
+			expect(mockGotPost.mock.calls[0][0]).toBe("https://apprise.example.com/notify/ops%20alerts");
+		});
+
+		it.each([
+			["critical", "failure"],
+			["warning", "warning"],
+			["success", "success"],
+			["info", "info"],
+		])("maps %s severity to Apprise type %s", async (severity, expected) => {
+			const { provider } = createProvider();
+			await provider.sendMessage(makeAppriseNotification() as any, makeMessage({ severity: severity as any }));
+			expect(postedJson().type).toBe(expected);
+		});
+
+		it("returns false when address is missing", async () => {
+			expect(await createProvider().provider.sendMessage(makeAppriseNotification({ address: "" }) as any, makeMessage())).toBe(false);
+		});
+
+		it("returns false and logs when neither a key nor URLs are configured", async () => {
+			const { provider, logger } = createProvider();
+			expect(await provider.sendMessage(makeAppriseNotification({ topic: "", appriseUrls: "  " }) as any, makeMessage())).toBe(false);
+			expect(mockGotPost).not.toHaveBeenCalled();
+			expect(logger.warn).toHaveBeenCalled();
+		});
+
+		it("returns false and logs on error", async () => {
+			mockGotPost.mockRejectedValue(new Error("fail"));
+			const { provider, logger } = createProvider();
+			expect(await provider.sendMessage(makeAppriseNotification() as any, makeMessage())).toBe(false);
+			expect(logger.warn).toHaveBeenCalled();
+		});
+
+		it("includes threshold breaches in the body", async () => {
+			const { provider } = createProvider();
+			await provider.sendMessage(makeAppriseNotification() as any, makeMessageWithThresholds());
+			expect(postedJson().body).toContain("CPU");
+		});
+
+		it("includes incident links in the body", async () => {
+			const { provider } = createProvider();
+			await provider.sendMessage(makeAppriseNotification() as any, makeMessageWithIncident());
+			expect(postedJson().body).toContain("/infrastructure/mon-1");
+		});
+	});
+});

--- a/server/test/unit/validation/notificationValidation.test.ts
+++ b/server/test/unit/validation/notificationValidation.test.ts
@@ -45,6 +45,36 @@ describe("notification validation", () => {
 		}
 	);
 
+	describe("apprise target", () => {
+		const parseApprise = (overrides: Record<string, unknown>) =>
+			createNotificationBodyValidation.safeParse({
+				notificationName: "Apprise",
+				type: "apprise",
+				address: "https://apprise.example.com",
+				...overrides,
+			});
+
+		it("accepts a configuration key", () => {
+			expect(parseApprise({ topic: "checkmate" }).success).toBe(true);
+		});
+
+		it("accepts Apprise URLs without a key", () => {
+			expect(parseApprise({ appriseUrls: "tgram://token/chat" }).success).toBe(true);
+		});
+
+		it("rejects a channel with neither a key nor URLs", () => {
+			const result = parseApprise({ topic: "", appriseUrls: " " });
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues.map((issue) => issue.path.join("."))).toContain("topic");
+			}
+		});
+
+		it("rejects an invalid server URL", () => {
+			expect(parseApprise({ address: "not-a-url", topic: "checkmate" }).success).toBe(false);
+		});
+	});
+
 	describe("ntfy authentication", () => {
 		const parseNtfy = (overrides: Record<string, unknown>) =>
 			createNotificationBodyValidation.safeParse({


### PR DESCRIPTION
## Describe your changes

Adds an Apprise channel so one notification reaches anything Apprise supports.

It takes an Apprise API server URL plus either a configuration key stored on that server (posts to `/notify/{key}`) or Apprise URLs given inline (posts to `/notify`). Severity maps onto Apprise's `info`, `success`, `warning` and `failure` types. Validation requires at least one of key or URLs. The key reuses the existing `topic` field like ntfy does; `appriseUrls` is the one new field.

Tested against a local HTTP receiver standing in for Apprise: both modes post the expected payload, and the edit page reloads both fields. Screenshot below.

I left `openapi.json` untouched because regenerating it also pulls in unrelated drift from develop; the route metadata is added so the build stays green.

## Write your issue number after "Fixes "

Fixes #3272

- [x] I deployed the application locally.
- [x] I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings.
- [x] I have not included any files that are not related to my pull request.
- [x] I didn't use any hardcoded values.
- [x] I made sure font sizes, color choices etc are all referenced from the theme.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

![Apprise channel form](https://raw.githubusercontent.com/egeoztass/Checkmate/assets/pr-3927/pr-3927/apprise-create-form.png)
