### PR TITLE
Add tag targeting to maintenance windows

### DIFF
--- a/client/src/Hooks/useMaintenanceWindowForm.ts
+++ b/client/src/Hooks/useMaintenanceWindowForm.ts
@@ -34,6 +34,7 @@ export const useMaintenanceWindowForm = ({
 				duration: data.duration ?? 0,
 				durationUnit: data.durationUnit ?? "minutes",
 				monitors: data.monitorIds,
+				tags: data.tagIds ?? [],
 			};
 		} else {
 			const now = dayjs();
@@ -45,6 +46,7 @@ export const useMaintenanceWindowForm = ({
 				duration: 0,
 				durationUnit: "minutes",
 				monitors: [],
+				tags: [],
 			};
 		}
 

--- a/client/src/Pages/Maintenance/create/index.tsx
+++ b/client/src/Pages/Maintenance/create/index.tsx
@@ -1,3 +1,4 @@
+import Box from "@mui/material/Box";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import { logger } from "@/Utils/logger";
@@ -81,6 +82,7 @@ const CreateMaintenanceWindowPage = () => {
 			duration: data.duration,
 			durationUnit: data.durationUnit,
 			monitors: data.monitors,
+			tags: data.tags,
 			start: startDateTime.toISOString(),
 			end: endDateTime.toISOString(),
 			repeat,
@@ -225,6 +227,36 @@ const CreateMaintenanceWindowPage = () => {
 										) : null;
 									})}
 								</Stack>
+							)}
+						/>
+					}
+				/>
+				<ConfigBox
+					title={t("pages.maintenanceWindow.form.startTime.tags.title")}
+					subtitle={t("pages.maintenanceWindow.form.startTime.tags.description")}
+					rightContent={
+						<FormMultiSelectField
+							name="tags"
+							fieldLabel={t(
+								"pages.maintenanceWindow.form.startTime.tags.option.addTags.label"
+							)}
+							placeholder={t(
+								"pages.maintenanceWindow.form.startTime.tags.option.addTags.label"
+							)}
+							options={tags ?? []}
+							renderRow={(tag) => (
+								<Box flexGrow={1}>
+									<ColoredLabel
+										text={tag.name}
+										color={tag.color}
+									/>
+								</Box>
+							)}
+							renderOptionContent={(option) => (
+								<ColoredLabel
+									text={option.name}
+									color={option.color}
+								/>
 							)}
 						/>
 					}

--- a/client/src/Types/MaintenanceWindow.ts
+++ b/client/src/Types/MaintenanceWindow.ts
@@ -3,6 +3,7 @@ export type DurationUnit = "seconds" | "minutes" | "hours" | "days";
 export interface MaintenanceWindow {
 	id: string;
 	monitorIds: string[];
+	tagIds: string[];
 	teamId: string;
 	active: boolean;
 	name: string;

--- a/client/src/Validation/maintenanceWindow.ts
+++ b/client/src/Validation/maintenanceWindow.ts
@@ -24,10 +24,20 @@ const maintenanceWindowBaseSchema = z.object({
 	startTime: z.string().min(1, "Start time is required"),
 	duration: z.number().int().min(1, "Duration must be at least 1"),
 	durationUnit: z.string(),
-	monitors: z.array(z.string()).min(1, "At least one monitor is required"),
+	monitors: z.array(z.string()),
+	tags: z.array(z.string()),
 });
 
-export const maintenanceWindowSchema = maintenanceWindowBaseSchema.refine(
+// Monitors and tags are additive targets; a window needs at least one of either
+const maintenanceWindowTargetsSchema = maintenanceWindowBaseSchema.refine(
+	(data) => data.monitors.length > 0 || data.tags.length > 0,
+	{
+		message: "At least one monitor or tag is required",
+		path: ["monitors"],
+	}
+);
+
+export const maintenanceWindowSchema = maintenanceWindowTargetsSchema.refine(
 	(data) => {
 		const startDateTime = dayjs(data.startDate)
 			.set("hour", parseInt(data.startTime.split(":")[0], 10))
@@ -40,6 +50,6 @@ export const maintenanceWindowSchema = maintenanceWindowBaseSchema.refine(
 	}
 );
 
-export const maintenanceWindowEditSchema = maintenanceWindowBaseSchema;
+export const maintenanceWindowEditSchema = maintenanceWindowTargetsSchema;
 
 export type MaintenanceWindowFormData = z.infer<typeof maintenanceWindowSchema>;

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1270,6 +1270,15 @@
 								"label": "Add monitors"
 							}
 						}
+					},
+					"tags": {
+						"title": "Tags",
+						"description": "Every monitor carrying one of these tags is also covered, in addition to the monitors selected above",
+						"option": {
+							"addTags": {
+								"label": "Add tags"
+							}
+						}
 					}
 				}
 			},

--- a/server/src/api/controllers/maintenanceWindowController.ts
+++ b/server/src/api/controllers/maintenanceWindowController.ts
@@ -31,6 +31,7 @@ class MaintenanceWindowController implements IMaintenanceWindowController {
 		const teamId = requireTeamId(req?.user?.teamId);
 
 		const monitorIDs = validatedBody.monitors;
+		const tagIDs = validatedBody.tags;
 		const name = validatedBody.name;
 		const active = validatedBody.active ?? true;
 		const duration = validatedBody.duration;
@@ -39,7 +40,18 @@ class MaintenanceWindowController implements IMaintenanceWindowController {
 		const start = validatedBody.start;
 		const end = validatedBody.end;
 
-		await this.maintenanceWindowService.createMaintenanceWindow({ teamId, monitorIDs, name, active, duration, durationUnit, repeat, start, end });
+		await this.maintenanceWindowService.createMaintenanceWindow({
+			teamId,
+			monitorIDs,
+			tagIDs,
+			name,
+			active,
+			duration,
+			durationUnit,
+			repeat,
+			start,
+			end,
+		});
 
 		return res.status(200).json({
 			success: true,

--- a/server/src/api/validation/maintenanceWindowValidation.ts
+++ b/server/src/api/validation/maintenanceWindowValidation.ts
@@ -11,7 +11,8 @@ const dateToString = z.coerce.date().transform((d) => d.toISOString());
 
 export const createMaintenanceWindowBodyValidation = z
 	.object({
-		monitors: z.array(z.string()).min(1, "At least one monitor is required"),
+		monitors: z.array(z.string()).default([]),
+		tags: z.array(z.string()).default([]),
 		name: z.string().min(1, "Name is required"),
 		active: z.boolean().optional(),
 		duration: z.number().min(1, "Duration is required"),
@@ -23,6 +24,13 @@ export const createMaintenanceWindowBodyValidation = z
 	})
 	.strict()
 	.superRefine((data, ctx) => {
+		if (data.monitors.length === 0 && data.tags.length === 0) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "At least one monitor or tag is required",
+				path: ["monitors"],
+			});
+		}
 		const start = new Date(data.start).getTime();
 		const end = new Date(data.end).getTime();
 		if (end <= start) {
@@ -73,12 +81,20 @@ export const editMaintenanceByIdWindowBodyValidation = z
 		start: dateToString.optional(),
 		end: dateToString.optional(),
 		expiry: dateToString.optional(),
-		monitors: z.array(z.string()).min(1, "At least one monitor is required").optional(),
+		monitors: z.array(z.string()).optional(),
+		tags: z.array(z.string()).optional(),
 		duration: z.number().optional(),
 		durationUnit: z.enum(DurationUnits).optional(),
 	})
 	.strict()
 	.superRefine((data, ctx) => {
+		if (data.monitors !== undefined && data.tags !== undefined && data.monitors.length === 0 && data.tags.length === 0) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "At least one monitor or tag is required",
+				path: ["monitors"],
+			});
+		}
 		if (data.start && data.end) {
 			const start = new Date(data.start).getTime();
 			const end = new Date(data.end).getTime();

--- a/server/src/config/services.api.ts
+++ b/server/src/config/services.api.ts
@@ -85,6 +85,7 @@ export const buildApi = (shared: SharedServices, jobScheduler: IJobScheduler): A
 	const maintenanceWindowService = new MaintenanceWindowService({
 		monitorsRepository,
 		maintenanceWindowsRepository,
+		tagsRepository,
 		jobsRepository,
 		scheduler: jobScheduler,
 	});
@@ -96,7 +97,7 @@ export const buildApi = (shared: SharedServices, jobScheduler: IJobScheduler): A
 	});
 
 	const statusPageService = new StatusPageService(statusPagesRepository, settingsService, monitorsRepository, checksRepository);
