### PR TITLE
fix(docker): bump MongoDB to 8.2 so the stack starts on Linux 6.19+ kernels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ npm run format           # Prettier formatting
 ```bash
 docker build -f docker/Dockerfile -t checkmate .          # build the mono image (server + built client)
 docker compose -f docker/dev/docker-compose.yaml up       # local full stack (builds image, runs mongo + worker)
-docker run -d -p 27017:27017 -v uptime_mongo_data:/data/db --name uptime_database_mongo mongo:8.0   # just a dev database
+docker run -d -p 27017:27017 -v uptime_mongo_data:/data/db --name uptime_database_mongo mongo:8.2   # just a dev database
 ```
 
 ## Environment Setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,7 +91,7 @@ cd Checkmate
 Run MongoDB container:
 
 ```bash
-docker run -d -p 27017:27017 -v uptime_mongo_data:/data/db --name uptime_database_mongo mongo:8.0
+docker run -d -p 27017:27017 -v uptime_mongo_data:/data/db --name uptime_database_mongo mongo:8.2
 ```
 
 #### Step 3: Set Up the Backend (Server)

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -39,7 +39,7 @@ services:
       mongodb:
         condition: service_healthy
   mongodb:
-    image: mongo:8.0
+    image: mongo:8.2
     restart: always
     ports:
       - "27017:27017"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
         condition: service_healthy
 
   mongodb:
-    image: mongo:8.0
+    image: mongo:8.2
     restart: always
     command: ["mongod", "--quiet", "--bind_ip_all"]
     volumes:


### PR DESCRIPTION
## Describe your changes

Bumps the MongoDB image from `mongo:8.0` to `mongo:8.2` in both Compose files, and in the two documented `docker run` dev-database commands.

Fixes #3842.

`mongo:8.0` refuses to start on Linux kernels **6.19 through 7.0.13** — the TCMalloc it vendors violates the upstream rseq ABI, so MongoDB detects those kernels and exits during startup ([MongoDB 8.0 release notes](https://www.mongodb.com/docs/manual/release-notes/8.0/), SERVER-121912). Since the Compose files gate `checkmate` on `mongodb: condition: service_healthy`, the whole stack never comes up: MongoDB crash-loops and `checkmate` sits in `Created`. That is the 502 in #3842, and it now hits anyone on Debian 13, Ubuntu 26.04, Proxmox VE 9 or Fedora 43+.

**8.2 has no kernel gate at all.** Grepping the shipped binaries:

| | `mongo:8.0` (8.0.30) | `mongo:8.2` (8.2.12) |
|---|---|---|
| `"known incompatibility with this version of MongoDB"` | 1 | **0** |
| `"6.19"` | 1 | **0** |
| `SERVER-121912` | 1 | **0** |

SERVER-121912 is closed as *Gone away* — the rseq violation was fixed upstream in TCMalloc — and SERVER-125742 removed the startup gate. 8.2 is also already what this project pins in `docs/hosting/checkmate-so/docker-compose.yaml`, so it is not a new dependency for the team.

## Why not the `GLIBC_TUNABLES` workaround

#3842 documents `GLIBC_TUNABLES=glibc.pthread.rseq=1`, and it does make 8.0 start — I verified that too. I deliberately did **not** submit that, because on 6.19–7.0.13 the crash the gate prevents is real: forcing rseq on keeps users on the unfixed allocator and swaps a loud refusal at startup for a latent memory-allocator bug at runtime. It is the right emergency fix for someone who cannot change images today; it is the wrong thing to ship as the default. The reporter says as much in the issue — *"the real fix won't land until MongoDB ships a patched TCMalloc"*. It has now landed, in 8.2.

## Testing

Ubuntu 26.04.1 LTS, kernel `7.0.0-1011-gcp` (inside the affected range), Docker 29.8.0. Same host, back to back, `docker/docker-compose.yaml` with nothing else changed.

**Before**

```
checkmate   created       Created
mongodb     restarting    Restarting (1)

mongodb-1  | "msg":"MongoDB cannot start: Linux kernel versions 6.19 and newer
              has a known incompatibility with this version of MongoDB."
$ curl http://localhost:52345/   ->  connection refused
```

**After**

```
checkmate   running    Up About a minute (healthy)
mongodb     running    Up About a minute (healthy)

mongodb-1  | "msg":"Waiting for connections","attr":{"port":27017,"ssl":"off"}
$ curl http://localhost:52345/   ->  200   <title>Checkmate</title>
$ mongosh --eval 'db.version()'  ->  8.2.12
```

**Upgrade and rollback for existing installs** — on a volume written by 8.0:

- `mongo:8.2` opens it, `featureCompatibilityVersion` stays `8.0`, documents intact.
- Putting `mongo:8.0` back afterwards still starts and still reads the data.

So this is a tag change for existing deployments, not a data migration, and it is reversible as long as nobody runs `setFeatureCompatibilityVersion: "8.2"`.

The existing `mongosh` healthcheck passes unchanged, so nothing else in either file needed touching.

## Checklist

- [x] Tested locally and confirmed the change works
- [x] Related issue referenced (#3842)
- [x] Addresses only one topic
- [x] No user-facing strings, styling or UI changed — no screenshots apply
- [ ] Issue assigned to me — I can't self-assign; happy for a maintainer to do it

`lint` / `format-check` / `build` are unaffected: this touches no files under `client/` or `server/`. The two remaining `mongo:8.0` strings in the repo are mock container fixtures in `server/test/unit`, deliberately left alone.

## Note on overlap

#3878 also edits both Compose files, but only the `healthcheck:` line, while this touches only `image:`. They shouldn't conflict, and I'm happy to rebase on whichever lands first.
