### PR TITLE
Feat/status page embed origins

### DIFF
--- a/client/src/Hooks/useStatusPageForm.ts
+++ b/client/src/Hooks/useStatusPageForm.ts
@@ -32,6 +32,7 @@ export const useStatusPageForm = ({
 			companyName: data?.companyName || "",
 			url: data?.url || generateDefaultUrl(),
 			customDomain: data?.customDomain ?? null,
+			embedAllowedOrigins: data?.embedAllowedOrigins?.join("\n") ?? "",
 			timezone: resolveTimezone(data?.timezone),
 			type: data?.type || ["uptime"],
 			color: data?.color || "#13715B",

--- a/client/src/Pages/StatusPage/Create/index.tsx
+++ b/client/src/Pages/StatusPage/Create/index.tsx
@@ -17,7 +17,11 @@ import { useForm, FormProvider, useController } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useStatusPageForm } from "@/Hooks/useStatusPageForm";
 import type { StatusPageFormData } from "@/Validation/statusPage";
-import { statusPageStepCount, statusPageStepFieldsFor } from "@/Validation/statusPage";
+import {
+	splitEmbedAllowedOrigins,
+	statusPageStepCount,
+	statusPageStepFieldsFor,
+} from "@/Validation/statusPage";
 import { useGet, usePost, usePut, useDelete } from "@/Hooks/UseApi";
 import type { Monitor } from "@/Types/Monitor";
 import { SelectableMonitorTypes } from "@/Types/Monitor";
@@ -183,6 +187,14 @@ const CreateStatusPage = () => {
 		} else {
 			fd.append("customDomain", "");
 		}
+		const embedAllowedOrigins = splitEmbedAllowedOrigins(data.embedAllowedOrigins);
+		if (embedAllowedOrigins.length === 0) {
+			// Absent field leaves the stored list alone; an empty entry clears it.
+			fd.append("embedAllowedOrigins[]", "");
+		}
+		embedAllowedOrigins.forEach((origin) => {
+			fd.append("embedAllowedOrigins[]", origin);
+		});
 		if (data.timezone) fd.append("timezone", data.timezone);
 		if (data.color) fd.append("color", data.color);
 		fd.append("showCharts", String(data.showCharts));
@@ -288,6 +300,20 @@ const CreateStatusPage = () => {
 									)}
 									helperText={t(
 										"pages.statusPages.form.basicInfo.option.customDomain.helper"
+									)}
+								/>
+								<FormTextField
+									name="embedAllowedOrigins"
+									multiline
+									rows={3}
+									fieldLabel={t(
+										"pages.statusPages.form.basicInfo.option.embedAllowedOrigins.label"
+									)}
+									placeholder={t(
+										"pages.statusPages.form.basicInfo.option.embedAllowedOrigins.placeholder"
+									)}
+									helperText={t(
+										"pages.statusPages.form.basicInfo.option.embedAllowedOrigins.helper"
 									)}
 								/>
 							</Stack>