-	const tagsService = new TagsService(tagsRepository, monitorsRepository);
+	const tagsService = new TagsService(tagsRepository, monitorsRepository, maintenanceWindowsRepository);
 	const diagnosticService = new DiagnosticService(db);
 	const proxiesService = new ProxiesService(proxiesRepository, monitorsRepository, settingsService);
 	return {

--- a/server/src/domain/maintenance-windows/maintenance-window.model.ts
+++ b/server/src/domain/maintenance-windows/maintenance-window.model.ts
@@ -1,8 +1,12 @@
 import { Schema, model, type Types } from "mongoose";
 import { DurationUnits, type MaintenanceWindow } from "@/domain/maintenance-windows/maintenance-window.type.js";
 
-type MaintenanceWindowDocumentBase = Omit<MaintenanceWindow, "id" | "monitorIds" | "teamId" | "start" | "end" | "createdAt" | "updatedAt"> & {
+type MaintenanceWindowDocumentBase = Omit<
+	MaintenanceWindow,
+	"id" | "monitorIds" | "tagIds" | "teamId" | "start" | "end" | "createdAt" | "updatedAt"
+> & {
 	monitorIds: Types.ObjectId[];
+	tagIds: Types.ObjectId[];
 	teamId: Types.ObjectId;
 	start: Date;
 	end: Date;
@@ -21,6 +25,12 @@ const MaintenanceWindowSchema = new Schema<MaintenanceWindowDocument>(
 			type: [Schema.Types.ObjectId],
 			ref: "Monitor",
 			index: true,
+		},
+		tagIds: {
+			type: [Schema.Types.ObjectId],
+			ref: "Tag",
+			index: true,
+			default: [],
 		},
 		teamId: {
 			type: Schema.Types.ObjectId,

--- a/server/src/domain/maintenance-windows/maintenance-window.repository.interface.ts
+++ b/server/src/domain/maintenance-windows/maintenance-window.repository.interface.ts
@@ -4,8 +4,9 @@ export interface IMaintenanceWindowsRepository {
 	create(data: Partial<MaintenanceWindow>): Promise<MaintenanceWindow>;
 	// fetch
 	findById(id: string, teamId: string): Promise<MaintenanceWindow>;
-	findByMonitorId(monitorId: string, teamId: string): Promise<MaintenanceWindow[]>;
-	findByMonitorIds(monitorIds: string[], teamId: string, excludeId?: string): Promise<MaintenanceWindow[]>;
+	// Windows that cover a monitor either directly (monitorIds) or through one of the monitor's tags (tagIds)
+	findByMonitorId(monitorId: string, teamId: string, tagIds?: string[]): Promise<MaintenanceWindow[]>;
+	findByMonitorIds(monitorIds: string[], teamId: string, excludeId?: string, tagIds?: string[]): Promise<MaintenanceWindow[]>;
 	findByTeamId(teamId: string, page: number, rowsPerPage: number, field?: string, order?: string, active?: boolean): Promise<MaintenanceWindow[]>;
 
 	// update
@@ -14,4 +15,5 @@ export interface IMaintenanceWindowsRepository {
 	deleteById(id: string, teamId: string): Promise<MaintenanceWindow>;
 	// other
 	countByTeamId(teamId: string, active?: boolean): Promise<number>;
+	removeTagFromWindows(tagId: string): Promise<void>;
 }

--- a/server/src/domain/maintenance-windows/maintenance-window.repository.mongo.ts
+++ b/server/src/domain/maintenance-windows/maintenance-window.repository.mongo.ts
@@ -16,6 +16,7 @@ class MongoMaintenanceWindowsRepository implements IMaintenanceWindowsRepository
 		return {
 			id: toStringId(doc._id),
 			monitorIds: doc.monitorIds.map(toStringId),
+			tagIds: (doc.tagIds ?? []).map(toStringId),
 			teamId: toStringId(doc.teamId),
 			active: doc.active,
 			name: doc.name,
@@ -51,9 +52,9 @@ class MongoMaintenanceWindowsRepository implements IMaintenanceWindowsRepository
 		return this.toEntity(maintenanceWindow);
 	};
 
-	findByMonitorIds = async (monitorIds: string[], teamId: string, excludeId?: string): Promise<MaintenanceWindow[]> => {
+	findByMonitorIds = async (monitorIds: string[], teamId: string, excludeId?: string, tagIds: string[] = []): Promise<MaintenanceWindow[]> => {
 		const query: Record<string, unknown> = {
-			monitorIds: { $in: monitorIds },
+			$or: [{ monitorIds: { $in: monitorIds } }, { tagIds: { $in: tagIds } }],
 			teamId,
 		};
 		if (excludeId) {
@@ -63,9 +64,9 @@ class MongoMaintenanceWindowsRepository implements IMaintenanceWindowsRepository
 		return this.mapDocuments(maintenanceWindows);
 	};
 
-	findByMonitorId = async (monitorId: string, teamId: string): Promise<MaintenanceWindow[]> => {
+	findByMonitorId = async (monitorId: string, teamId: string, tagIds: string[] = []): Promise<MaintenanceWindow[]> => {
 		const maintenanceWindows = await MaintenanceWindowModel.find({
-			monitorIds: monitorId,
+			$or: [{ monitorIds: monitorId }, { tagIds: { $in: tagIds } }],
 			teamId: teamId,
 		});
 		return this.mapDocuments(maintenanceWindows);
@@ -132,6 +133,10 @@ class MongoMaintenanceWindowsRepository implements IMaintenanceWindowsRepository
 		if (active !== undefined) maintenanceQuery.active = active;
 
 		return await MaintenanceWindowModel.countDocuments(maintenanceQuery);
+	};
+
+	removeTagFromWindows = async (tagId: string): Promise<void> => {
+		await MaintenanceWindowModel.updateMany({ tagIds: tagId }, { $pull: { tagIds: tagId } });
 	};
 }
 

--- a/server/src/domain/maintenance-windows/maintenance-window.service.ts
+++ b/server/src/domain/maintenance-windows/maintenance-window.service.ts
@@ -1,17 +1,23 @@
 import { IMaintenanceWindowsRepository } from "@/domain/maintenance-windows/maintenance-window.repository.interface.js";
 import { IMonitorsRepository } from "@/domain/monitors/monitor.repository.interface.js";
 import { IJobsRepository } from "@/domain/jobs/job.repository.interface.js";
+import { ITagsRepository } from "@/domain/tags/tag.repository.interface.js";
 import type { DurationUnit, MaintenanceWindow } from "@/domain/maintenance-windows/maintenance-window.type.js";
 import { AppError } from "@/utils/AppError.js";
-import { isWindowActive } from "@/utils/maintenanceWindow.js";
+import { isWindowActive, windowCoversMonitor } from "@/utils/maintenanceWindow.js";
 import { IJobScheduler } from "@/worker/worker.interface.js";
 
 const SERVICE_NAME = "maintenanceWindowService";
+
+// Maps the calling method to the verb used in ownership error messages
+const VERB_BY_METHOD = { createMaintenanceWindow: "create", editMaintenanceWindow: "edit" } as const;
+type OwnershipCheckMethod = keyof typeof VERB_BY_METHOD;
 
 export interface IMaintenanceWindowService {
 	createMaintenanceWindow(params: {
 		teamId: string;
 		monitorIDs: string[];
+		tagIDs: string[];
 		name: string;
 		active: boolean;
 		duration: number;
@@ -34,7 +40,7 @@ export interface IMaintenanceWindowService {
 	editMaintenanceWindow(params: {
 		id: string;
 		teamId: string;
-		body: Partial<Omit<MaintenanceWindow, "monitorIds">> & { monitors?: string[] };
+		body: Partial<Omit<MaintenanceWindow, "monitorIds" | "tagIds">> & { monitors?: string[]; tags?: string[] };
 	}): Promise<MaintenanceWindow>;
 }
 
@@ -42,35 +48,78 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 	static SERVICE_NAME = SERVICE_NAME;
 	private monitorsRepository: IMonitorsRepository;
 	private maintenanceWindowsRepository: IMaintenanceWindowsRepository;
+	private tagsRepository: ITagsRepository;
 	private jobsRepository: IJobsRepository;
 	private scheduler: IJobScheduler;
 
 	constructor({
 		monitorsRepository,
 		maintenanceWindowsRepository,
+		tagsRepository,
 		jobsRepository,
 		scheduler,
 	}: {
 		monitorsRepository: IMonitorsRepository;
 		maintenanceWindowsRepository: IMaintenanceWindowsRepository;
+		tagsRepository: ITagsRepository;
 		jobsRepository: IJobsRepository;
 		scheduler: IJobScheduler;
 	}) {
 		this.monitorsRepository = monitorsRepository;
 		this.maintenanceWindowsRepository = maintenanceWindowsRepository;
+		this.tagsRepository = tagsRepository;
 		this.jobsRepository = jobsRepository;
 		this.scheduler = scheduler;
 	}
 
+	private assertMonitorsOwned = async (monitorIds: string[], teamId: string, method: OwnershipCheckMethod): Promise<void> => {
+		if (monitorIds.length === 0) return;
+		const monitors = await this.monitorsRepository.findByIds(monitorIds, { recentChecks: "none" });
+		const unauthorizedMonitors = monitors.filter((monitor) => monitor.teamId !== teamId);
+		if (unauthorizedMonitors.length > 0) {
+			throw new AppError({
+				message: `Unauthorized to ${VERB_BY_METHOD[method]} maintenance window for one or more monitors`,
+				service: SERVICE_NAME,
+				method,
+				status: 403,
+			});
+		}
+	};
+
+	private assertTagsOwned = async (tagIds: string[], teamId: string, method: OwnershipCheckMethod): Promise<void> => {
+		if (tagIds.length === 0) return;
+		const tags = await this.tagsRepository.findByIds(tagIds, teamId);
+		if (tags.length !== new Set(tagIds).size) {
+			throw new AppError({
+				message: `Unauthorized to ${VERB_BY_METHOD[method]} maintenance window for one or more tags`,
+				service: SERVICE_NAME,
+				method,
+				status: 403,
+			});
+		}
+	};
+
+	// The monitors a window covers: those listed directly plus every team monitor carrying one of its tags.
+	// Union semantics, so a monitor picked both ways is included once.
+	private resolveMonitorIds = async (window: MaintenanceWindow): Promise<string[]> => {
+		const taggedMonitorIds = await this.monitorsRepository.findIdsByTagIds(window.tagIds, window.teamId);
+		return Array.from(new Set([...window.monitorIds, ...taggedMonitorIds]));
+	};
+
 	private flipMonitorsLeavingMaintenance = async (monitorIds: string[], teamId: string, excludeWindowId: string, now: Date): Promise<void> => {
 		if (monitorIds.length === 0) return;
 
-		const otherWindows = await this.maintenanceWindowsRepository.findByMonitorIds(monitorIds, teamId, excludeWindowId);
+		// Other windows may still cover a leaving monitor through its tags, so look those up as well
+		const monitors = await this.monitorsRepository.findByIds(monitorIds, { recentChecks: "none" });
+		const tagIdsByMonitor = new Map(monitors.map((monitor) => [monitor.id, monitor.tags ?? []]));
+		const tagIds = Array.from(new Set(monitors.flatMap((monitor) => monitor.tags ?? [])));
+
+		const otherWindows = await this.maintenanceWindowsRepository.findByMonitorIds(monitorIds, teamId, excludeWindowId, tagIds);
 		const stillCovered = new Set<string>();
 		for (const otherWindow of otherWindows) {
 			if (!isWindowActive(otherWindow, now)) continue;
-			for (const monitorId of otherWindow.monitorIds) {
-				if (monitorIds.includes(monitorId)) stillCovered.add(monitorId);
+			for (const monitorId of monitorIds) {
+				if (windowCoversMonitor(otherWindow, monitorId, tagIdsByMonitor.get(monitorId))) stillCovered.add(monitorId);
 			}
 		}
 
@@ -88,6 +137,7 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 	createMaintenanceWindow = async ({
 		teamId,
 		monitorIDs,
+		tagIDs,
 		name,
 		active,
 		duration,
@@ -98,6 +148,7 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 	}: {
 		teamId: string;
 		monitorIDs: string[];
+		tagIDs: string[];
 		name: string;
 		active: boolean;
 		duration: number;
@@ -106,22 +157,13 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 		start: string;
 		end: string;
 	}) => {
-		const monitors = await this.monitorsRepository.findByIds(monitorIDs, { recentChecks: "none" });
-
-		const unauthorizedMonitors = monitors.filter((monitor) => monitor.teamId !== teamId);
-
-		if (unauthorizedMonitors.length > 0) {
-			throw new AppError({
-				message: "Unauthorized to create maintenance window for one or more monitors",
-				service: SERVICE_NAME,
-				method: "createMaintenanceWindow",
-				status: 403,
-			});
-		}
+		await this.assertMonitorsOwned(monitorIDs, teamId, "createMaintenanceWindow");
+		await this.assertTagsOwned(tagIDs, teamId, "createMaintenanceWindow");
 
 		const created = await this.maintenanceWindowsRepository.create({
 			teamId,
 			monitorIds: monitorIDs,
+			tagIds: tagIDs,
 			name: name,
 			active: active,
 			duration: duration,
@@ -132,7 +174,10 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 		});
 
 		if (isWindowActive(created)) {
-			await this.monitorsRepository.updateByIds(created.monitorIds, teamId, { status: "maintenance" }, ["paused"]);
+			const coveredMonitorIds = await this.resolveMonitorIds(created);
+			if (coveredMonitorIds.length > 0) {
+				await this.monitorsRepository.updateByIds(coveredMonitorIds, teamId, { status: "maintenance" }, ["paused"]);
+			}
 		}
 	};
 
@@ -164,7 +209,8 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 	};
 
 	getMaintenanceWindowsByMonitorId = async ({ monitorId, teamId }: { monitorId: string; teamId: string }) => {
-		return await this.maintenanceWindowsRepository.findByMonitorId(monitorId, teamId);
+		const monitor = await this.monitorsRepository.findById(monitorId, teamId);
+		return await this.maintenanceWindowsRepository.findByMonitorId(monitorId, teamId, monitor.tags ?? []);
 	};
 
 	deleteMaintenanceWindow = async ({ id, teamId }: { id: string; teamId: string }) => {
@@ -172,7 +218,7 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 
 		const now = new Date();
 		if (isWindowActive(deleted, now)) {
-			await this.flipMonitorsLeavingMaintenance(deleted.monitorIds, teamId, deleted.id, now);
+			await this.flipMonitorsLeavingMaintenance(await this.resolveMonitorIds(deleted), teamId, deleted.id, now);
 		}
 
 		return deleted;
@@ -185,36 +231,48 @@ export class MaintenanceWindowService implements IMaintenanceWindowService {
 	}: {
 		id: string;
 		teamId: string;
-		body: Partial<Omit<MaintenanceWindow, "monitorIds">> & { monitors?: string[] };
+		body: Partial<Omit<MaintenanceWindow, "monitorIds" | "tagIds">> & { monitors?: string[]; tags?: string[] };
 	}) => {
 		const existing = await this.maintenanceWindowsRepository.findById(id, teamId);
 
-		const { monitors, ...rest } = body;
+		const { monitors, tags, ...rest } = body;
 		const update: Partial<MaintenanceWindow> = rest;
 
 		if (monitors !== undefined) {
-			const monitorDocs = await this.monitorsRepository.findByIds(monitors, { recentChecks: "none" });
-			const unauthorizedMonitors = monitorDocs.filter((monitor) => monitor.teamId !== teamId);
-			if (unauthorizedMonitors.length > 0) {
-				throw new AppError({
-					message: "Unauthorized to edit maintenance window for one or more monitors",
-					service: SERVICE_NAME,
-					method: "editMaintenanceWindow",
-					status: 403,
-				});
-			}
+			await this.assertMonitorsOwned(monitors, teamId, "editMaintenanceWindow");
 			update.monitorIds = monitors;
 		}
 
+		if (tags !== undefined) {
+			await this.assertTagsOwned(tags, teamId, "editMaintenanceWindow");
+			update.tagIds = tags;
+		}
+
+		// A window must keep at least one target once the partial update is applied
+		const nextMonitorIds = update.monitorIds ?? existing.monitorIds;
+		const nextTagIds = update.tagIds ?? existing.tagIds;
+		if (nextMonitorIds.length === 0 && nextTagIds.length === 0) {
+			throw new AppError({
+				message: "At least one monitor or tag is required",
+				service: SERVICE_NAME,
+				method: "editMaintenanceWindow",
+				status: 400,
+			});
+		}
+
+		// Resolve tag membership before the update so both sides reflect the same monitor set
+		const existingMonitorIds = await this.resolveMonitorIds(existing);
+
 		const updated = await this.maintenanceWindowsRepository.updateById(id, teamId, update);
+		const updatedMonitorIds = await this.resolveMonitorIds(updated);
 
 		const now = new Date();
 		const wasActive = isWindowActive(existing, now);
 		const isActive = isWindowActive(updated, now);
 
-		const enteringMaintenance = isActive ? updated.monitorIds.filter((monitorId) => !wasActive || !existing.monitorIds.includes(monitorId)) : [];
+		const enteringMaintenance = isActive ? updatedMonitorIds.filter((monitorId) => !wasActive || !existingMonitorIds.includes(monitorId)) : [];
 
-		const leavingCandidates = wasActive ? existing.monitorIds.filter((monitorId) => !isActive || !updated.monitorIds.includes(monitorId)) : [];
+		const leavingCandidates = wasActive ? existingMonitorIds.filter((monitorId) => !isActive || !updatedMonitorIds.includes(monitorId)) : [];
 
 		if (enteringMaintenance.length > 0) {
 			await this.monitorsRepository.updateByIds(enteringMaintenance, teamId, { status: "maintenance" }, ["paused"]);

--- a/server/src/domain/maintenance-windows/maintenance-window.type.ts
+++ b/server/src/domain/maintenance-windows/maintenance-window.type.ts
@@ -4,6 +4,7 @@ export type DurationUnit = (typeof DurationUnits)[number];
 export interface MaintenanceWindow {
 	id: string;
 	monitorIds: string[];
+	tagIds: string[];
 	teamId: string;
 	active: boolean;
 	name: string;

--- a/server/src/domain/monitors/monitor.repository.interface.ts
+++ b/server/src/domain/monitors/monitor.repository.interface.ts
@@ -32,6 +32,7 @@ export interface IMonitorsRepository {
 	findByTeamId(teamId: string, config: TeamQueryConfig, options?: { includeRecentChecks?: boolean }): Promise<Monitor[]>;
 	findByTeamIdWithStats(teamId: string, config: TeamQueryConfig): Promise<Monitor[]>;
 	findByIds(monitorIds: string[], options?: { recentChecks?: RecentChecksMode }): Promise<Monitor[]>;
+	findIdsByTagIds(tagIds: string[], teamId: string): Promise<string[]>;
 
 	// update
 	updateById(monitorId: string, teamId: string, updates: Partial<Monitor>, options?: { unsetProxyId?: boolean }): Promise<Monitor>;

--- a/server/src/domain/monitors/monitor.repository.mongo.ts
+++ b/server/src/domain/monitors/monitor.repository.mongo.ts
@@ -166,6 +166,14 @@ class MongoMonitorsRepository implements IMonitorsRepository {
 		return documents.map((doc) => this.toEntity(doc));
 	};
 
+	findIdsByTagIds = async (tagIds: string[], teamId: string): Promise<string[]> => {
+		if (!tagIds.length) {
+			return [];
+		}
+		const documents = await MonitorModel.find({ teamId, tags: { $in: tagIds } }, { _id: 1 }).lean();
+		return documents.map((doc) => doc._id.toString());
+	};
+
 	findMonitorCountByTeamIdAndType = async (teamId: string, config: TeamQueryConfig): Promise<number> => {
 		const query = this.queryBuilder(config, teamId);
 		const count = await MonitorModel.countDocuments(query);

--- a/server/src/domain/tags/tag.repository.interface.ts
+++ b/server/src/domain/tags/tag.repository.interface.ts
@@ -5,6 +5,7 @@ export interface ITagsRepository {
 	create(tagData: Partial<Tag>): Promise<Tag>;
 	// read
 	findById(tagId: string, teamId: string): Promise<Tag>;
+	findByIds(tagIds: string[], teamId: string): Promise<Tag[]>;
 	findByTeamId(teamId: string): Promise<Tag[]>;
 	// update
 	updateById(tagId: string, teamId: string, patch: Partial<Tag>): Promise<Tag>;

--- a/server/src/domain/tags/tag.repository.mongo.ts
+++ b/server/src/domain/tags/tag.repository.mongo.ts
@@ -40,6 +40,11 @@ class MongoTagsRepository implements ITagsRepository {
 		return this.toEntity(tag);
 	}
 
+	async findByIds(tagIds: string[], teamId: string): Promise<Tag[]> {
+		const tags = await TagModel.find({ _id: { $in: tagIds }, teamId });
+		return tags.map(this.toEntity);
+	}
+
 	async findByTeamId(teamId: string): Promise<Tag[]> {
 		const tags = await TagModel.find({ teamId });
 		return tags.map(this.toEntity);

--- a/server/src/domain/tags/tag.service.ts
+++ b/server/src/domain/tags/tag.service.ts
@@ -1,6 +1,7 @@
 import { Tag } from "@/domain/tags/tag.type.js";
 import { IMonitorsRepository } from "@/domain/monitors/monitor.repository.interface.js";
 import { ITagsRepository } from "@/domain/tags/tag.repository.interface.js";
+import { IMaintenanceWindowsRepository } from "@/domain/maintenance-windows/maintenance-window.repository.interface.js";
 export interface ITagsService {
 	createTag(tag: Partial<Tag>, teamId: string): Promise<Tag>;
 	getTag(tagId: string, teamId: string): Promise<Tag>;
@@ -12,7 +13,8 @@ export interface ITagsService {
 export class TagsService implements ITagsService {
 	constructor(
 		private tagsRepository: ITagsRepository,
-		private monitorsRepository: IMonitorsRepository
+		private monitorsRepository: IMonitorsRepository,
+		private maintenanceWindowsRepository: IMaintenanceWindowsRepository
 	) {}
 
 	createTag = async (tagData: Partial<Tag>, teamId: string): Promise<Tag> => {
@@ -33,6 +35,7 @@ export class TagsService implements ITagsService {
 	};
 	deleteTag = async (tagId: string, teamId: string): Promise<Tag> => {
 		await this.monitorsRepository.removeTagFromMonitors(tagId);
+		await this.maintenanceWindowsRepository.removeTagFromWindows(tagId);
 		return await this.tagsRepository.deleteById(tagId, teamId);
 	};
 }

--- a/server/src/utils/maintenanceWindow.ts
+++ b/server/src/utils/maintenanceWindow.ts
@@ -26,3 +26,12 @@ export const isWindowActive = (window: MaintenanceWindow, now: Date = new Date()
 
 	return false;
 };
+
+// A window covers a monitor when the monitor is listed directly or carries any of the window's tags.
+// Both routes are additive, so a monitor that is selected directly and also matched by a tag stays covered.
+export const windowCoversMonitor = (window: MaintenanceWindow, monitorId: string, monitorTagIds: string[] = []): boolean => {
+	if (window.monitorIds.includes(monitorId)) {
+		return true;
+	}
+	return monitorTagIds.some((tagId) => window.tagIds.includes(tagId));
+};

--- a/server/src/worker/worker.check-pipeline.ts
+++ b/server/src/worker/worker.check-pipeline.ts
@@ -22,8 +22,8 @@ export class GeoChecksPipeline implements ICheckPipeline {
 		private logger: ILogger
 	) {}
 
-	private async isInMaintenanceWindow(monitorId: string, teamId: string) {
-		const maintenanceWindows = await this.maintenanceWindowsRepository.findByMonitorId(monitorId, teamId);
+	private async isInMaintenanceWindow(monitorId: string, teamId: string, tagIds: string[]) {
+		const maintenanceWindows = await this.maintenanceWindowsRepository.findByMonitorId(monitorId, teamId, tagIds);
 		const now = new Date();
 		return maintenanceWindows.some((window) => isWindowActive(window, now));
 	}
@@ -61,7 +61,7 @@ export class GeoChecksPipeline implements ICheckPipeline {
 		}
 
 		// Step 1b: Maintenance window check
-		const maintenanceWindowActive = await this.isInMaintenanceWindow(monitor.id, monitor.teamId);
+		const maintenanceWindowActive = await this.isInMaintenanceWindow(monitor.id, monitor.teamId, monitor.tags ?? []);
 		if (maintenanceWindowActive) {
 			this.logger.debug({
 				message: `Monitor ${monitor.id} is in maintenance window, skipping geo check`,

--- a/server/src/worker/worker.check-producer.ts
+++ b/server/src/worker/worker.check-producer.ts
@@ -30,8 +30,8 @@ export class CheckProducer implements ICheckProducer {
 		private logger: ILogger
 	) {}
 
-	private async isInMaintenanceWindow(monitorId: string, teamId: string) {
-		const windows = await this.maintenanceWindowsRepository.findByMonitorId(monitorId, teamId);
+	private async isInMaintenanceWindow(monitorId: string, teamId: string, tagIds: string[]) {
+		const windows = await this.maintenanceWindowsRepository.findByMonitorId(monitorId, teamId, tagIds);
 		const now = new Date();
 		return windows.some((w) => isWindowActive(w, now));
 	}
@@ -45,7 +45,7 @@ export class CheckProducer implements ICheckProducer {
 		// ****************************
 
 		// Step 1a:  Maintenance window gate - skip if in maintenance
-		const maintenanceWindowActive = await this.isInMaintenanceWindow(monitor.id, monitor.teamId);
+		const maintenanceWindowActive = await this.isInMaintenanceWindow(monitor.id, monitor.teamId, monitor.tags ?? []);
 		if (maintenanceWindowActive) {
 			this.logger.debug({
 				message: `Monitor ${monitor.id} is in maintenance window`,

--- a/server/test/integration/heartbeatJobMaintenance.test.ts
+++ b/server/test/integration/heartbeatJobMaintenance.test.ts
@@ -9,6 +9,7 @@ const makeMaintenanceWindow = (overrides?: Partial<MaintenanceWindow>): Maintena
 	return {
 		id: "mw-1",
 		monitorIds: ["mon-1"],
+		tagIds: [],
 		teamId: "team-1",
 		active: true,
 		name: "Test Maintenance",

--- a/server/test/integration/maintenanceWindowRepository.test.ts
+++ b/server/test/integration/maintenanceWindowRepository.test.ts
@@ -58,4 +58,77 @@ describe("MongoMaintenanceWindowsRepository", () => {
 			expect((await repo.findByMonitorId(addedMonitorId.toString(), teamId.toString())).map((item) => item.id)).toEqual([window._id.toString()]);
 		});
 	});
+
+	describe("findByMonitorId", () => {
+		it("returns windows that cover the monitor directly or through one of its tags, without duplicates", async () => {
+			const repo = new MongoMaintenanceWindowsRepository();
+			const teamId = makeId();
+			const monitorId = makeId();
+			const tagId = makeId();
+			const otherTagId = makeId();
+			const base = {
+				teamId,
+				active: true,
+				duration: 60,
+				durationUnit: "minutes",
+				repeat: 0,
+				start: new Date("2026-04-10T02:00:00Z"),
+				end: new Date("2026-04-10T03:00:00Z"),
+			};
+			const direct = await MaintenanceWindowModel.create({ ...base, name: "direct", monitorIds: [monitorId], tagIds: [] });
+			const viaTag = await MaintenanceWindowModel.create({ ...base, name: "via tag", monitorIds: [], tagIds: [tagId] });
+			const both = await MaintenanceWindowModel.create({ ...base, name: "both", monitorIds: [monitorId], tagIds: [tagId] });
+			await MaintenanceWindowModel.create({ ...base, name: "unrelated", monitorIds: [makeId()], tagIds: [otherTagId] });
+
+			const found = await repo.findByMonitorId(monitorId.toString(), teamId.toString(), [tagId.toString()]);
+
+			expect(found.map((item) => item.id).sort()).toEqual([direct._id.toString(), viaTag._id.toString(), both._id.toString()].sort());
+		});
+
+		it("ignores tag-based windows when the monitor has no tags", async () => {
+			const repo = new MongoMaintenanceWindowsRepository();
+			const teamId = makeId();
+			const monitorId = makeId();
+			await MaintenanceWindowModel.create({
+				teamId,
+				name: "via tag",
+				monitorIds: [],
+				tagIds: [makeId()],
+				active: true,
+				duration: 60,
+				durationUnit: "minutes",
+				repeat: 0,
+				start: new Date("2026-04-10T02:00:00Z"),
+				end: new Date("2026-04-10T03:00:00Z"),
+			});
+
+			expect(await repo.findByMonitorId(monitorId.toString(), teamId.toString(), [])).toEqual([]);
+		});
+	});
+
+	describe("removeTagFromWindows", () => {
+		it("pulls the tag id from every window that references it", async () => {
+			const repo = new MongoMaintenanceWindowsRepository();
+			const teamId = makeId();
+			const tagId = makeId();
+			const keptTagId = makeId();
+			const window = await MaintenanceWindowModel.create({
+				teamId,
+				name: "tagged",
+				monitorIds: [],
+				tagIds: [tagId, keptTagId],
+				active: true,
+				duration: 60,
+				durationUnit: "minutes",
+				repeat: 0,
+				start: new Date("2026-04-10T02:00:00Z"),
+				end: new Date("2026-04-10T03:00:00Z"),
+			});
+
+			await repo.removeTagFromWindows(tagId.toString());
+
+			const reloaded = await repo.findById(window._id.toString(), teamId.toString());
+			expect(reloaded.tagIds).toEqual([keptTagId.toString()]);
+		});
+	});
 });

--- a/server/test/unit/services/checkProducer.test.ts
+++ b/server/test/unit/services/checkProducer.test.ts
@@ -52,6 +52,14 @@ describe("CheckProducer", () => {
 
 	// ── maintenance gate ──────────────────────────────────────────────────────
 
+	it("passes the monitor's tags to the maintenance lookup so tag-based windows apply", async () => {
+		const { producer, defaults } = createProducer();
+
+		await producer.produce(makeMonitor({ tags: ["tag-1"] }));
+
+		expect(defaults.maintenanceWindowsRepository.findByMonitorId).toHaveBeenCalledWith("m1", "team", ["tag-1"]);
+	});
+
 	it("skips the check and flips status to 'maintenance' when in a maintenance window", async () => {
 		const { producer, defaults } = createProducer({
 			maintenanceWindowsRepository: { findByMonitorId: jest.fn().mockResolvedValue([activeWindow()]) },

--- a/server/test/unit/services/maintenanceWindowService.test.ts
+++ b/server/test/unit/services/maintenanceWindowService.test.ts
@@ -3,6 +3,7 @@ import { MaintenanceWindowService } from "../../../src/domain/maintenance-window
 import type { IMaintenanceWindowsRepository } from "../../../src/domain/maintenance-windows/maintenance-window.repository.interface.ts";
 import type { IMonitorsRepository } from "../../../src/domain/monitors/monitor.repository.interface.ts";
 import type { IJobsRepository } from "../../../src/domain/jobs/job.repository.interface.ts";
+import type { ITagsRepository } from "../../../src/domain/tags/tag.repository.interface.ts";
 import type { IJobScheduler } from "../../../src/worker/worker.interface.ts";
 import type { MaintenanceWindow } from "../../../src/domain/maintenance-windows/maintenance-window.type.ts";
 
@@ -18,16 +19,24 @@ const createMaintenanceWindowsRepo = () =>
 		updateById: jest.fn().mockResolvedValue(makeWindow()),
 		deleteById: jest.fn().mockResolvedValue(makeWindow()),
 		countByTeamId: jest.fn().mockResolvedValue(1),
+		removeTagFromWindows: jest.fn().mockResolvedValue(undefined),
 	}) as unknown as jest.Mocked<IMaintenanceWindowsRepository>;
 
 const createMonitorsRepo = () =>
 	({
+		findById: jest.fn().mockResolvedValue({ id: "mon-1", teamId: "team-1", tags: ["tag-1"] }),
 		findByIds: jest.fn().mockResolvedValue([
 			{ id: "mon-1", teamId: "team-1" },
 			{ id: "mon-2", teamId: "team-1" },
 		]),
+		findIdsByTagIds: jest.fn().mockResolvedValue([]),
 		updateByIds: jest.fn().mockResolvedValue(0),
 	}) as unknown as jest.Mocked<IMonitorsRepository>;
+
+const createTagsRepo = () =>
+	({
+		findByIds: jest.fn().mockResolvedValue([{ id: "tag-1", teamId: "team-1" }]),
+	}) as unknown as jest.Mocked<ITagsRepository>;
 
 const createJobsRepo = () =>
 	({
@@ -42,20 +51,29 @@ const createWorker = () =>
 const createService = (overrides?: {
 	monitorsRepository?: ReturnType<typeof createMonitorsRepo>;
 	maintenanceWindowsRepository?: ReturnType<typeof createMaintenanceWindowsRepo>;
+	tagsRepository?: ReturnType<typeof createTagsRepo>;
 	jobsRepository?: ReturnType<typeof createJobsRepo>;
 	worker?: ReturnType<typeof createWorker>;
 }) => {
 	const monitorsRepository = overrides?.monitorsRepository ?? createMonitorsRepo();
 	const maintenanceWindowsRepository = overrides?.maintenanceWindowsRepository ?? createMaintenanceWindowsRepo();
+	const tagsRepository = overrides?.tagsRepository ?? createTagsRepo();
 	const jobsRepository = overrides?.jobsRepository ?? createJobsRepo();
 	const worker = overrides?.worker ?? createWorker();
-	const service = new MaintenanceWindowService({ monitorsRepository, maintenanceWindowsRepository, jobsRepository, scheduler: worker });
-	return { service, monitorsRepository, maintenanceWindowsRepository, jobsRepository, worker };
+	const service = new MaintenanceWindowService({
+		monitorsRepository,
+		maintenanceWindowsRepository,
+		tagsRepository,
+		jobsRepository,
+		scheduler: worker,
+	});
+	return { service, monitorsRepository, maintenanceWindowsRepository, tagsRepository, jobsRepository, worker };
 };
 
 const makeWindow = (overrides?: Partial<MaintenanceWindow>): MaintenanceWindow => ({
 	id: "mw-1",
 	monitorIds: ["mon-1"],
+	tagIds: [],
 	teamId: "team-1",
 	active: true,
 	name: "Scheduled Maintenance",
@@ -82,6 +100,7 @@ const makeActiveWindow = (overrides?: Partial<MaintenanceWindow>): MaintenanceWi
 const defaultCreateParams = {
 	teamId: "team-1",
 	monitorIDs: ["mon-1", "mon-2"],
+	tagIDs: [],
 	name: "Scheduled Maintenance",
 	active: true,
 	duration: 60,
@@ -107,6 +126,7 @@ describe("MaintenanceWindowService", () => {
 				expect.objectContaining({
 					teamId: "team-1",
 					monitorIds: ["mon-1", "mon-2"],
+					tagIds: [],
 					name: "Scheduled Maintenance",
 					active: true,
 					duration: 60,
@@ -174,6 +194,61 @@ describe("MaintenanceWindowService", () => {
 
 			expect(monitorsRepository.updateByIds).not.toHaveBeenCalled();
 		});
+
+		// ── tags ────────────────────────────────────────────────────────────
+
+		it("persists tagIds alongside monitorIds", async () => {
+			const { service, maintenanceWindowsRepository } = createService();
+
+			await service.createMaintenanceWindow({ ...defaultCreateParams, tagIDs: ["tag-1"] });
+
+			expect(maintenanceWindowsRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({ monitorIds: ["mon-1", "mon-2"], tagIds: ["tag-1"] })
+			);
+		});
+
+		it("allows a window that targets only tags", async () => {
+			const { service, maintenanceWindowsRepository, monitorsRepository } = createService();
+
+			await service.createMaintenanceWindow({ ...defaultCreateParams, monitorIDs: [], tagIDs: ["tag-1"] });
+
+			expect(monitorsRepository.findByIds).not.toHaveBeenCalled();
+			expect(maintenanceWindowsRepository.create).toHaveBeenCalledWith(expect.objectContaining({ monitorIds: [], tagIds: ["tag-1"] }));
+		});
+
+		it("verifies tag ownership via tagsRepository.findByIds", async () => {
+			const { service, tagsRepository } = createService();
+
+			await service.createMaintenanceWindow({ ...defaultCreateParams, tagIDs: ["tag-1"] });
+
+			expect(tagsRepository.findByIds).toHaveBeenCalledWith(["tag-1"], "team-1");
+		});
+
+		it("throws 403 when a tag is not found in the team", async () => {
+			const tagsRepository = createTagsRepo();
+			(tagsRepository.findByIds as jest.Mock).mockResolvedValue([]);
+			const { service, maintenanceWindowsRepository } = createService({ tagsRepository });
+
+			await expect(service.createMaintenanceWindow({ ...defaultCreateParams, tagIDs: ["tag-other"] })).rejects.toThrow(
+				"Unauthorized to create maintenance window for one or more tags"
+			);
+			expect(maintenanceWindowsRepository.create).not.toHaveBeenCalled();
+		});
+
+		it("flips tagged monitors and directly selected monitors to maintenance, deduplicating overlaps", async () => {
+			const maintenanceWindowsRepository = createMaintenanceWindowsRepo();
+			(maintenanceWindowsRepository.create as jest.Mock).mockResolvedValue(makeActiveWindow({ monitorIds: ["mon-1"], tagIds: ["tag-1"] }));
+			const monitorsRepository = createMonitorsRepo();
+			// mon-1 is both selected directly and carries tag-1; it must be flipped exactly once
+			(monitorsRepository.findIdsByTagIds as jest.Mock).mockResolvedValue(["mon-1", "mon-3"]);
+			const { service } = createService({ maintenanceWindowsRepository, monitorsRepository });
+
+			await service.createMaintenanceWindow({ ...defaultCreateParams, monitorIDs: ["mon-1"], tagIDs: ["tag-1"] });
+
+			expect(monitorsRepository.findIdsByTagIds).toHaveBeenCalledWith(["tag-1"], "team-1");
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledTimes(1);
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledWith(["mon-1", "mon-3"], "team-1", { status: "maintenance" }, ["paused"]);
+		});
 	});
 
 	// ── getMaintenanceWindowById ─────────────────────────────────────────────
@@ -233,15 +308,16 @@ describe("MaintenanceWindowService", () => {
 	// ── getMaintenanceWindowsByMonitorId ─────────────────────────────────────
 
 	describe("getMaintenanceWindowsByMonitorId", () => {
-		it("delegates to repository with monitorId and teamId", async () => {
+		it("looks up windows by the monitor id and the monitor's tags so tag-based windows are included", async () => {
 			const windows = [makeWindow()];
-			const { service, maintenanceWindowsRepository } = createService();
+			const { service, maintenanceWindowsRepository, monitorsRepository } = createService();
 			(maintenanceWindowsRepository.findByMonitorId as jest.Mock).mockResolvedValue(windows);
 
 			const result = await service.getMaintenanceWindowsByMonitorId({ monitorId: "mon-1", teamId: "team-1" });
 
 			expect(result).toBe(windows);
-			expect(maintenanceWindowsRepository.findByMonitorId).toHaveBeenCalledWith("mon-1", "team-1");
+			expect(monitorsRepository.findById).toHaveBeenCalledWith("mon-1", "team-1");
+			expect(maintenanceWindowsRepository.findByMonitorId).toHaveBeenCalledWith("mon-1", "team-1", ["tag-1"]);
 		});
 	});
 
@@ -302,7 +378,7 @@ describe("MaintenanceWindowService", () => {
 
 			await service.deleteMaintenanceWindow({ id: "mw-1", teamId: "team-1" });
 
-			expect(maintenanceWindowsRepository.findByMonitorIds).toHaveBeenCalledWith(["mon-1"], "team-1", "mw-1");
+			expect(maintenanceWindowsRepository.findByMonitorIds).toHaveBeenCalledWith(["mon-1"], "team-1", "mw-1", []);
 		});
 
 		it("does not flip a monitor still covered by another active window", async () => {
@@ -326,6 +402,42 @@ describe("MaintenanceWindowService", () => {
 
 			expect(maintenanceWindowsRepository.findByMonitorIds).not.toHaveBeenCalled();
 			expect(monitorsRepository.updateByIds).not.toHaveBeenCalled();
+		});
+
+		it("flips tag-covered monitors to initializing when a tag-based window is deleted", async () => {
+			const maintenanceWindowsRepository = createMaintenanceWindowsRepo();
+			(maintenanceWindowsRepository.deleteById as jest.Mock).mockResolvedValue(makeActiveWindow({ monitorIds: [], tagIds: ["tag-1"] }));
+			const monitorsRepository = createMonitorsRepo();
+			(monitorsRepository.findIdsByTagIds as jest.Mock).mockResolvedValue(["mon-1", "mon-2"]);
+			(monitorsRepository.findByIds as jest.Mock).mockResolvedValue([
+				{ id: "mon-1", teamId: "team-1", tags: ["tag-1"] },
+				{ id: "mon-2", teamId: "team-1", tags: ["tag-1"] },
+			]);
+			const { service } = createService({ maintenanceWindowsRepository, monitorsRepository });
+
+			await service.deleteMaintenanceWindow({ id: "mw-1", teamId: "team-1" });
+
+			expect(maintenanceWindowsRepository.findByMonitorIds).toHaveBeenCalledWith(["mon-1", "mon-2"], "team-1", "mw-1", ["tag-1"]);
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledWith(["mon-1", "mon-2"], "team-1", { status: "initializing" }, ["paused"]);
+		});
+
+		it("keeps a monitor in maintenance when another active window still covers it through a tag", async () => {
+			const maintenanceWindowsRepository = createMaintenanceWindowsRepo();
+			(maintenanceWindowsRepository.deleteById as jest.Mock).mockResolvedValue(makeActiveWindow({ monitorIds: ["mon-1", "mon-2"] }));
+			(maintenanceWindowsRepository.findByMonitorIds as jest.Mock).mockResolvedValue([
+				makeActiveWindow({ id: "mw-2", monitorIds: [], tagIds: ["tag-1"] }),
+			]);
+			const monitorsRepository = createMonitorsRepo();
+			(monitorsRepository.findByIds as jest.Mock).mockResolvedValue([
+				{ id: "mon-1", teamId: "team-1", tags: [] },
+				{ id: "mon-2", teamId: "team-1", tags: ["tag-1"] },
+			]);
+			const { service } = createService({ maintenanceWindowsRepository, monitorsRepository });
+
+			await service.deleteMaintenanceWindow({ id: "mw-1", teamId: "team-1" });
+
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledTimes(1);
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledWith(["mon-1"], "team-1", { status: "initializing" }, ["paused"]);
 		});
 
 		it("ignores monitorIds in overlapping windows that are outside the leaving set", async () => {
@@ -560,7 +672,7 @@ describe("MaintenanceWindowService", () => {
 				body: { active: false },
 			});
 
-			expect(maintenanceWindowsRepository.findByMonitorIds).toHaveBeenCalledWith(["mon-1"], "team-1", "mw-1");
+			expect(maintenanceWindowsRepository.findByMonitorIds).toHaveBeenCalledWith(["mon-1"], "team-1", "mw-1", []);
 		});
 
 		it("flips a leaving monitor to initializing if other windows covering it are inactive", async () => {
@@ -579,6 +691,105 @@ describe("MaintenanceWindowService", () => {
 			});
 
 			expect(monitorsRepository.updateByIds).toHaveBeenCalledWith(["mon-1"], "team-1", { status: "initializing" }, ["paused"]);
+		});
+
+		// ── tags ────────────────────────────────────────────────────────────
+
+		it("maps the tags body field to tagIds when calling the repository", async () => {
+			const { service, maintenanceWindowsRepository, tagsRepository } = createService();
+
+			await service.editMaintenanceWindow({
+				id: "mw-1",
+				teamId: "team-1",
+				body: { tags: ["tag-1"] },
+			});
+
+			expect(tagsRepository.findByIds).toHaveBeenCalledWith(["tag-1"], "team-1");
+			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { tagIds: ["tag-1"] });
+		});
+
+		it("throws 403 when an edited tag is not found in the team", async () => {
+			const tagsRepository = createTagsRepo();
+			(tagsRepository.findByIds as jest.Mock).mockResolvedValue([]);
+			const { service, maintenanceWindowsRepository } = createService({ tagsRepository });
+
+			await expect(
+				service.editMaintenanceWindow({
+					id: "mw-1",
+					teamId: "team-1",
+					body: { tags: ["tag-other"] },
+				})
+			).rejects.toThrow("Unauthorized to edit maintenance window for one or more tags");
+			expect(maintenanceWindowsRepository.updateById).not.toHaveBeenCalled();
+		});
+
+		it("rejects an edit that would leave the window with neither monitors nor tags", async () => {
+			const maintenanceWindowsRepository = createMaintenanceWindowsRepo();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(makeWindow({ monitorIds: ["mon-1"], tagIds: [] }));
+			const { service } = createService({ maintenanceWindowsRepository });
+
+			await expect(
+				service.editMaintenanceWindow({
+					id: "mw-1",
+					teamId: "team-1",
+					body: { monitors: [] },
+				})
+			).rejects.toThrow("At least one monitor or tag is required");
+			expect(maintenanceWindowsRepository.updateById).not.toHaveBeenCalled();
+		});
+
+		it("allows clearing monitors when the window still has tags", async () => {
+			const maintenanceWindowsRepository = createMaintenanceWindowsRepo();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(makeWindow({ monitorIds: ["mon-1"], tagIds: ["tag-1"] }));
+			(maintenanceWindowsRepository.updateById as jest.Mock).mockResolvedValue(makeWindow({ monitorIds: [], tagIds: ["tag-1"] }));
+			const { service } = createService({ maintenanceWindowsRepository });
+
+			await service.editMaintenanceWindow({
+				id: "mw-1",
+				teamId: "team-1",
+				body: { monitors: [] },
+			});
+
+			expect(maintenanceWindowsRepository.updateById).toHaveBeenCalledWith("mw-1", "team-1", { monitorIds: [] });
+		});
+
+		it("flips monitors newly covered by an added tag to maintenance while the window is active", async () => {
+			const maintenanceWindowsRepository = createMaintenanceWindowsRepo();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(makeActiveWindow({ monitorIds: ["mon-1"], tagIds: [] }));
+			(maintenanceWindowsRepository.updateById as jest.Mock).mockResolvedValue(makeActiveWindow({ monitorIds: ["mon-1"], tagIds: ["tag-1"] }));
+			const monitorsRepository = createMonitorsRepo();
+			// mon-1 overlaps (direct + tag); only mon-3 is genuinely new
+			(monitorsRepository.findIdsByTagIds as jest.Mock).mockImplementation(async (tagIds: string[]) => (tagIds.length ? ["mon-1", "mon-3"] : []));
+			const { service } = createService({ maintenanceWindowsRepository, monitorsRepository });
+
+			await service.editMaintenanceWindow({
+				id: "mw-1",
+				teamId: "team-1",
+				body: { tags: ["tag-1"] },
+			});
+
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledTimes(1);
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledWith(["mon-3"], "team-1", { status: "maintenance" }, ["paused"]);
+		});
+
+		it("flips monitors that lose tag coverage to initializing when a tag is removed from an active window", async () => {
+			const maintenanceWindowsRepository = createMaintenanceWindowsRepo();
+			(maintenanceWindowsRepository.findById as jest.Mock).mockResolvedValue(makeActiveWindow({ monitorIds: ["mon-1"], tagIds: ["tag-1"] }));
+			(maintenanceWindowsRepository.updateById as jest.Mock).mockResolvedValue(makeActiveWindow({ monitorIds: ["mon-1"], tagIds: [] }));
+			const monitorsRepository = createMonitorsRepo();
+			(monitorsRepository.findIdsByTagIds as jest.Mock).mockImplementation(async (tagIds: string[]) => (tagIds.length ? ["mon-1", "mon-3"] : []));
+			(monitorsRepository.findByIds as jest.Mock).mockResolvedValue([{ id: "mon-3", teamId: "team-1", tags: ["tag-1"] }]);
+			const { service } = createService({ maintenanceWindowsRepository, monitorsRepository });
+
+			await service.editMaintenanceWindow({
+				id: "mw-1",
+				teamId: "team-1",
+				body: { tags: [] },
+			});
+
+			// mon-1 stays covered directly; only mon-3 leaves
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledTimes(1);
+			expect(monitorsRepository.updateByIds).toHaveBeenCalledWith(["mon-3"], "team-1", { status: "initializing" }, ["paused"]);
 		});
 	});
 });

--- a/server/test/unit/services/tagsService.test.ts
+++ b/server/test/unit/services/tagsService.test.ts
@@ -16,17 +16,23 @@ const createMonitorsRepo = () => ({
 	removeTagFromMonitors: jest.fn(),
 });
 
+const createMaintenanceWindowsRepo = () => ({
+	removeTagFromWindows: jest.fn(),
+});
+
 const createService = (overrides?: Record<string, unknown>) => {
 	const tagsRepository = createTagsRepo();
 	const monitorsRepository = createMonitorsRepo();
+	const maintenanceWindowsRepository = createMaintenanceWindowsRepo();
 
 	const defaults = {
 		tagsRepository,
 		monitorsRepository,
+		maintenanceWindowsRepository,
 		...overrides,
 	};
 
-	const service = new TagsService(defaults.tagsRepository as any, defaults.monitorsRepository as any);
+	const service = new TagsService(defaults.tagsRepository as any, defaults.monitorsRepository as any, defaults.maintenanceWindowsRepository as any);
 
 	return { service, ...defaults };
 };
@@ -108,6 +114,18 @@ describe("TagsService", () => {
 			expect(result).toBe(deleted);
 			expect(monitorsRepository.removeTagFromMonitors).toHaveBeenCalledWith("tag-1");
 			expect(tagsRepository.deleteById).toHaveBeenCalledWith("tag-1", "team-1");
+		});
+
+		it("removes the tag from maintenance windows so tag-based windows do not keep a dangling reference", async () => {
+			const { service, tagsRepository, maintenanceWindowsRepository } = createService();
+			(tagsRepository.deleteById as jest.Mock).mockResolvedValue(makeTag());
+
+			await service.deleteTag("tag-1", "team-1");
+
+			expect(maintenanceWindowsRepository.removeTagFromWindows).toHaveBeenCalledWith("tag-1");
+			const removeOrder = (maintenanceWindowsRepository.removeTagFromWindows as jest.Mock).mock.invocationCallOrder[0];
+			const deleteOrder = (tagsRepository.deleteById as jest.Mock).mock.invocationCallOrder[0];
+			expect(removeOrder).toBeLessThan(deleteOrder);
 		});
 
 		it("detaches the tag from monitors before deleting it", async () => {

--- a/server/test/unit/utils/maintenanceWindow.test.ts
+++ b/server/test/unit/utils/maintenanceWindow.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "@jest/globals";
-import { isWindowActive } from "../../../src/utils/maintenanceWindow.ts";
+import { isWindowActive, windowCoversMonitor } from "../../../src/utils/maintenanceWindow.ts";
 import type { MaintenanceWindow } from "../../../src/domain/maintenance-windows/maintenance-window.type.ts";
 
 const makeWindow = (overrides?: Partial<MaintenanceWindow>): MaintenanceWindow => {
@@ -7,6 +7,7 @@ const makeWindow = (overrides?: Partial<MaintenanceWindow>): MaintenanceWindow =
 	return {
 		id: "mw-1",
 		monitorIds: ["mon-1"],
+		tagIds: [],
 		teamId: "team-1",
 		active: true,
 		name: "Scheduled Maintenance",
@@ -91,5 +92,27 @@ describe("isWindowActive", () => {
 		expect(isWindowActive(win, new Date("2026-01-15T12:00:00Z"))).toBe(true);
 		expect(isWindowActive(win, new Date("2026-01-15T14:00:00Z"))).toBe(false);
 		expect(isWindowActive(win, new Date("2026-01-15T10:00:00Z"))).toBe(false);
+	});
+});
+
+describe("windowCoversMonitor", () => {
+	it("covers a monitor listed directly in monitorIds", () => {
+		expect(windowCoversMonitor(makeWindow({ monitorIds: ["mon-1"] }), "mon-1", [])).toBe(true);
+	});
+
+	it("covers a monitor that carries one of the window's tags", () => {
+		expect(windowCoversMonitor(makeWindow({ monitorIds: [], tagIds: ["tag-1"] }), "mon-9", ["tag-1", "tag-2"])).toBe(true);
+	});
+
+	it("covers a monitor that is both listed directly and tagged (overlap is additive)", () => {
+		expect(windowCoversMonitor(makeWindow({ monitorIds: ["mon-1"], tagIds: ["tag-1"] }), "mon-1", ["tag-1"])).toBe(true);
+	});
+
+	it("does not cover a monitor that is neither listed nor tagged", () => {
+		expect(windowCoversMonitor(makeWindow({ monitorIds: ["mon-1"], tagIds: ["tag-1"] }), "mon-2", ["tag-2"])).toBe(false);
+	});
+
+	it("treats a missing monitor tag list as no tags", () => {
+		expect(windowCoversMonitor(makeWindow({ monitorIds: [], tagIds: ["tag-1"] }), "mon-2")).toBe(false);
 	});
 });

--- a/server/test/unit/validation/maintenanceWindowValidation.test.ts
+++ b/server/test/unit/validation/maintenanceWindowValidation.test.ts
@@ -124,6 +124,38 @@ describe("createMaintenanceWindowBodyValidation", () => {
 		const result = createMaintenanceWindowBodyValidation.safeParse(withoutName);
 		expect(result.success).toBe(false);
 	});
+
+	it("accepts a window that targets only tags", () => {
+		jest.useFakeTimers().setSystemTime(FROZEN_NOW);
+		const result = createMaintenanceWindowBodyValidation.safeParse(baseCreateBody({ monitors: [], tags: ["tag-1"] }));
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts a window that targets both monitors and tags", () => {
+		jest.useFakeTimers().setSystemTime(FROZEN_NOW);
+		const result = createMaintenanceWindowBodyValidation.safeParse(baseCreateBody({ monitors: ["mon-1"], tags: ["tag-1"] }));
+		expect(result.success).toBe(true);
+	});
+
+	it("defaults tags to an empty array when omitted", () => {
+		jest.useFakeTimers().setSystemTime(FROZEN_NOW);
+		const result = createMaintenanceWindowBodyValidation.safeParse(baseCreateBody());
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.tags).toEqual([]);
+		}
+	});
+
+	it("rejects a window with neither monitors nor tags", () => {
+		jest.useFakeTimers().setSystemTime(FROZEN_NOW);
+		const result = createMaintenanceWindowBodyValidation.safeParse(baseCreateBody({ monitors: [], tags: [] }));
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([expect.objectContaining({ message: "At least one monitor or tag is required", path: ["monitors"] })])
+			);
+		}
+	});
 });
 
 describe("editMaintenanceByIdWindowBodyValidation", () => {
@@ -179,12 +211,22 @@ describe("editMaintenanceByIdWindowBodyValidation", () => {
 		expect(result.success).toBe(true);
 	});
 
-	it("rejects an empty monitors array", () => {
+	it("accepts an empty monitors array on its own (the window may still be covered by tags)", () => {
 		const result = editMaintenanceByIdWindowBodyValidation.safeParse({ monitors: [] });
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts a body with one or more tags", () => {
+		const result = editMaintenanceByIdWindowBodyValidation.safeParse({ tags: ["tag-1"] });
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects when monitors and tags are both provided and both empty", () => {
+		const result = editMaintenanceByIdWindowBodyValidation.safeParse({ monitors: [], tags: [] });
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(result.error.issues).toEqual(
-				expect.arrayContaining([expect.objectContaining({ message: "At least one monitor is required", path: ["monitors"] })])
+				expect.arrayContaining([expect.objectContaining({ message: "At least one monitor or tag is required", path: ["monitors"] })])
 			);
 		}
 	});


### PR DESCRIPTION
## Describe your changes

Maintenance windows can now target tags, not only monitors. Pick monitors, pick tags, or both. Every monitor carrying one of the selected tags is covered, on top of the monitors selected directly. If a monitor shows up both ways it is simply included once.

The reason this was created is because I have a hundred various monitors spanning different tags and I want a quick and easy way to multi-select them without having to do it one at a time. 

Coverage is resolved when a check runs, not when the window is saved. So a monitor that gets the tag after the window exists is picked up on its next check, and a monitor that loses the tag drops out the same way.

**Server**

- `tagIds` on the maintenance window type, schema (indexed) and repository mapping. Old documents read as an empty list, so there is no migration.
- The by-monitor lookups now match through the monitor's tags as well. Both worker gates pass `monitor.tags` into that lookup.
- The service checks tag ownership the same way it checks monitors, resolves the effective monitor set before flipping statuses on create, edit and delete, and rejects an edit that would leave a window with nothing to cover.
- Create and edit validators accept `tags`. At least one monitor or tag is required.
- Deleting a tag pulls it out of any window that references it, mirroring what already happens for monitors.

**Client**

- A Tags multi-select under the Monitors one on the maintenance window form, using the same component and colored labels as the monitor page.
- Form schema requires at least one monitor or tag.
- New strings in `en.json`. Other locales fall back to English.

**How I tested it**

Server: 89 suites, 1656 tests pass, 24 of them new (service, validation, util, worker gate, tags service, and a real-Mongo repository test for the `$or` lookup and tag removal). Lint, typecheck and format-check are clean in both `client` and `server`, and `npm run build` passes in both.

Then I ran the Docker dev stack and drove the API directly. Created a window with two monitors plus a tag: the two monitors, the tag-only monitor and the overlapping monitor all went to maintenance and the unrelated monitor did not. Removing the tag via PATCH released only the tag-only monitor. Clearing the monitors while keeping the tag released only the untagged one. Deleting the window released everything. Watched the worker for a full check interval afterwards: covered monitors stayed in maintenance and logged the skip, the unrelated one kept checking.

**Worth knowing for review**

This lands over the 200-line guideline. The server side is where the size comes from, mostly because each status-flip path (create, edit, delete) now has to resolve tags to monitors, and the tests cover each of those paths. I kept the client part small on purpose.

While testing I noticed a pre-existing race: a check produced right before a window is created can be evaluated after the flip, and the evaluator resolves a `maintenance` status to up/down without consulting windows. The next check cycle puts the monitor back. Not tag-specific, so I left it alone here.

## Write your issue number after "Fixes "

No open issue for this. Related to #3904, which added tag labels to the monitor selector on this same form.

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [ ] I have included the issue # in the PR. (none exists; see above)
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

<img width="1357" height="1085" alt="SCR-20260910-oosv" src="https://github.com/user-attachments/assets/d0d644aa-dd89-425b-bc84-79746ec8192b" />


<img width="1358" height="729" alt="SCR-20260910-oovt" src="https://github.com/user-attachments/assets/e5229a0f-af7f-4650-b830-e328d4e04250" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)