### PR TITLE
fix: return ntfy auth fields from the notification repository

### DIFF
--- a/server/src/domain/notifications/notification.repository.mongo.ts
+++ b/server/src/domain/notifications/notification.repository.mongo.ts
@@ -28,6 +28,8 @@ class MongoNotificationsRepository implements INotificationsRepository {
 			accountSid: doc.accountSid ?? undefined,
 			twilioPhoneNumber: doc.twilioPhoneNumber ?? undefined,
 			topic: doc.topic ?? undefined,
+			ntfyAuthType: doc.ntfyAuthType ?? undefined,
+			ntfyUsername: doc.ntfyUsername ?? undefined,
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/test/integration/notificationRepository.test.ts
+++ b/server/test/integration/notificationRepository.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from "@jest/globals";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import MongoNotificationsRepository from "../../src/domain/notifications/notification.repository.mongo.ts";
+import { NotificationModel } from "../../src/domain/notifications/notification.model.ts";
+
+// ── Real-Mongo harness ─────────────────────────────────────────────────────────
+// Alerts are sent with whatever the repository mapper returns. A field the schema
+// stores but the mapper drops is silently ignored at send time, so this suite reads
+// stored channels back through the real repository rather than a mock.
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+	mongod = await MongoMemoryServer.create();
+	await mongoose.connect(mongod.getUri());
+	await NotificationModel.init();
+}, 120_000);
+
+afterAll(async () => {
+	await mongoose.disconnect();
+	await mongod.stop();
+});
+
+beforeEach(async () => {
+	await NotificationModel.deleteMany({});
+});
+
+const makeId = () => new mongoose.Types.ObjectId();
+
+describe("MongoNotificationsRepository", () => {
+	it("returns ntfy authentication fields when loading channels for sending", async () => {
+		const repo = new MongoNotificationsRepository();
+		const stored = await NotificationModel.create({
+			userId: makeId(),
+			teamId: makeId(),
+			type: "ntfy",
+			notificationName: "Protected topic",
+			address: "https://ntfy.example.com",
+			topic: "checkmate-alerts",
+			ntfyAuthType: "basic",
+			ntfyUsername: "alice",
+			accessToken: "s3cret",
+		});
+
+		const [loaded] = await repo.findNotificationsByIds([stored._id.toString()]);
+
+		expect(loaded).toMatchObject({
+			ntfyAuthType: "basic",
+			ntfyUsername: "alice",
+			accessToken: "s3cret",
+		});
+	});
+
+	it("returns ntfy authentication fields from findById", async () => {
+		const repo = new MongoNotificationsRepository();
+		const teamId = makeId();
+		const stored = await NotificationModel.create({
+			userId: makeId(),
+			teamId,
+			type: "ntfy",
+			notificationName: "Token topic",
+			address: "https://ntfy.example.com",
+			topic: "checkmate-alerts",
+			ntfyAuthType: "token",
+			accessToken: "tk_secret",
+		});
+
+		const loaded = await repo.findById(stored._id.toString(), teamId.toString());
+
+		expect(loaded.ntfyAuthType).toBe("token");
+		expect(loaded.ntfyUsername).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Describe your changes

`toEntity` in the notification repository never returned `ntfyAuthType` or `ntfyUsername`. Since alerts are sent with whatever the repository returns, the ntfy provider treated every channel as unauthenticated and posted anonymously. This adds the two fields to the mapper and a mongodb-memory-server test that reads a stored ntfy channel back through the real repository, which fails on develop and passes here.

Regression from #3839, sorry about that.

## Write your issue number after "Fixes "

Fixes #3928

- [x] I deployed the application locally.
- [x] I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] i18n (no visible strings).
- [x] I have not included any files that are not related to my pull request.
- [x] I didn't use any hardcoded values.
- [ ] Theme references (no UI).
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in the server directory.
- [ ] Screenshot or video (no UI change).
