### PR TITLE
fix: admin gate docker logs

### DIFF
--- a/client/src/Pages/Docker/ContainerDetails/TabLogs.tsx
+++ b/client/src/Pages/Docker/ContainerDetails/TabLogs.tsx
@@ -23,6 +23,7 @@ import {
 import { useTheme } from "@mui/material";
 import { useTranslation } from "react-i18next";
 import { useToast } from "@/Hooks/UseToast";
+import { useIsAdmin } from "@/Hooks/useIsAdmin";
 
 // Utils
 import { get } from "@/Utils/ApiClient";
@@ -50,6 +51,7 @@ export const TabLogs = ({ monitorId, containerName, enabled }: TabLogsProps) => 
 	const theme = useTheme();
 	const { t } = useTranslation();
 	const { toastError } = useToast();
+	const isAdmin = useIsAdmin();
 
 	// logs is newest-first, matching the API and what flattenDockerLogs expects.
 	const [logs, setLogs] = useState<DockerLog[]>([]);
@@ -167,6 +169,15 @@ export const TabLogs = ({ monitorId, containerName, enabled }: TabLogsProps) => 
 			setLoadingOlder(false);
 		}
 	}, [logsUrl, oldestCursor, loadingOlder, t, toastError]);
+
+	if (!isAdmin) {
+		return (
+			<EmptyState
+				title={t("pages.docker.container.logs.forbidden.title")}
+				description={t("pages.docker.container.logs.forbidden.description")}
+			/>
+		);
+	}
 
 	if (!enabled) {
 		return (

--- a/client/src/Pages/Docker/ContainerDetails/TabLogs.tsx
+++ b/client/src/Pages/Docker/ContainerDetails/TabLogs.tsx
@@ -61,7 +61,7 @@ export const TabLogs = ({ monitorId, containerName, enabled }: TabLogsProps) => 
 	const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null);
 
 	const logsUrl =
-		enabled && monitorId && containerName
+		isAdmin && enabled && monitorId && containerName
 			? `/monitors/docker/details/${encodeURIComponent(monitorId)}/containers/${encodeURIComponent(containerName)}/logs`
 			: null;
 

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -985,6 +985,10 @@
 						"title": "Log collection is off for this host",
 						"description": "Turn on container logs in the monitor settings to start collecting.",
 						"action": "Configure monitor"
+					},
+					"forbidden": {
+						"title": "You don't have access to container logs",
+						"description": "Only administrators can view logs. Ask an administrator for access if you need to see them."
 					}
 				}
 			},

--- a/server/src/api/routes/monitorRoutes.ts
+++ b/server/src/api/routes/monitorRoutes.ts
@@ -21,7 +21,11 @@ export const createMonitorRoutes = (monitorController: IMonitorController): Rout
 	// Docker routes
 	router.get("/docker/details/:monitorId", monitorController.getDockerDetailsById);
 	router.get("/docker/details/:monitorId/containers/:containerName", monitorController.getDockerContainerByName);
-	router.get("/docker/details/:monitorId/containers/:containerName/logs", monitorController.getDockerContainerLogs);
+	router.get(
+		"/docker/details/:monitorId/containers/:containerName/logs",
+		isAllowed(["admin", "superadmin"]),
+		monitorController.getDockerContainerLogs
+	);
 
 	// Geo checks routes
 	router.get("/:monitorId/geo-checks", monitorController.getGeoChecksByMonitorId);


### PR DESCRIPTION
This PR gates Docker logs behind admin check

## Changes
- [x] Gate the container logs API route behind admin and superadmin roles
- [x] Show forbidden message on the logs tab for non admin users
- [x] Skip the logs fetch and polling for non admin users