--- a/client/src/Types/StatusPage.ts
+++ b/client/src/Types/StatusPage.ts
@@ -57,6 +57,7 @@ export interface StatusPage {
 	companyName: string;
 	url: string;
 	customDomain?: string | null;
+	embedAllowedOrigins?: string[];
 	timezone?: string;
 	color: string;
 	monitors: string[];

--- a/client/src/Validation/statusPage.ts
+++ b/client/src/Validation/statusPage.ts
@@ -15,11 +15,22 @@ const statusPageHostnamePattern =
 
 const statusPageHostnameRegex = new RegExp(`^(?=.{1,253}$)${statusPageHostnamePattern}$`);
 
-// An embedding origin: scheme + hostname (or localhost) + optional port, no path.
-// Kept in sync with embedOriginRegex in server/src/api/validation/shared.ts.
-const statusPageOriginRegex = new RegExp(
-	`^https?:\\/\\/(?:localhost|${statusPageHostnamePattern})(:\\d{1,5})?$`
-);
+// An embedding origin: scheme + host + optional port, no path. The host may be
+// a hostname, localhost, an IPv4 address, or a bracketed IPv6 address. Kept in
+// sync with isEmbedOrigin in server/src/api/validation/shared.ts.
+const statusPageOriginShapeRegex =
+	/^https?:\/\/([^\s/?#:[\]]+|\[[^\s/?#[\]]+\])(?::\d{1,5})?$/;
+
+const isStatusPageOrigin = (value: string): boolean => {
+	const host = statusPageOriginShapeRegex.exec(value)?.[1];
+	if (host === undefined) return false;
+	if (host.startsWith("[")) return z.ipv6().safeParse(host.slice(1, -1)).success;
+	return (
+		host === "localhost" ||
+		z.ipv4().safeParse(host).success ||
+		statusPageHostnameRegex.test(host)
+	);
+};
 
 const MAX_EMBED_ALLOWED_ORIGINS = 20;
 
@@ -69,16 +80,10 @@ export const statusPageSchema = z.object({
 		.refine((raw) => splitEmbedAllowedOrigins(raw).length <= MAX_EMBED_ALLOWED_ORIGINS, {
 			message: `At most ${MAX_EMBED_ALLOWED_ORIGINS} embedding origins are allowed`,
 		})
-		.refine(
-			(raw) =>
-				splitEmbedAllowedOrigins(raw).every((origin) =>
-					statusPageOriginRegex.test(origin)
-				),
-			{
-				message:
-					"Each origin must be a scheme and host with no path (e.g. https://dashboard.example.com)",
-			}
-		),
+		.refine((raw) => splitEmbedAllowedOrigins(raw).every(isStatusPageOrigin), {
+			message:
+				"Each origin must be a scheme and host with no path (e.g. https://dashboard.example.com)",
+		}),
 	timezone: z.string().optional(),
 	type: z
 		.array(z.enum(["uptime", "infrastructure"]))

--- a/client/src/Validation/statusPage.ts
+++ b/client/src/Validation/statusPage.ts
@@ -10,8 +10,25 @@ import { cssReferencesExternalResource } from "@/Utils/customCss";
 // field definitions.
 export const statusPageStepRegistry = z.registry<{ step: number }>();
 
-const statusPageHostnameRegex =
-	/^(?=.{1,253}$)([a-zA-Z0-9_](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
+const statusPageHostnamePattern =
+	"([a-zA-Z0-9_](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,63}";
+
+const statusPageHostnameRegex = new RegExp(`^(?=.{1,253}$)${statusPageHostnamePattern}$`);
+
+// An embedding origin: scheme + hostname (or localhost) + optional port, no path.
+// Kept in sync with embedOriginRegex in server/src/api/validation/shared.ts.
+const statusPageOriginRegex = new RegExp(
+	`^https?:\\/\\/(?:localhost|${statusPageHostnamePattern})(:\\d{1,5})?$`
+);
+
+const MAX_EMBED_ALLOWED_ORIGINS = 20;
+
+// One origin per line (or comma-separated); blanks are dropped.
+export const splitEmbedAllowedOrigins = (raw: string | undefined): string[] =>
+	(raw ?? "")
+		.split(/[\n,]/)
+		.map((origin) => origin.trim())
+		.filter((origin) => origin.length > 0);
 
 const normalizeCustomDomainInput = (raw: string | null): string | null => {
 	if (raw === null) {
@@ -46,6 +63,22 @@ export const statusPageSchema = z.object({
 		.refine((domain) => domain === null || statusPageHostnameRegex.test(domain), {
 			message: "Enter a valid domain name (e.g. status.example.com)",
 		}),
+	embedAllowedOrigins: z
+		.string()
+		.optional()
+		.refine((raw) => splitEmbedAllowedOrigins(raw).length <= MAX_EMBED_ALLOWED_ORIGINS, {
+			message: `At most ${MAX_EMBED_ALLOWED_ORIGINS} embedding origins are allowed`,
+		})
+		.refine(
+			(raw) =>
+				splitEmbedAllowedOrigins(raw).every((origin) =>
+					statusPageOriginRegex.test(origin)
+				),
+			{
+				message:
+					"Each origin must be a scheme and host with no path (e.g. https://dashboard.example.com)",
+			}
+		),
 	timezone: z.string().optional(),
 	type: z
 		.array(z.enum(["uptime", "infrastructure"]))

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1758,9 +1758,9 @@
 							"helper": "Optional. Point a DNS record to this Checkmate instance to serve the status page at your own domain."
 						},
 						"embedAllowedOrigins": {
-							"label": "Allowed embedding origins",
+							"label": "Allow embedding from origins",
 							"placeholder": "https://dashboard.example.com",
-							"helper": "Optional. One origin per line. Pages on these origins may embed this status page in an iframe."
+							"helper": "Optional. One origin per line. Pages on these origins may embed this status page in an iframe. Updates may take five minutes to appear as they are cached."
 						}
 					}
 				},

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -1756,6 +1756,11 @@
 							"label": "Custom domain",
 							"placeholder": "status.example.com",
 							"helper": "Optional. Point a DNS record to this Checkmate instance to serve the status page at your own domain."
+						},
+						"embedAllowedOrigins": {
+							"label": "Allowed embedding origins",
+							"placeholder": "https://dashboard.example.com",
+							"helper": "Optional. One origin per line. Pages on these origins may embed this status page in an iframe."
 						}
 					}
 				},

--- a/server/src/api/middleware/statusPageDocumentCsp.ts
+++ b/server/src/api/middleware/statusPageDocumentCsp.ts
@@ -1,7 +1,14 @@
 import type { NextFunction, Request, Response } from "express";
+import type { IStatusPagesRepository } from "@/domain/status-pages/status-page-repository.interface.js";
+import type { StatusPage } from "@/domain/status-pages/status-page.type.js";
 import { normalizeStatusPageDomain } from "@/utils/statusPageDomain.js";
 
+const API_PATH_PREFIX = "/api/";
 const PUBLIC_STATUS_PAGE_DOCUMENT_PREFIX = "/status/public";
+
+const EMBED_ORIGINS_POSITIVE_CACHE_TTL_MS = 5 * 60 * 1000;
+const EMBED_ORIGINS_NEGATIVE_CACHE_TTL_MS = 60 * 1000;
+const EMBED_ORIGINS_CACHE_MAX_ENTRIES = 1000;
 
 // Browsers enforce the intersection of all CSP headers, so this only tightens
 // the status page on top of the global helmet policy, blocking external images,
@@ -12,16 +19,111 @@ const STATUS_PAGE_CSP = [
 	"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
 ].join("; ");
 
+type EmbedOriginsCacheEntry = {
+	origins: string[];
+	expiresAt: number;
+};
+
+const getEmbedOriginsCacheTtlMs = (origins: string[]): number =>
+	origins.length > 0 ? EMBED_ORIGINS_POSITIVE_CACHE_TTL_MS : EMBED_ORIGINS_NEGATIVE_CACHE_TTL_MS;
+
+// frame-ancestors is intersected like every other directive, so helmet must not
+// emit it globally; this middleware sets it on every non-API response instead.
+const frameAncestorsDirective = (origins: string[]): string => ["frame-ancestors 'self'", ...origins].join(" ");
+
+const embedOriginsOf = (statusPage: StatusPage): string[] => (statusPage.isPublished ? (statusPage.embedAllowedOrigins ?? []) : []);
+
+// Path segment after /status/public/, ignoring anything deeper.
+const publicStatusPageUrlFromPath = (path: string): string | null => {
+	const remainder = path.slice(PUBLIC_STATUS_PAGE_DOCUMENT_PREFIX.length);
+	if (!remainder.startsWith("/")) {
+		return null;
+	}
+
+	const segment = remainder.slice(1).split("/")[0] ?? "";
+	if (!segment) {
+		return null;
+	}
+
+	try {
+		return decodeURIComponent(segment);
+	} catch {
+		return null;
+	}
+};
+
 // A status page document is served on the public path or on a custom domain
 // (any host other than the app's own). Mirrors the client isCustomDomainHost.
-export const createStatusPageDocumentCsp = (clientHost: string) => {
+export const createStatusPageDocumentCsp = (clientHost: string, statusPagesRepository: IStatusPagesRepository) => {
 	const appHostname = normalizeStatusPageDomain(clientHost);
+	const cache = new Map<string, EmbedOriginsCacheEntry>();
+
+	const cacheOrigins = (key: string, origins: string[]) => {
+		if (cache.size >= EMBED_ORIGINS_CACHE_MAX_ENTRIES) {
+			const now = Date.now();
+			for (const [cachedKey, entry] of cache) {
+				if (entry.expiresAt <= now) {
+					cache.delete(cachedKey);
+				}
+			}
+			if (cache.size >= EMBED_ORIGINS_CACHE_MAX_ENTRIES) {
+				cache.clear();
+			}
+		}
+
+		cache.set(key, {
+			origins,
+			expiresAt: Date.now() + getEmbedOriginsCacheTtlMs(origins),
+		});
+	};
+
+	const resolveEmbedOrigins = (key: string, lookup: () => Promise<StatusPage>): Promise<string[]> => {
+		const cached = cache.get(key);
+		if (cached && cached.expiresAt > Date.now()) {
+			return Promise.resolve(cached.origins);
+		}
+
+		return lookup()
+			.then((statusPage) => {
+				const origins = embedOriginsOf(statusPage);
+				cacheOrigins(key, origins);
+				return origins;
+			})
+			.catch(() => {
+				cacheOrigins(key, []);
+				return [];
+			});
+	};
+
+	const lookupStatusPageOrigins = (req: Request, customDomain: string | null): Promise<string[]> => {
+		if (customDomain) {
+			return resolveEmbedOrigins(`custom:${customDomain}`, () => statusPagesRepository.findByCustomDomain(customDomain));
+		}
+
+		const url = publicStatusPageUrlFromPath(req.path);
+		if (!url) {
+			return Promise.resolve([]);
+		}
+		return resolveEmbedOrigins(`url:${url}`, () => statusPagesRepository.findByUrl(url));
+	};
 
 	return (req: Request, res: Response, next: NextFunction) => {
-		const onCustomDomain = appHostname !== null && normalizeStatusPageDomain(req.hostname) !== appHostname;
-		if (req.path.startsWith(PUBLIC_STATUS_PAGE_DOCUMENT_PREFIX) || onCustomDomain) {
-			res.append("Content-Security-Policy", STATUS_PAGE_CSP);
+		if (req.path.startsWith(API_PATH_PREFIX)) {
+			return next();
 		}
-		return next();
+
+		const requestHostname = normalizeStatusPageDomain(req.hostname);
+		const onCustomDomain = appHostname !== null && requestHostname !== appHostname;
+		if (!req.path.startsWith(PUBLIC_STATUS_PAGE_DOCUMENT_PREFIX) && !onCustomDomain) {
+			res.append("Content-Security-Policy", frameAncestorsDirective([]));
+			return next();
+		}
+
+		lookupStatusPageOrigins(req, onCustomDomain ? requestHostname : null)
+			.catch(() => [])
+			.then((origins) => {
+				res.append("Content-Security-Policy", `${STATUS_PAGE_CSP}; ${frameAncestorsDirective(origins)}`);
+				next();
+			});
 	};
 };

--- a/server/src/api/validation/shared.ts
+++ b/server/src/api/validation/shared.ts
@@ -44,7 +44,12 @@ export const timezoneValidation = z
 // optionally prefixed with `_` for service labels (e.g. _dmarc, _imaps._tcp).
 // No scheme, port, path, or whitespace. Total length ≤ 253. Kept in sync with
 // the client-side regex in client/src/Validation/monitor.ts.
-export const dnsHostnameRegex = /^(?=.{1,253}$)([a-zA-Z0-9_](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/;
+const dnsHostnamePattern = "([a-zA-Z0-9_](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,63}";
+export const dnsHostnameRegex = new RegExp(`^(?=.{1,253}$)${dnsHostnamePattern}$`);
+
+// Web origin for CSP frame-ancestors: http(s) scheme, a hostname (or localhost),
+// an optional port, and nothing else — no path, query, or trailing slash.
+export const embedOriginRegex = new RegExp(`^https?://(?:localhost|${dnsHostnamePattern})(?::\\d{1,5})?$`);
 
 export const booleanCoercion = z.preprocess((val) => {
 	if (val === "true" || val === true) return true;

--- a/server/src/api/validation/shared.ts
+++ b/server/src/api/validation/shared.ts
@@ -47,9 +47,18 @@ export const timezoneValidation = z
 const dnsHostnamePattern = "([a-zA-Z0-9_](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\\.)+[a-zA-Z]{2,63}";
 export const dnsHostnameRegex = new RegExp(`^(?=.{1,253}$)${dnsHostnamePattern}$`);
 
-// Web origin for CSP frame-ancestors: http(s) scheme, a hostname (or localhost),
-// an optional port, and nothing else — no path, query, or trailing slash.
-export const embedOriginRegex = new RegExp(`^https?://(?:localhost|${dnsHostnamePattern})(?::\\d{1,5})?$`);
+// Web origin for CSP frame-ancestors: http(s) scheme, a host, an optional port,
+// and nothing else — no path, query, or trailing slash. The host may be a
+// hostname, localhost, an IPv4 address, or a bracketed IPv6 address. Kept in
+// sync with isStatusPageOrigin in client/src/Validation/statusPage.ts.
+const embedOriginShapeRegex = /^https?:\/\/([^\s/?#:[\]]+|\[[^\s/?#[\]]+\])(?::\d{1,5})?$/;
+
+export const isEmbedOrigin = (value: string): boolean => {
+	const host = embedOriginShapeRegex.exec(value)?.[1];
+	if (host === undefined) return false;
+	if (host.startsWith("[")) return z.ipv6().safeParse(host.slice(1, -1)).success;
+	return host === "localhost" || z.ipv4().safeParse(host).success || dnsHostnameRegex.test(host);
+};
 
 export const booleanCoercion = z.preprocess((val) => {
 	if (val === "true" || val === true) return true;

--- a/server/src/api/validation/statusPageValidation.ts
+++ b/server/src/api/validation/statusPageValidation.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { booleanCoercion, dnsHostnameRegex, timezoneValidation } from "./shared.js";
+import { booleanCoercion, dnsHostnameRegex, embedOriginRegex, timezoneValidation } from "./shared.js";
 import {
 	StatusPageTypes,
 	StatusPageThemes,
@@ -9,6 +9,7 @@ import {
 } from "@/domain/status-pages/status-page.type.js";
 import { MonitorTypes, MonitorStatuses } from "@/domain/monitors/monitor.type.js";
 import { normalizeStatusPageDomain } from "@/utils/statusPageDomain.js";
+import { normalizeEmbedAllowedOrigins } from "@/utils/embedOrigins.js";
 import { cssReferencesExternalResource } from "@/utils/customCss.js";
 import { ImageMimeTypes } from "@/types/upload.js";
 
@@ -39,6 +40,16 @@ const customDomainValidation = z.preprocess(
 	z.union([z.string().regex(dnsHostnameRegex, "Enter a valid domain name (e.g. status.example.com)"), z.null()]).optional()
 );
 
+const MAX_EMBED_ALLOWED_ORIGINS = 20;
+
+const embedAllowedOriginsValidation = z.preprocess(
+	(val) => normalizeEmbedAllowedOrigins(val),
+	z
+		.array(z.string().regex(embedOriginRegex, "Enter a valid origin with scheme and host only (e.g. https://www.example.com)"))
+		.max(MAX_EMBED_ALLOWED_ORIGINS, `At most ${MAX_EMBED_ALLOWED_ORIGINS} embedding origins are allowed`)
+		.optional()
+);
+
 export const createStatusPageBodyValidation = z
 	.object({
 		type: z.union([z.enum(StatusPageTypes), z.array(z.enum(StatusPageTypes))]).transform((val) => (Array.isArray(val) ? val : [val])),
@@ -47,6 +58,7 @@ export const createStatusPageBodyValidation = z
 			message: "URL can only contain letters, numbers, underscores, and hyphens",
 		}),
 		customDomain: customDomainValidation,
+		embedAllowedOrigins: embedAllowedOriginsValidation,
 		timezone: timezoneValidation.optional(),
 		color: z.string().optional(),
 		monitors: z.array(z.string().regex(/^[0-9a-fA-F]{24}$/, "Must be a valid monitor ID")).min(1, "At least one monitor is required"),
@@ -126,6 +138,7 @@ export const statusPageResponseSchema = z.object({
 	companyName: z.string(),
 	url: z.string(),
 	customDomain: z.string().nullable().optional(),
+	embedAllowedOrigins: z.array(z.string()).optional(),
 	timezone: z.string().optional(),
 	color: z.string(),
 	monitors: z.array(z.string()),

--- a/server/src/api/validation/statusPageValidation.ts
+++ b/server/src/api/validation/statusPageValidation.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { booleanCoercion, dnsHostnameRegex, embedOriginRegex, timezoneValidation } from "./shared.js";
+import { booleanCoercion, dnsHostnameRegex, isEmbedOrigin, timezoneValidation } from "./shared.js";
 import {
 	StatusPageTypes,
 	StatusPageThemes,
@@ -45,7 +45,7 @@ const MAX_EMBED_ALLOWED_ORIGINS = 20;
 const embedAllowedOriginsValidation = z.preprocess(
 	(val) => normalizeEmbedAllowedOrigins(val),
 	z
-		.array(z.string().regex(embedOriginRegex, "Enter a valid origin with scheme and host only (e.g. https://www.example.com)"))
+		.array(z.string().refine(isEmbedOrigin, "Enter a valid origin with scheme and host only (e.g. https://www.example.com)"))
 		.max(MAX_EMBED_ALLOWED_ORIGINS, `At most ${MAX_EMBED_ALLOWED_ORIGINS} embedding origins are allowed`)
 		.optional()
 );

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -16,6 +16,18 @@ import { isPublicStatusPageApiPath } from "@/api/middleware/statusPagePublicApiP
 import { createStatusPageDocumentCsp } from "@/api/middleware/statusPageDocumentCsp.js";
 import { ApiServices } from "@/config/services.api.js";
 
+// Origin of the API the client is configured to call, when it is absolute.
+// Relative values (the default) resolve to the serving origin, covered by 'self'.
+const resolveApiOrigin = (apiBaseUrl: string | undefined): string | undefined => {
+	if (!apiBaseUrl) return undefined;
+	try {
+		const { protocol, origin } = new URL(apiBaseUrl);
+		return protocol === "http:" || protocol === "https:" ? origin : undefined;
+	} catch {
+		return undefined;
+	}
+};
+
 export const createApp = ({
 	apiServices: services,
 	controllers,
@@ -30,6 +42,7 @@ export const createApp = ({
 	openApiSpec: JsonObject;
 }) => {
 	const allowedOrigin = envSettings.clientHost;
+	const apiOrigin = resolveApiOrigin(envSettings.clientConfig.apiBaseUrl);
 	const app = express();
 	const defaultCorsOptions: CorsOptions = {
 		origin: allowedOrigin,
@@ -65,6 +78,9 @@ export const createApp = ({
 					"img-src": ["'self'", "data:", "blob:", "https://img.shields.io"],
 					"object-src": ["'none'"],
 					"base-uri": ["'self'"],
+					// The client defaults to the origin it is served from, but
+					// CLIENT_CONFIG_API_BASE_URL can point it at another origin.
+					"connect-src": apiOrigin ? ["'self'", apiOrigin] : ["'self'"],
 					// Emitted per request by statusPageDocumentCsp so status pages can allow configured embedding origins.
 					"frame-ancestors": null,
 				},

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -50,7 +50,29 @@ export const createApp = ({
 		return cors(corsOptions)(req, res, next);
 	});
 
-	app.use(createStatusPageDocumentCsp(allowedOrigin));
+	// helmet sets the Content-Security-Policy header, replacing any value already
+	// present, so it must run before express.static (so documents served from the
+	// client build get a policy at all) and before statusPageDocumentCsp, which
+	// appends a second header that the browser intersects with this one.
+	app.use(
+		helmet({
+			hsts: false,
+			contentSecurityPolicy: {
+				useDefaults: true,
+				directives: {
+					upgradeInsecureRequests: null,
+					"script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
+					"img-src": ["'self'", "data:", "blob:", "https://img.shields.io"],
+					"object-src": ["'none'"],
+					"base-uri": ["'self'"],
+					// Emitted per request by statusPageDocumentCsp so status pages can allow configured embedding origins.
+					"frame-ancestors": null,
+				},
+			},
+		})
+	);
+
+	app.use(createStatusPageDocumentCsp(allowedOrigin, services.statusPagesRepository));
 
 	// Client runtime config; registered before express.static so it shadows the
 	// fallback config.js in the client build output
@@ -68,21 +90,6 @@ export const createApp = ({
 	app.use(sanitizeBody());
 	app.use(sanitizeQuery());
 
-	app.use(
-		helmet({
-			hsts: false,
-			contentSecurityPolicy: {
-				useDefaults: true,
-				directives: {
-					upgradeInsecureRequests: null,
-					"script-src": ["'self'", "'unsafe-inline'", "'unsafe-eval'"],
-					"img-src": ["'self'", "data:", "blob:", "https://img.shields.io"],
-					"object-src": ["'none'"],
-					"base-uri": ["'self'"],
-				},
-			},
-		})
-	);
 	app.use(
 		compression({
 			level: 6,

--- a/server/src/domain/status-pages/status-page-repository.mongo.ts
+++ b/server/src/domain/status-pages/status-page-repository.mongo.ts
@@ -36,6 +36,7 @@ class MongoStatusPagesRepository implements IStatusPagesRepository {
 			companyName: doc.companyName,
 			url: doc.url,
 			customDomain: doc.customDomain ?? null,
+			embedAllowedOrigins: doc.embedAllowedOrigins ?? [],
 			timezone: doc.timezone ?? undefined,
 			color: doc.color,
 			monitors: this.mapIdArray(doc.monitors),

--- a/server/src/domain/status-pages/status-page.model.ts
+++ b/server/src/domain/status-pages/status-page.model.ts
@@ -70,6 +70,10 @@ const StatusPageSchema = new Schema<StatusPageDocument>(
 			lowercase: true,
 			trim: true,
 		},
+		embedAllowedOrigins: {
+			type: [String],
+			default: [],
+		},
 		timezone: {
 			type: String,
 		},

--- a/server/src/domain/status-pages/status-page.service.ts
+++ b/server/src/domain/status-pages/status-page.service.ts
@@ -11,6 +11,7 @@ import {
 } from "@/domain/status-pages/status-page.type.js";
 import { AppError } from "@/utils/AppError.js";
 import { normalizeStatusPageDomain } from "@/utils/statusPageDomain.js";
+import { normalizeEmbedAllowedOrigins } from "@/utils/embedOrigins.js";
 import { Monitor } from "@/domain/monitors/monitor.type.js";
 import { IChecksRepository } from "@/domain/checks/check.repository.interface.js";
 import type { DailyCheckBucket } from "@/domain/checks/check.type.js";
@@ -58,6 +59,16 @@ export class StatusPageService implements IStatusPageService {
 		return { ...data, customDomain };
 	};
 
+	// The controller validates the raw body but passes it through unchanged, so the
+	// same normalisation the validator applies has to be repeated before persisting.
+	private normalizeEmbedAllowedOriginsInput = (data: Partial<StatusPage>): Partial<StatusPage> => {
+		if (!("embedAllowedOrigins" in data)) {
+			return data;
+		}
+
+		return { ...data, embedAllowedOrigins: normalizeEmbedAllowedOrigins(data.embedAllowedOrigins) ?? [] };
+	};
+
 	private withoutThemeFields = (data: Partial<StatusPage>): Partial<StatusPage> => {
 		const { theme: _theme, themeMode: _themeMode, ...rest } = data;
 		return rest;
@@ -101,7 +112,7 @@ export class StatusPageService implements IStatusPageService {
 		image: Express.Multer.File | undefined,
 		data: Partial<StatusPage>
 	): Promise<StatusPage> => {
-		const normalizedData = this.normalizeCustomDomainInput(this.normalizeInput(data));
+		const normalizedData = this.normalizeEmbedAllowedOriginsInput(this.normalizeCustomDomainInput(this.normalizeInput(data)));
 		const created = await this.statusPagesRepository.create(userId, teamId, image, normalizedData);
 		return this.normalizeTheme(created);
 	};
@@ -168,7 +179,7 @@ export class StatusPageService implements IStatusPageService {
 	};
 
 	updateStatusPage = async (id: string, teamId: string, image: Express.Multer.File | undefined, data: Partial<StatusPage>): Promise<StatusPage> => {
-		const normalizedData = this.normalizeCustomDomainInput(this.normalizeInput(data));
+		const normalizedData = this.normalizeEmbedAllowedOriginsInput(this.normalizeCustomDomainInput(this.normalizeInput(data)));
 		const updated = await this.statusPagesRepository.updateById(id, teamId, image, normalizedData);
 		return this.normalizeTheme(updated);
 	};

--- a/server/src/domain/status-pages/status-page.type.ts
+++ b/server/src/domain/status-pages/status-page.type.ts
@@ -38,6 +38,7 @@ export interface StatusPage {
 	companyName: string;
 	url: string;
 	customDomain?: string | null;
+	embedAllowedOrigins?: string[];
 	timezone?: string;
 	color: string;
 	monitors: string[];

--- a/server/src/utils/embedOrigins.ts
+++ b/server/src/utils/embedOrigins.ts
@@ -1,0 +1,13 @@
+// Multipart forms send the field as `embedAllowedOrigins[]`, which arrives as a
+// string for one value and an array for several. Coerce to a trimmed, lowercased,
+// deduplicated array; undefined stays undefined so an absent field is left alone.
+export const normalizeEmbedAllowedOrigins = (value: unknown): string[] | undefined => {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+
+	const values = Array.isArray(value) ? value : [value];
+	const normalized = values.filter((entry): entry is string => typeof entry === "string").map((entry) => entry.trim().toLowerCase());
+
+	return [...new Set(normalized.filter((entry) => entry.length > 0))];
+};

--- a/server/test/unit/middleware/statusPageDocumentCsp.test.ts
+++ b/server/test/unit/middleware/statusPageDocumentCsp.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it, jest } from "@jest/globals";
+import { describe, expect, it, jest, beforeEach } from "@jest/globals";
 import type { NextFunction, Request, Response } from "express";
 import { createStatusPageDocumentCsp } from "../../../src/api/middleware/statusPageDocumentCsp.ts";
+import type { IStatusPagesRepository } from "../../../src/domain/status-pages/status-page-repository.interface.ts";
+import { makeStatusPage } from "../../helpers/makeStatusPage.ts";
+
+const EMBED_ORIGINS = ["https://a.example", "https://b.example"];
 
 const makeRes = (): Response => {
 	const res = {} as Response;
@@ -8,20 +12,36 @@ const makeRes = (): Response => {
 	return res;
 };
 
-const cspMiddleware = createStatusPageDocumentCsp("http://localhost:10001");
+const createRepo = () =>
+	({
+		findByUrl: jest.fn().mockResolvedValue(makeStatusPage({ isPublished: true, embedAllowedOrigins: EMBED_ORIGINS })),
+		findByCustomDomain: jest
+			.fn()
+			.mockResolvedValue(makeStatusPage({ isPublished: true, customDomain: "status.example.com", embedAllowedOrigins: EMBED_ORIGINS })),
+	}) as unknown as jest.Mocked<Pick<IStatusPagesRepository, "findByUrl" | "findByCustomDomain">>;
 
-const run = (req: Partial<Request>) => {
-	const res = makeRes();
-	const next = jest.fn() as unknown as NextFunction;
-	cspMiddleware(req as Request, res, next);
-	return { res, next };
-};
+type Middleware = ReturnType<typeof createStatusPageDocumentCsp>;
+
+const run = (cspMiddleware: Middleware, req: Partial<Request>): Promise<{ res: Response; next: NextFunction }> =>
+	new Promise((resolve) => {
+		const res = makeRes();
+		const next = jest.fn(() => resolve({ res, next })) as unknown as NextFunction;
+		cspMiddleware(req as Request, res, next);
+	});
 
 const appendedValue = (res: Response): string => ((res.append as jest.Mock).mock.calls[0] as [string, string])[1];
 
 describe("statusPageDocumentCsp", () => {
-	it("appends a tightened CSP on the public status page path", () => {
-		const { res, next } = run({ path: "/status/public/my-status-page", hostname: "localhost" });
+	let repo: ReturnType<typeof createRepo>;
+	let cspMiddleware: Middleware;
+
+	beforeEach(() => {
+		repo = createRepo();
+		cspMiddleware = createStatusPageDocumentCsp("http://localhost:10001", repo as unknown as IStatusPagesRepository);
+	});
+
+	it("appends a tightened CSP on the public status page path", async () => {
+		const { res, next } = await run(cspMiddleware, { path: "/status/public/my-status-page", hostname: "localhost" });
 
 		expect(res.append).toHaveBeenCalledTimes(1);
 		const value = appendedValue(res);
@@ -31,26 +51,81 @@ describe("statusPageDocumentCsp", () => {
 		expect(next).toHaveBeenCalledTimes(1);
 	});
 
-	it("does not restrict default-src or connect-src so the page can still reach the API", () => {
-		const { res } = run({ path: "/status/public/my-status-page", hostname: "localhost" });
+	it("does not restrict default-src or connect-src so the page can still reach the API", async () => {
+		const { res } = await run(cspMiddleware, { path: "/status/public/my-status-page", hostname: "localhost" });
 
 		const value = appendedValue(res);
 		expect(value).not.toContain("default-src");
 		expect(value).not.toContain("connect-src");
 	});
 
-	it("appends the CSP on a custom domain document at the host root", () => {
-		const { res, next } = run({ path: "/", hostname: "status.example.com" });
+	it("allows the configured embedding origins on the public status page path", async () => {
+		const { res } = await run(cspMiddleware, { path: "/status/public/my-status-page", hostname: "localhost" });
+
+		expect(appendedValue(res)).toContain("frame-ancestors 'self' https://a.example https://b.example");
+		expect(repo.findByUrl).toHaveBeenCalledWith("my-status-page");
+		expect(repo.findByCustomDomain).not.toHaveBeenCalled();
+	});
+
+	it("appends the CSP with embedding origins on a custom domain document at the host root", async () => {
+		const { res, next } = await run(cspMiddleware, { path: "/", hostname: "status.example.com" });
 
 		expect(res.append).toHaveBeenCalledTimes(1);
-		expect(appendedValue(res)).toContain("img-src 'self' data:");
+		const value = appendedValue(res);
+		expect(value).toContain("img-src 'self' data:");
+		expect(value).toContain("frame-ancestors 'self' https://a.example https://b.example");
+		expect(repo.findByCustomDomain).toHaveBeenCalledWith("status.example.com");
+		expect(repo.findByUrl).not.toHaveBeenCalled();
 		expect(next).toHaveBeenCalledTimes(1);
 	});
 
-	it("leaves the app's own non-public routes untouched", () => {
-		const { res, next } = run({ path: "/status/create", hostname: "localhost" });
+	it("ignores embedding origins on an unpublished status page", async () => {
+		repo.findByUrl.mockResolvedValue(makeStatusPage({ isPublished: false, embedAllowedOrigins: EMBED_ORIGINS }));
+
+		const { res } = await run(cspMiddleware, { path: "/status/public/my-status-page", hostname: "localhost" });
+
+		const value = appendedValue(res);
+		expect(value).toContain("frame-ancestors 'self'");
+		expect(value).not.toContain("https://a.example");
+	});
+
+	it("falls back to 'self' when the status page is unknown", async () => {
+		repo.findByUrl.mockRejectedValue(new Error("Status page not found"));
+
+		const { res, next } = await run(cspMiddleware, { path: "/status/public/missing-page", hostname: "localhost" });
+
+		const value = appendedValue(res);
+		expect(value).toContain("img-src 'self' data:");
+		expect(value).toContain("frame-ancestors 'self'");
+		expect(value).not.toContain("https://a.example");
+		expect(next).toHaveBeenCalledTimes(1);
+	});
+
+	it("emits only frame-ancestors 'self' on other documents", async () => {
+		const { res, next } = await run(cspMiddleware, { path: "/", hostname: "localhost" });
+
+		expect(res.append).toHaveBeenCalledTimes(1);
+		expect(appendedValue(res)).toBe("frame-ancestors 'self'");
+		expect(appendedValue(res)).not.toContain("img-src");
+		expect(repo.findByUrl).not.toHaveBeenCalled();
+		expect(repo.findByCustomDomain).not.toHaveBeenCalled();
+		expect(next).toHaveBeenCalledTimes(1);
+	});
+
+	it("leaves API requests untouched", async () => {
+		const { res, next } = await run(cspMiddleware, { path: "/api/v1/monitors", hostname: "localhost" });
 
 		expect(res.append).not.toHaveBeenCalled();
+		expect(repo.findByUrl).not.toHaveBeenCalled();
+		expect(repo.findByCustomDomain).not.toHaveBeenCalled();
 		expect(next).toHaveBeenCalledTimes(1);
+	});
+
+	it("caches the lookup for a status page url", async () => {
+		await run(cspMiddleware, { path: "/status/public/my-status-page", hostname: "localhost" });
+		const { res } = await run(cspMiddleware, { path: "/status/public/my-status-page/details", hostname: "localhost" });
+
+		expect(repo.findByUrl).toHaveBeenCalledTimes(1);
+		expect(appendedValue(res)).toContain("frame-ancestors 'self' https://a.example https://b.example");
 	});
 });

--- a/server/test/unit/validation/statusPageValidation.test.ts
+++ b/server/test/unit/validation/statusPageValidation.test.ts
@@ -63,6 +63,61 @@ describe("createStatusPageBodyValidation", () => {
 	});
 });
 
+describe("createStatusPageBodyValidation embedAllowedOrigins", () => {
+	const parseOrigins = (embedAllowedOrigins: unknown) => createStatusPageBodyValidation.safeParse(baseCreateBody({ embedAllowedOrigins }));
+
+	it("accepts https, http with a port, and localhost origins", () => {
+		const result = parseOrigins(["https://a.example", "http://a.example:8080", "http://localhost:10001"]);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.embedAllowedOrigins).toEqual(["https://a.example", "http://a.example:8080", "http://localhost:10001"]);
+		}
+	});
+
+	it("trims, lowercases, and dedupes origins", () => {
+		const result = parseOrigins([" HTTPS://A.example ", "https://a.example", "", "https://b.example"]);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.embedAllowedOrigins).toEqual(["https://a.example", "https://b.example"]);
+		}
+	});
+
+	it("accepts a single string as one origin", () => {
+		const result = parseOrigins("https://a.example");
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.embedAllowedOrigins).toEqual(["https://a.example"]);
+		}
+	});
+
+	it("leaves the field undefined when absent", () => {
+		const result = createStatusPageBodyValidation.safeParse(baseCreateBody());
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.embedAllowedOrigins).toBeUndefined();
+		}
+	});
+
+	it.each([["https://a.example/path"], ["a.example"], ["javascript:alert(1)"], ["https://a.example/"]])("rejects %s", (origin) => {
+		const result = parseOrigins([origin]);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(expect.arrayContaining([expect.objectContaining({ path: ["embedAllowedOrigins", 0] })]));
+		}
+	});
+
+	it("rejects more than 20 origins", () => {
+		const origins = Array.from({ length: 21 }, (_, i) => `https://site${i}.example`);
+		const result = parseOrigins(origins);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues).toEqual(
+				expect.arrayContaining([expect.objectContaining({ message: "At most 20 embedding origins are allowed", path: ["embedAllowedOrigins"] })])
+			);
+		}
+	});
+});
+
 describe("getStatusPageQueryValidation", () => {
 	it("defaults range to latest when absent", () => {
 		const result = getStatusPageQueryValidation.safeParse({ type: "uptime" });

--- a/server/test/unit/validation/statusPageValidation.test.ts
+++ b/server/test/unit/validation/statusPageValidation.test.ts
@@ -74,6 +74,14 @@ describe("createStatusPageBodyValidation embedAllowedOrigins", () => {
 		}
 	});
 
+	it("accepts IPv4 and bracketed IPv6 origins", () => {
+		const result = parseOrigins(["http://192.168.1.10:8080", "https://10.0.0.1", "http://[::1]:3000", "https://[2001:db8::1]"]);
+		expect(result.success).toBe(true);
+		if (result.success) {
+			expect(result.data.embedAllowedOrigins).toEqual(["http://192.168.1.10:8080", "https://10.0.0.1", "http://[::1]:3000", "https://[2001:db8::1]"]);
+		}
+	});
+
 	it("trims, lowercases, and dedupes origins", () => {
 		const result = parseOrigins([" HTTPS://A.example ", "https://a.example", "", "https://b.example"]);
 		expect(result.success).toBe(true);
@@ -98,7 +106,16 @@ describe("createStatusPageBodyValidation embedAllowedOrigins", () => {
 		}
 	});
 
-	it.each([["https://a.example/path"], ["a.example"], ["javascript:alert(1)"], ["https://a.example/"]])("rejects %s", (origin) => {
+	it.each([
+		["https://a.example/path"],
+		["a.example"],
+		["javascript:alert(1)"],
+		["https://a.example/"],
+		["http://999.1.1.1"],
+		["http://[not-an-address]"],
+		["http://::1"],
+		["https://a.example:99999999"],
+	])("rejects %s", (origin) => {
 		const result = parseOrigins([origin]);
 		expect(result.success).toBe(false);
 		if (!result.success) {


### PR DESCRIPTION
## Describe your changes

Public status pages were served with helmet's default `frame-ancestors 'self'`, so embedding one in an iframe from another origin was blocked, and a custom domain did not help because the embedding page is still a different origin.

Each status page now has an optional list of allowed embedding origins, set in the status page form next to the custom domain. Origins are validated as `https?://host[:port]` with no path, limited to 20, and normalised (trimmed, lowercased, deduplicated) before saving. The status page document CSP middleware looks the page up by `/status/public/:url` or by custom domain, cached in the same way as the CORS origin middleware, and emits `frame-ancestors 'self' <origins>` for published pages. Every other non-API document gets `frame-ancestors 'self'`. helmet no longer emits `frame-ancestors`.

One ordering fix on the way: helmet sets the Content-Security-Policy header with a replace, not an append, so the existing status page CSP tightening was being lost on documents served by the SPA catch-all, and documents served straight from the client build carried no helmet policy at all. helmet now runs before `express.static` and before the status page middleware. Verified with curl before and after.

`X-Frame-Options: SAMEORIGIN` is still sent. Browsers that support `frame-ancestors` ignore it when both are present. Happy to drop it for status page documents if preferred.

Tested locally: server lint, format-check, build and unit tests (Node 20); client lint, format-check and build; a published page with two origins checked with curl on the public path and on a custom domain host, plus unknown page, unpublished page, app root and API responses.

Happy to split this into a server PR and a client PR if that is easier to review.

## Write your issue number after "Fixes "

Fixes #3941

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

Screen shot showing the new addition to the status page area - /status/configure/<PAGEID>

<img width="930" height="488" alt="Screenshot 2026-09-11 at 12 32 44" src="https://github.com/user-attachments/assets/f62f65b4-dea8-47f5-99cc-db94a38ab77d" />
