### PR TITLE
fix: return systemEmailDisplayName from the settings repository

### DIFF
--- a/server/src/domain/app-settings/app-settings.repository.mongo.ts
+++ b/server/src/domain/app-settings/app-settings.repository.mongo.ts
@@ -15,6 +15,7 @@ class MongoSettingsRepository implements ISettingsRepository {
 			systemEmailHost: doc.systemEmailHost ?? undefined,
 			systemEmailPort: doc.systemEmailPort ?? undefined,
 			systemEmailAddress: doc.systemEmailAddress ?? undefined,
+			systemEmailDisplayName: doc.systemEmailDisplayName ?? undefined,
 			systemEmailPassword: doc.systemEmailPassword ?? undefined,
 			systemEmailUser: doc.systemEmailUser ?? undefined,
 			systemEmailConnectionHost: doc.systemEmailConnectionHost ?? undefined,

--- a/server/test/integration/appSettingsRepository.test.ts
+++ b/server/test/integration/appSettingsRepository.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from "@jest/globals";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import MongoAppSettingsRepository from "../../src/domain/app-settings/app-settings.repository.mongo.ts";
+import { AppSettingsModel } from "../../src/domain/app-settings/app-settings.model.ts";
+
+// ── Real-Mongo harness ─────────────────────────────────────────────────────────
+// Outgoing alert emails are built from whatever the repository mapper returns. A
+// field the schema stores but the mapper drops silently disappears from every real
+// send while still working in the test-email path, so read settings back through
+// the real repository rather than a mock.
+
+let mongod: MongoMemoryServer;
+
+beforeAll(async () => {
+	mongod = await MongoMemoryServer.create();
+	await mongoose.connect(mongod.getUri());
+	await AppSettingsModel.init();
+}, 120_000);
+
+afterAll(async () => {
+	await mongoose.disconnect();
+	await mongod.stop();
+});
+
+beforeEach(async () => {
+	await AppSettingsModel.deleteMany({});
+});
+
+describe("MongoAppSettingsRepository", () => {
+	it("returns the system email display name from findSingleton", async () => {
+		const repo = new MongoAppSettingsRepository();
+		await AppSettingsModel.create({
+			singleton: true,
+			systemEmailAddress: "alerts@example.com",
+			systemEmailDisplayName: "Checkmate Alerts",
+		});
+
+		const settings = await repo.findSingleton();
+
+		expect(settings).toMatchObject({
+			systemEmailAddress: "alerts@example.com",
+			systemEmailDisplayName: "Checkmate Alerts",
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes

Adds `systemEmailDisplayName` to the settings repository mapper so alert emails carry the configured sender name, matching what the test-email path already does. Includes a mongodb-memory-server test that reads settings back through the real repository; it fails on develop and passes here.

## Write your issue number after "Fixes "

Fixes #3930

- [x] I deployed the application locally.
- [x] I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [ ] i18n (no visible strings).
- [x] I have not included any files that are not related to my pull request.
- [x] I didn't use any hardcoded values.
- [ ] Theme references (no UI).
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in the server directory.
- [ ] Screenshot or video (no UI change).
