### PR TITLE
Add instance egress self-check (#3937)

### DIFF
--- a/client/src/Components/design-elements/EgressBanner.tsx
+++ b/client/src/Components/design-elements/EgressBanner.tsx
@@ -1,0 +1,59 @@
+import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { useTheme } from "@mui/material/styles";
+import { useTranslation } from "react-i18next";
+import { useSelector } from "react-redux";
+import { TriangleAlert } from "lucide-react";
+import type { RootState } from "@/Types/state";
+import type { EgressState } from "@/Types/Egress";
+import { formatDateWithTz } from "@/Utils/TimeUtils";
+import { LAYOUT } from "@/Utils/Theme/constants";
+
+interface EgressBannerProps {
+	state: EgressState | null;
+}
+
+export const EgressBanner = ({ state }: EgressBannerProps) => {
+	const theme = useTheme();
+	const { t } = useTranslation();
+	const uiTimezone = useSelector((s: RootState) => s.ui.timezone);
+
+	if (state?.status !== "degraded") return null;
+
+	const message = state.degradedSince
+		? t("components.egressBanner.degraded", {
+				time: formatDateWithTz(state.degradedSince, "ddd, MMM D, HH:mm", uiTimezone),
+			})
+		: t("components.egressBanner.degradedNoTime");
+
+	return (
+		<Box
+			position="fixed"
+			top={0}
+			left={0}
+			right={0}
+			zIndex={theme.zIndex.snackbar}
+			bgcolor={theme.palette.warning.main}
+			color={theme.palette.warning.contrastText}
+			px={theme.spacing(LAYOUT.MD)}
+			py={theme.spacing(LAYOUT.XS)}
+			role="status"
+		>
+			<Stack
+				direction="row"
+				alignItems="center"
+				justifyContent="center"
+				gap={theme.spacing(LAYOUT.XS)}
+			>
+				<TriangleAlert size={20} />
+				<Typography
+					variant="body2"
+					fontWeight={500}
+				>
+					{message}
+				</Typography>
+			</Stack>
+		</Box>
+	);
+};

--- a/client/src/Components/design-elements/index.tsx
+++ b/client/src/Components/design-elements/index.tsx
@@ -24,6 +24,7 @@ export * from "./SplitBox";
 export * from "./TextLink";
 export * from "./NoticeBanner";
 export * from "./OfflineBanner";
+export * from "./EgressBanner";
 export * from "./Avatar";
 export * from "./StatusCodeLabel";
 export * from "./StrategyBadge";

--- a/client/src/Components/layout/AppLayout.tsx
+++ b/client/src/Components/layout/AppLayout.tsx
@@ -1,8 +1,14 @@
 import Box from "@mui/material/Box";
 import { useState, useEffect, useRef } from "react";
 import { useTheme } from "@mui/material/styles";
-import { OfflineBanner } from "@/Components/design-elements";
+import { useSelector } from "react-redux";
+import { OfflineBanner, EgressBanner } from "@/Components/design-elements";
 import { setServerUnreachableCallback, get } from "@/Utils/ApiClient";
+import { useGet } from "@/Hooks/UseApi";
+import type { RootState } from "@/Types/state";
+import type { EgressState } from "@/Types/Egress";
+
+const EGRESS_POLL_MS = 30_000;
 
 interface AppLayoutProps {
 	children: React.ReactNode;
@@ -12,6 +18,15 @@ const AppLayout = ({ children }: AppLayoutProps) => {
 	const theme = useTheme();
 	const [serverUnreachable, setServerUnreachable] = useState(false);
 	const retryIntervalRef = useRef<number | null>(null);
+	const authToken = useSelector((state: RootState) => state.auth.authToken);
+
+	// Poll egress state only for signed-in users; failures are swallowed because
+	// an unreachable server is already reported by OfflineBanner.
+	const { data: egressState } = useGet<EgressState>(
+		authToken ? "/egress" : null,
+		undefined,
+		{ refreshInterval: EGRESS_POLL_MS, shouldRetryOnError: false }
+	);
 
 	useEffect(() => {
 		setServerUnreachableCallback(setServerUnreachable);
@@ -46,6 +61,7 @@ const AppLayout = ({ children }: AppLayoutProps) => {
 			}}
 		>
 			<OfflineBanner visible={serverUnreachable} />
+			{!serverUnreachable && <EgressBanner state={egressState} />}
 			{children}
 		</Box>
 	);

--- a/client/src/Hooks/useSettingsForm.ts
+++ b/client/src/Hooks/useSettingsForm.ts
@@ -45,6 +45,10 @@ export const useSettingsForm = ({ data = null }: UseSettingsFormOptions = {}) =>
 			systemEmailPassword: "",
 			globalProxyEnabled: data?.globalProxyEnabled ?? false,
 			globalProxyId: data?.globalProxyId ?? null,
+			egressCheckEnabled: data?.egressCheckEnabled ?? false,
+			egressCheckTargets: (data?.egressCheckTargets ?? []).join("\n"),
+			egressPollIntervalSeconds: data?.egressPollIntervalSeconds ?? 30,
+			egressNotifications: data?.egressNotifications ?? [],
 		};
 
 		return { schema: settingsSchema, defaults };

--- a/client/src/Pages/Settings/index.tsx
+++ b/client/src/Pages/Settings/index.tsx
@@ -39,12 +39,19 @@ import { timezoneOptions } from "@/Utils/timezoneOptions";
 import type { TimezoneOption } from "@/Utils/timezoneOptions";
 import type { RootState } from "@/Types/state";
 import { CHECK_TTL_SENTINEL } from "@/Types/Check";
+import {
+	EGRESS_POLL_INTERVAL_MAX,
+	EGRESS_POLL_INTERVAL_MIN,
+	EGRESS_TARGETS_MAX,
+} from "@/Validation/settings";
 import { FormTextField } from "@/Components/inputs/forms/FormTextField";
 import { FormSliderField } from "@/Components/inputs/forms/FormSliderField";
 import { FormSwitchField } from "@/Components/inputs/forms/FormSwitchField";
 import { FormNumberField } from "@/Components/inputs/forms/FormNumberField";
 import { FormSelectField } from "@/Components/inputs/forms/FormSelectField";
+import { FormMultiSelectField } from "@/Components/inputs/forms/FormMultiSelectField";
 import type { ProxyResponse } from "@/Types/Proxy";
+import type { Notification } from "@/Types/Notification";
 import type { AppSettingsResponse } from "@/Types/Settings";
 import { useSearchParams } from "react-router-dom";
 
@@ -61,6 +68,10 @@ type SettingsTabKey = (typeof SETTINGS_TABS)[number]["key"];
 const FIELD_TAB: Record<string, SettingsTabKey> = {
 	checkTTL: "monitoring",
 	globalThresholds: "monitoring",
+	egressCheckEnabled: "monitoring",
+	egressCheckTargets: "monitoring",
+	egressPollIntervalSeconds: "monitoring",
+	egressNotifications: "monitoring",
 	pagespeedApiKey: "integrations",
 	globalProxyEnabled: "integrations",
 	globalProxyId: "integrations",
@@ -81,6 +92,10 @@ const FIELD_LABEL_KEY: Record<string, string> = {
 		"pages.settings.form.thresholds.option.temperature.label",
 	pagespeedApiKey: "pages.settings.form.pagespeed.option.apiKey.label",
 	globalProxyEnabled: "pages.settings.form.globalProxy.option.enabled.label",
+	egressCheckEnabled: "pages.settings.form.egress.option.enabled.label",
+	egressCheckTargets: "pages.settings.form.egress.option.targets.label",
+	egressPollIntervalSeconds: "pages.settings.form.egress.option.pollInterval.label",
+	egressNotifications: "pages.settings.form.egress.option.notifications.label",
 	showURL: "pages.settings.form.url.option.showURL.label",
 	systemEmailHost: "pages.settings.form.email.option.host.label",
 	systemEmailPort: "pages.settings.form.email.option.port.label",
@@ -181,6 +196,15 @@ export const SettingsPage = () => {
 				label: `${proxy.name} (${proxy.host}:${proxy.port})`,
 			})),
 		[proxies]
+	);
+
+	// Notification channels for the egress self-check picker
+	const { data: notifications } = useGet<Notification[]>(
+		isAdmin ? "/notifications/team" : null
+	);
+	const notificationOptions = useMemo(
+		() => (notifications ?? []).map((n) => ({ ...n, name: n.notificationName })),
+		[notifications]
 	);
 
 	// Form submission
@@ -420,6 +444,7 @@ export const SettingsPage = () => {
 	const languages = Object.keys(i18n.options.resources || {});
 
 	const globalProxyEnabled = watch("globalProxyEnabled");
+	const egressCheckEnabled = watch("egressCheckEnabled");
 
 	// Enabling the proxy with nothing selected preselects the first proxy
 	useEffect(() => {
@@ -632,6 +657,65 @@ export const SettingsPage = () => {
 												: `${value}`
 										}
 									/>
+								}
+							/>
+						)}
+
+						{/* Egress self-check */}
+						{isAdmin && (
+							<ConfigBox
+								title={t("pages.settings.form.egress.title")}
+								subtitle={t("pages.settings.form.egress.description")}
+								rightContent={
+									<Stack gap={theme.spacing(LAYOUT.MD)}>
+										<FormSwitchField
+											name="egressCheckEnabled"
+											labelPlacement="start"
+											label={t("pages.settings.form.egress.option.enabled.label")}
+										/>
+										<FormTextField
+											name="egressCheckTargets"
+											multiline
+											minRows={3}
+											fieldLabel={t("pages.settings.form.egress.option.targets.label")}
+											placeholder={t(
+												"pages.settings.form.egress.option.targets.placeholder"
+											)}
+											helperText={t("pages.settings.form.egress.option.targets.helper", {
+												max: EGRESS_TARGETS_MAX,
+											})}
+										/>
+										{egressCheckEnabled && (
+											<FormNumberField
+												name="egressPollIntervalSeconds"
+												fieldLabel={t(
+													"pages.settings.form.egress.option.pollInterval.label"
+												)}
+												placeholder={t(
+													"pages.settings.form.egress.option.pollInterval.placeholder"
+												)}
+												slotProps={{
+													htmlInput: {
+														min: EGRESS_POLL_INTERVAL_MIN,
+														max: EGRESS_POLL_INTERVAL_MAX,
+													},
+												}}
+											/>
+										)}
+										<FormMultiSelectField
+											name="egressNotifications"
+											options={notificationOptions}
+											fieldLabel={t(
+												"pages.settings.form.egress.option.notifications.label"
+											)}
+											placeholder={t(
+												"pages.settings.form.egress.option.notifications.placeholder"
+											)}
+											description={t(
+												"pages.settings.form.egress.option.notifications.description"
+											)}
+										/>
+									</Stack>
 								}
 							/>
 						)}

--- a/client/src/Pages/Uptime/Details/Components/ChecksTable.tsx
+++ b/client/src/Pages/Uptime/Details/Components/ChecksTable.tsx
@@ -5,6 +5,11 @@ import {
 	StatusCodeLabel,
 } from "@/Components/design-elements";
 import Box from "@mui/material/Box";
+import Stack from "@mui/material/Stack";
+import Typography from "@mui/material/Typography";
+import { useTheme } from "@mui/material/styles";
+import { LAYOUT } from "@/Utils/Theme/constants";
+import { typographyLevels } from "@/Utils/Theme/Palette";
 import type { Header } from "@/Components/design-elements";
 import type { Check } from "@/Types/Check";
 
@@ -31,6 +36,7 @@ export const ChecksTable = ({
 }) => {
 	const navigate = useNavigate();
 	const { t } = useTranslation();
+	const theme = useTheme();
 	const uiTimezone = useSelector((state: RootState) => state.ui.timezone);
 
 	const headers: Header<Check>[] = [
@@ -38,7 +44,23 @@ export const ChecksTable = ({
 			id: "status",
 			content: t("common.table.headers.status"),
 			render: (row) => {
-				return <StatusLabel status={row.status === true ? "up" : "down"} />;
+				return (
+					<Stack
+						direction="row"
+						alignItems="center"
+						gap={theme.spacing(LAYOUT.XS)}
+					>
+						<StatusLabel status={row.status === true ? "up" : "down"} />
+						{row.egressStatus === "degraded" && (
+							<Typography
+								color={theme.palette.warning.main}
+								fontSize={typographyLevels.xs}
+							>
+								{t("pages.checks.table.egressDegraded")}
+							</Typography>
+						)}
+					</Stack>
+				);
 			},
 		},
 		{

--- a/client/src/Types/Check.ts
+++ b/client/src/Types/Check.ts
@@ -1,3 +1,5 @@
+import type { EgressStatus } from "@/Types/Egress";
+
 export const CHECK_TTL_SENTINEL = 366;
 
 export interface CheckMetadata {
@@ -224,6 +226,7 @@ export interface Check {
 	seo?: number;
 	performance?: number;
 	audits?: CheckAudits;
+	egressStatus?: EgressStatus;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/client/src/Types/Egress.ts
+++ b/client/src/Types/Egress.ts
@@ -1,0 +1,19 @@
+// Mirrors the egress self-check state returned by GET /egress.
+export const EgressStatuses = ["ok", "degraded"] as const;
+export type EgressStatus = (typeof EgressStatuses)[number];
+
+export interface EgressProbeResult {
+	target: string;
+	reachable: boolean;
+	responseTime: number;
+	message?: string;
+}
+
+export interface EgressState {
+	id: string;
+	status: EgressStatus;
+	degradedSince: string | null;
+	lastRecoveredAt: string | null;
+	lastProbeAt: string | null;
+	lastProbeResults: EgressProbeResult[];
+}

--- a/client/src/Types/Settings.ts
+++ b/client/src/Types/Settings.ts
@@ -26,6 +26,10 @@ export interface Settings {
 	globalThresholds?: SettingsThresholds;
 	globalProxyEnabled: boolean;
 	globalProxyId?: string | null;
+	egressCheckEnabled: boolean;
+	egressCheckTargets: string[];
+	egressPollIntervalSeconds: number;
+	egressNotifications: string[];
 	createdAt: string;
 	updatedAt: string;
 }

--- a/client/src/Validation/settings.ts
+++ b/client/src/Validation/settings.ts
@@ -1,6 +1,24 @@
 import { CHECK_TTL_SENTINEL } from "@/Types/Check";
 import { z } from "zod";
 
+export const EGRESS_TARGETS_MIN = 1;
+export const EGRESS_TARGETS_MAX = 10;
+export const EGRESS_POLL_INTERVAL_MIN = 5;
+export const EGRESS_POLL_INTERVAL_MAX = 600;
+
+// Mirrors the server-side target format: bare host/IP, host:port, or http(s) URL.
+const EGRESS_TARGET_REGEX = /^(https?:\/\/\S+|[A-Za-z0-9.\-:[\]]+)$/;
+
+const splitEgressTargets = (raw: string): string[] =>
+	Array.from(
+		new Set(
+			raw
+				.split(/[\s,]+/)
+				.map((entry) => entry.trim())
+				.filter((entry) => entry !== "")
+		)
+	);
+
 export const settingsSchema = z
 	.object({
 		systemEmailIgnoreTLS: z.boolean(),
@@ -58,8 +76,40 @@ export const settingsSchema = z
 		}),
 		globalProxyEnabled: z.boolean(),
 		globalProxyId: z.string().nullable().optional(),
+		egressCheckEnabled: z.boolean(),
+		egressCheckTargets: z
+			.string()
+			.transform(splitEgressTargets)
+			.pipe(
+				z
+					.array(
+						z
+							.string()
+							.regex(
+								EGRESS_TARGET_REGEX,
+								"Each target must be a host, IP, host:port, or http(s) URL"
+							)
+					)
+					.max(EGRESS_TARGETS_MAX, `Maximum ${EGRESS_TARGETS_MAX} targets`)
+			),
+		egressPollIntervalSeconds: z
+			.number()
+			.int()
+			.min(EGRESS_POLL_INTERVAL_MIN, `Minimum ${EGRESS_POLL_INTERVAL_MIN} seconds`)
+			.max(EGRESS_POLL_INTERVAL_MAX, `Maximum ${EGRESS_POLL_INTERVAL_MAX} seconds`),
+		egressNotifications: z.array(z.string()),
 	})
 	.superRefine((body, ctx) => {
+		if (
+			body.egressCheckEnabled === true &&
+			body.egressCheckTargets.length < EGRESS_TARGETS_MIN
+		) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["egressCheckTargets"],
+				message: "Enter at least one target to enable the egress self-check",
+			});
+		}
 		if (body.globalProxyEnabled === true && !body.globalProxyId) {
 			ctx.addIssue({
 				code: "custom",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -206,6 +206,10 @@
 			"retrying": "Retrying...",
 			"reconnected": "Connection restored"
 		},
+		"egressBanner": {
+			"degraded": "Checkmate cannot reach its reliability targets. Outbound connectivity appears to be down since {{time}}; monitor failures are not being reported as incidents until it recovers.",
+			"degradedNoTime": "Checkmate cannot reach its reliability targets. Outbound connectivity appears to be down; monitor failures are not being reported as incidents until it recovers."
+		},
 		"sidebar": {
 			"menu": {
 				"uptime": "Uptime",
@@ -507,6 +511,7 @@
 			},
 			"table": {
 				"empty": "No down checks in this time range",
+				"egressDegraded": "Egress degraded",
 				"headers": {
 					"statusCode": "Status code",
 					"location": "Location"
@@ -1602,6 +1607,29 @@
 						},
 						"rejectUnauthorized": {
 							"label": "Reject invalid certificates: Reject connections with self-signed or untrusted certificates"
+						}
+					}
+				},
+				"egress": {
+					"title": "Egress self-check",
+					"description": "Periodically probe a set of reliability targets from this instance. While none of them can be reached, outbound connectivity is treated as down and monitor failures are not recorded as incidents.",
+					"option": {
+						"enabled": {
+							"label": "Enable egress self-check"
+						},
+						"targets": {
+							"label": "Reliability targets",
+							"placeholder": "1.1.1.1\ndns.google:53\nhttps://example.com",
+							"helper": "One per line or comma-separated, up to {{max}}. A bare host or IP is pinged (ICMP), host:port opens a TCP connection, and an http:// or https:// URL is requested over HTTP."
+						},
+						"pollInterval": {
+							"label": "Poll interval (seconds)",
+							"placeholder": "30"
+						},
+						"notifications": {
+							"label": "Notify on change",
+							"placeholder": "Select notification channels",
+							"description": "Channels alerted when egress becomes degraded and when it recovers."
 						}
 					}
 				},

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -53,6 +53,10 @@
 			"description": "Outbound proxy servers for routing HTTP monitor checks, team-scoped with an instance-wide admin listing."
 		},
 		{
+			"name": "egress",
+			"description": "Instance egress self-check state: whether the server's own outbound connectivity is currently degraded."
+		},
+		{
 			"name": "invite",
 			"description": "Team invitations and accepting them."
 		},
@@ -422,9 +426,6 @@
 					"secret": {
 						"type": "string"
 					},
-					"sshPrivateKey": {
-						"type": "string"
-					},
 					"cpuAlertThreshold": {
 						"type": "number"
 					},
@@ -465,6 +466,9 @@
 					},
 					"geoCheckInterval": {
 						"type": "number"
+					},
+					"dockerLogsEnabled": {
+						"type": "boolean"
 					},
 					"dnsServer": {
 						"type": "string"
@@ -513,6 +517,7 @@
 					"geoCheckEnabled",
 					"geoCheckLocations",
 					"geoCheckInterval",
+					"dockerLogsEnabled",
 					"teamId",
 					"userId",
 					"createdAt",
@@ -640,9 +645,6 @@
 									"secret": {
 										"type": "string"
 									},
-									"sshPrivateKey": {
-										"type": "string"
-									},
 									"cpuAlertThreshold": {
 										"type": "number"
 									},
@@ -683,6 +685,9 @@
 									},
 									"geoCheckInterval": {
 										"type": "number"
+									},
+									"dockerLogsEnabled": {
+										"type": "boolean"
 									},
 									"dnsServer": {
 										"type": "string"
@@ -733,6 +738,7 @@
 									"geoCheckEnabled",
 									"geoCheckLocations",
 									"geoCheckInterval",
+									"dockerLogsEnabled",
 									"teamId",
 									"userId",
 									"createdAt",
@@ -930,6 +936,9 @@
 						"$ref": "#/components/schemas/PushoverNotification"
 					},
 					{
+						"$ref": "#/components/schemas/SignalgridNotification"
+					},
+					{
 						"$ref": "#/components/schemas/TwilioNotification"
 					},
 					{
@@ -949,6 +958,7 @@
 						"teams": "#/components/schemas/TeamsNotification",
 						"telegram": "#/components/schemas/TelegramNotification",
 						"pushover": "#/components/schemas/PushoverNotification",
+						"signalgrid": "#/components/schemas/SignalgridNotification",
 						"twilio": "#/components/schemas/TwilioNotification",
 						"ntfy": "#/components/schemas/NtfyNotification"
 					}
@@ -1378,6 +1388,34 @@
 					"type": "pushover",
 					"address": "u1234567890abcdef",
 					"accessToken": "a1234567890abcdef"
+				}
+			},
+			"SignalgridNotification": {
+				"type": "object",
+				"properties": {
+					"notificationName": {
+						"type": "string",
+						"minLength": 1
+					},
+					"type": {
+						"type": "string",
+						"enum": ["signalgrid"]
+					},
+					"address": {
+						"type": "string",
+						"minLength": 1
+					},
+					"accessToken": {
+						"type": "string",
+						"minLength": 1
+					}
+				},
+				"required": ["notificationName", "type", "address", "accessToken"],
+				"example": {
+					"notificationName": "Signalgrid",
+					"type": "signalgrid",
+					"address": "your-channel",
+					"accessToken": "your-client-key"
 				}
 			},
 			"TwilioNotification": {
@@ -4113,6 +4151,160 @@
 										}
 									},
 									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Forbidden",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/egress": {
+			"get": {
+				"tags": ["egress"],
+				"summary": "Get the instance's current egress self-check state",
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"type": "object",
+											"properties": {
+												"id": {
+													"type": "string"
+												},
+												"status": {
+													"type": "string",
+													"enum": ["ok", "degraded"]
+												},
+												"degradedSince": {
+													"type": "string",
+													"nullable": true
+												},
+												"lastRecoveredAt": {
+													"type": "string",
+													"nullable": true
+												},
+												"lastProbeAt": {
+													"type": "string",
+													"nullable": true
+												},
+												"lastProbeResults": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"properties": {
+															"target": {
+																"type": "string"
+															},
+															"reachable": {
+																"type": "boolean"
+															},
+															"responseTime": {
+																"type": "number"
+															},
+															"message": {
+																"type": "string"
+															}
+														},
+														"required": ["target", "reachable", "responseTime"]
+													}
+												},
+												"createdAt": {
+													"type": "string"
+												},
+												"updatedAt": {
+													"type": "string"
+												}
+											},
+											"required": ["id", "status", "degradedSince", "lastRecoveredAt", "lastProbeAt", "lastProbeResults", "createdAt", "updatedAt"]
+										}
+									},
+									"required": ["success", "msg", "data"]
 								}
 							}
 						}
@@ -7090,9 +7282,6 @@
 														"secret": {
 															"type": "string"
 														},
-														"sshPrivateKey": {
-															"type": "string"
-														},
 														"cpuAlertThreshold": {
 															"type": "number"
 														},
@@ -7133,6 +7322,9 @@
 														},
 														"geoCheckInterval": {
 															"type": "number"
+														},
+														"dockerLogsEnabled": {
+															"type": "boolean"
 														},
 														"dnsServer": {
 															"type": "string"
@@ -7183,6 +7375,7 @@
 														"geoCheckEnabled",
 														"geoCheckLocations",
 														"geoCheckInterval",
+														"dockerLogsEnabled",
 														"teamId",
 														"userId",
 														"createdAt",
@@ -7655,9 +7848,6 @@
 														"secret": {
 															"type": "string"
 														},
-														"sshPrivateKey": {
-															"type": "string"
-														},
 														"cpuAlertThreshold": {
 															"type": "number"
 														},
@@ -7698,6 +7888,9 @@
 														},
 														"geoCheckInterval": {
 															"type": "number"
+														},
+														"dockerLogsEnabled": {
+															"type": "boolean"
 														},
 														"dnsServer": {
 															"type": "string"
@@ -7748,6 +7941,7 @@
 														"geoCheckEnabled",
 														"geoCheckLocations",
 														"geoCheckInterval",
+														"dockerLogsEnabled",
 														"teamId",
 														"userId",
 														"createdAt",
@@ -7905,6 +8099,231 @@
 												}
 											},
 											"required": ["monitor", "stats"]
+										}
+									},
+									"required": ["success", "msg", "data"]
+								}
+							}
+						}
+					},
+					"401": {
+						"description": "Unauthorized",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"403": {
+						"description": "Forbidden",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal server error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [false]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"nullable": true
+										}
+									},
+									"required": ["success", "msg"]
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"/monitors/docker/details/{monitorId}/containers/{containerName}/logs": {
+			"get": {
+				"tags": ["monitors"],
+				"summary": "Get stored log lines for one container on a Docker host monitor, newest first",
+				"security": [
+					{
+						"bearerAuth": []
+					}
+				],
+				"parameters": [
+					{
+						"schema": {
+							"type": "string",
+							"minLength": 1
+						},
+						"required": true,
+						"name": "monitorId",
+						"in": "path"
+					},
+					{
+						"schema": {
+							"type": "string",
+							"minLength": 1
+						},
+						"required": true,
+						"name": "containerName",
+						"in": "path"
+					},
+					{
+						"schema": {
+							"type": "string",
+							"format": "date-time"
+						},
+						"required": false,
+						"name": "before",
+						"in": "query"
+					},
+					{
+						"schema": {
+							"type": "string",
+							"format": "date-time"
+						},
+						"required": false,
+						"name": "after",
+						"in": "query"
+					},
+					{
+						"schema": {
+							"type": "integer",
+							"minimum": 1,
+							"maximum": 50,
+							"default": 20
+						},
+						"required": false,
+						"name": "limit",
+						"in": "query"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "object",
+									"properties": {
+										"success": {
+											"type": "boolean",
+											"enum": [true]
+										},
+										"msg": {
+											"type": "string"
+										},
+										"data": {
+											"type": "object",
+											"properties": {
+												"logs": {
+													"type": "array",
+													"items": {
+														"type": "object",
+														"properties": {
+															"id": {
+																"type": "string"
+															},
+															"metadata": {
+																"type": "object",
+																"properties": {
+																	"monitorId": {
+																		"type": "string"
+																	},
+																	"teamId": {
+																		"type": "string"
+																	},
+																	"containerId": {
+																		"type": "string"
+																	},
+																	"containerName": {
+																		"type": "string"
+																	}
+																},
+																"required": ["monitorId", "teamId", "containerId", "containerName"]
+															},
+															"lines": {
+																"type": "array",
+																"items": {
+																	"type": "object",
+																	"properties": {
+																		"ts": {
+																			"type": "string"
+																		},
+																		"stream": {
+																			"type": "string",
+																			"enum": ["stdout", "stderr"]
+																		},
+																		"text": {
+																			"type": "string"
+																		}
+																	},
+																	"required": ["ts", "stream", "text"]
+																}
+															},
+															"gap": {
+																"type": "boolean"
+															},
+															"checkedAt": {
+																"type": "string"
+															},
+															"expiry": {
+																"type": "string"
+															},
+															"createdAt": {
+																"type": "string"
+															},
+															"updatedAt": {
+																"type": "string"
+															}
+														},
+														"required": ["id", "metadata", "lines", "gap", "checkedAt", "expiry", "createdAt", "updatedAt"]
+													}
+												},
+												"nextCursor": {
+													"type": "string",
+													"nullable": true
+												}
+											},
+											"required": ["logs", "nextCursor"]
 										}
 									},
 									"required": ["success", "msg", "data"]
@@ -8908,9 +9327,6 @@
 									"secret": {
 										"type": "string"
 									},
-									"sshPrivateKey": {
-										"type": "string"
-									},
 									"jsonPath": {
 										"anyOf": [
 											{
@@ -9010,6 +9426,9 @@
 									"geoCheckInterval": {
 										"type": "number",
 										"minimum": 300000
+									},
+									"dockerLogsEnabled": {
+										"type": "boolean"
 									},
 									"dnsServer": {
 										"type": "string",
@@ -9604,9 +10023,6 @@
 												"secret": {
 													"type": "string"
 												},
-												"sshPrivateKey": {
-													"type": "string"
-												},
 												"cpuAlertThreshold": {
 													"type": "number",
 													"default": 100
@@ -9701,6 +10117,10 @@
 													"type": "number",
 													"minimum": 300000,
 													"default": 300000
+												},
+												"dockerLogsEnabled": {
+													"type": "boolean",
+													"default": false
 												},
 												"dnsServer": {
 													"type": "string",
@@ -10137,9 +10557,6 @@
 									"secret": {
 										"type": "string"
 									},
-									"sshPrivateKey": {
-										"type": "string"
-									},
 									"ignoreTlsErrors": {
 										"type": "boolean"
 									},
@@ -10268,6 +10685,9 @@
 									"geoCheckInterval": {
 										"type": "number",
 										"minimum": 300000
+									},
+									"dockerLogsEnabled": {
+										"type": "boolean"
 									},
 									"dnsServer": {
 										"type": "string",
@@ -12930,6 +13350,32 @@
 									"globalProxyId": {
 										"type": "string",
 										"nullable": true
+									},
+									"egressCheckEnabled": {
+										"type": "boolean"
+									},
+									"egressCheckTargets": {
+										"type": "array",
+										"items": {
+											"type": "string",
+											"minLength": 1,
+											"maxLength": 253,
+											"pattern": "^(https?:\\/\\/\\S+|[A-Za-z0-9.\\-:[\\]]+)$"
+										},
+										"minItems": 1,
+										"maxItems": 10
+									},
+									"egressPollIntervalSeconds": {
+										"type": "integer",
+										"minimum": 5,
+										"maximum": 600
+									},
+									"egressNotifications": {
+										"type": "array",
+										"items": {
+											"type": "string",
+											"pattern": "^[a-f\\d]{24}$/i"
+										}
 									}
 								}
 							}

--- a/server/openapi/index.ts
+++ b/server/openapi/index.ts
@@ -2,6 +2,7 @@ import "./registry.js";
 import "./routes/auth.js";
 import "./routes/check.js";
 import "./routes/diagnostic.js";
+import "./routes/egress.js";
 import "./routes/geoCheck.js";
 import "./routes/incident.js";
 import "./routes/invite.js";
@@ -47,6 +48,7 @@ export function getOpenApiSpec(): JsonObject {
 			{ name: "status-page", description: "Public status pages, their configuration, and the monitors they expose." },
 			{ name: "settings", description: "Global application settings (admin/superadmin)." },
 			{ name: "proxies", description: "Outbound proxy servers for routing HTTP monitor checks, team-scoped with an instance-wide admin listing." },
+			{ name: "egress", description: "Instance egress self-check state: whether the server's own outbound connectivity is currently degraded." },
 			{ name: "invite", description: "Team invitations and accepting them." },
 			{ name: "queue", description: "Background job queue introspection and admin actions (admin/superadmin)." },
 			{ name: "diagnostic", description: "System diagnostics for the running server (admin/superadmin)." },

--- a/server/openapi/routes/egress.ts
+++ b/server/openapi/routes/egress.ts
@@ -1,0 +1,14 @@
+import { registry } from "../registry.js";
+import { bearer, okJson, standardErrors } from "../helpers.js";
+import { egressStateResponseSchema } from "@/api/validation/egressValidation.js";
+
+const tags = ["egress"];
+
+registry.registerPath({
+	method: "get",
+	path: "/egress",
+	tags,
+	summary: "Get the instance's current egress self-check state",
+	security: bearer,
+	responses: { "200": okJson(egressStateResponseSchema), ...standardErrors },
+});

--- a/server/src/api/controllers/egressController.ts
+++ b/server/src/api/controllers/egressController.ts
@@ -1,0 +1,22 @@
+import { Request, Response, RequestHandler } from "express";
+import { catchAsync } from "@/utils/catchAsync.js";
+import { IEgressStateService } from "@/domain/egress/egress-state.service.js";
+
+export interface IEgressController {
+	getState: RequestHandler;
+}
+
+class EgressController implements IEgressController {
+	constructor(private egressStateService: IEgressStateService) {}
+
+	getState = catchAsync(async (req: Request, res: Response) => {
+		const state = await this.egressStateService.getState();
+		return res.status(200).json({
+			success: true,
+			msg: "Egress state retrieved successfully",
+			data: state,
+		});
+	});
+}
+
+export default EgressController;

--- a/server/src/api/controllers/settingsController.ts
+++ b/server/src/api/controllers/settingsController.ts
@@ -7,6 +7,7 @@ import { ISettingsService } from "@/domain/app-settings/app-settings.service.js"
 import { IEmailService } from "@/service/emailService.js";
 import { IProxiesService } from "@/domain/proxies/proxy.service.js";
 import { Settings } from "@/domain/app-settings/app-settings.type.js";
+import { INotificationsRepository } from "@/domain/notifications/notification.repository.interface.js";
 
 export interface ISettingsController {
 	getAppSettings: RequestHandler;
@@ -18,10 +19,17 @@ class SettingsController implements ISettingsController {
 	private settingsService: ISettingsService;
 	private emailService: IEmailService;
 	private proxiesService: IProxiesService;
-	constructor(settingsService: ISettingsService, emailService: IEmailService, proxiesService: IProxiesService) {
+	private notificationsRepository: INotificationsRepository;
+	constructor(
+		settingsService: ISettingsService,
+		emailService: IEmailService,
+		proxiesService: IProxiesService,
+		notificationsRepository: INotificationsRepository
+	) {
 		this.settingsService = settingsService;
 		this.emailService = emailService;
 		this.proxiesService = proxiesService;
+		this.notificationsRepository = notificationsRepository;
 	}
 
 	buildAppSettings = async (dbSettings: Settings) => {
@@ -67,6 +75,16 @@ class SettingsController implements ISettingsController {
 			const proxy = await this.proxiesService.getProxySummary(validatedBody.globalProxyId);
 			if (!proxy) {
 				throw new AppError({ message: "Referenced proxy does not exist", status: 422 });
+			}
+		}
+
+		if (validatedBody.egressNotifications && validatedBody.egressNotifications.length > 0) {
+			const requestedIds = [...new Set(validatedBody.egressNotifications)];
+			const notifications = await this.notificationsRepository.findNotificationsByIds(requestedIds);
+			const foundIds = new Set(notifications.map((notification) => notification.id));
+			const missing = requestedIds.filter((id) => !foundIds.has(id));
+			if (missing.length > 0) {
+				throw new AppError({ message: `Referenced notification does not exist: ${missing.join(", ")}`, status: 422 });
 			}
 		}
 

--- a/server/src/api/routes/egressRoutes.ts
+++ b/server/src/api/routes/egressRoutes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { IEgressController } from "@/api/controllers/egressController.js";
+
+// Any authenticated role may read the state: the client banner polls it.
+export const createEgressRoutes = (egressController: IEgressController): Router => {
+	const router = Router();
+	router.get("/", egressController.getState);
+	return router;
+};

--- a/server/src/api/validation/egressValidation.ts
+++ b/server/src/api/validation/egressValidation.ts
@@ -1,0 +1,24 @@
+import { EgressStatuses } from "@/domain/egress/egress.type.js";
+import { z } from "zod";
+
+//****************************************
+// Egress Validations
+//****************************************
+
+export const egressProbeResultResponseSchema = z.object({
+	target: z.string(),
+	reachable: z.boolean(),
+	responseTime: z.number(),
+	message: z.string().optional(),
+});
+
+export const egressStateResponseSchema = z.object({
+	id: z.string(),
+	status: z.enum(EgressStatuses),
+	degradedSince: z.string().nullable(),
+	lastRecoveredAt: z.string().nullable(),
+	lastProbeAt: z.string().nullable(),
+	lastProbeResults: z.array(egressProbeResultResponseSchema),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+});

--- a/server/src/api/validation/index.ts
+++ b/server/src/api/validation/index.ts
@@ -23,3 +23,4 @@ export * from "./userValidation.js";
 export * from "./incidentValidation.js";
 export * from "./tagValidation.js";
 export * from "./proxyValidation.js";
+export * from "./egressValidation.js";

--- a/server/src/api/validation/settingsValidation.ts
+++ b/server/src/api/validation/settingsValidation.ts
@@ -53,7 +53,7 @@ export const updateAppSettingsBodyValidation = z
 		globalProxyId: z.string().nullable().optional(),
 
 		egressCheckEnabled: z.boolean().optional(),
-		egressCheckTargets: z.array(egressTargetValidation).min(1).max(MAX_EGRESS_TARGETS).optional(),
+		egressCheckTargets: z.array(egressTargetValidation).max(MAX_EGRESS_TARGETS).optional(), // empty list falls back to DEFAULT_EGRESS_TARGETS
 		egressPollIntervalSeconds: z.number().int().min(MIN_EGRESS_POLL_INTERVAL_SECONDS).max(MAX_EGRESS_POLL_INTERVAL_SECONDS).optional(),
 		egressNotifications: z.array(z.string().regex(/^[a-f\d]{24}$/i, "Invalid notification id")).optional(),
 	})

--- a/server/src/api/validation/settingsValidation.ts
+++ b/server/src/api/validation/settingsValidation.ts
@@ -1,5 +1,14 @@
 import { CHECK_TTL_SENTINEL } from "@/domain/checks/check.type.js";
+import { MAX_EGRESS_POLL_INTERVAL_SECONDS, MAX_EGRESS_TARGETS, MIN_EGRESS_POLL_INTERVAL_SECONDS } from "@/domain/egress/egress.type.js";
 import { z } from "zod";
+
+// A reliability target is a bare host/IP (ICMP ping), host:port (TCP connect) or an http(s) URL.
+const egressTargetValidation = z
+	.string()
+	.trim()
+	.min(1)
+	.max(253)
+	.regex(/^(https?:\/\/\S+|[A-Za-z0-9.\-:[\]]+)$/, "Invalid egress target");
 
 //****************************************
 // Settings Validations
@@ -42,6 +51,11 @@ export const updateAppSettingsBodyValidation = z
 			.optional(),
 		globalProxyEnabled: z.boolean().optional(),
 		globalProxyId: z.string().nullable().optional(),
+
+		egressCheckEnabled: z.boolean().optional(),
+		egressCheckTargets: z.array(egressTargetValidation).min(1).max(MAX_EGRESS_TARGETS).optional(),
+		egressPollIntervalSeconds: z.number().int().min(MIN_EGRESS_POLL_INTERVAL_SECONDS).max(MAX_EGRESS_POLL_INTERVAL_SECONDS).optional(),
+		egressNotifications: z.array(z.string().regex(/^[a-f\d]{24}$/i, "Invalid notification id")).optional(),
 	})
 	.strip()
 	.superRefine((body, ctx) => {

--- a/server/src/config/controllers.ts
+++ b/server/src/config/controllers.ts
@@ -13,6 +13,7 @@ import TagsController from "../api/controllers/tagController.js";
 import DiagnosticController from "../api/controllers/diagnosticController.js";
 import IncidentController from "../api/controllers/incidentController.js";
 import ProxyController from "@/api/controllers/proxyController.js";
+import EgressController from "@/api/controllers/egressController.js";
 import { ApiServices } from "@/config/services.api.js";
 
 export interface InitializedControllers {
@@ -31,12 +32,18 @@ export interface InitializedControllers {
 	diagnosticController: DiagnosticController;
 	incidentController: IncidentController;
 	proxyController: ProxyController;
+	egressController: EgressController;
 }
 export const initializeControllers = (apiServices: ApiServices): InitializedControllers => {
 	return {
 		authController: new AuthController(apiServices.userService),
 		monitorController: new MonitorController(apiServices.monitorService, apiServices.notificationsService),
-		settingsController: new SettingsController(apiServices.settingsService, apiServices.emailService, apiServices.proxiesService),
+		settingsController: new SettingsController(
+			apiServices.settingsService,
+			apiServices.emailService,
+			apiServices.proxiesService,
+			apiServices.notificationsRepository
+		),
 		checkController: new CheckController(apiServices.checkService),
 		geoCheckController: new GeoCheckController(apiServices.geoChecksService),
 		inviteController: new InviteController(apiServices.inviteService),
@@ -49,5 +56,6 @@ export const initializeControllers = (apiServices: ApiServices): InitializedCont
 		diagnosticController: new DiagnosticController(apiServices.diagnosticService),
 		incidentController: new IncidentController(apiServices.incidentService),
 		proxyController: new ProxyController(apiServices.proxiesService),
+		egressController: new EgressController(apiServices.egressStateService),
 	};
 };

--- a/server/src/config/routes.ts
+++ b/server/src/config/routes.ts
@@ -20,6 +20,7 @@ import { createNotificationRoutes } from "@/api/routes/notificationRoutes.js";
 import { createTagRoutes } from "@/api/routes/tagRoutes.js";
 import { createIncidentRoutes } from "@/api/routes/incidentRoutes.js";
 import { createProxyRoutes } from "@/api/routes/proxyRoutes.js";
+import { createEgressRoutes } from "@/api/routes/egressRoutes.js";
 
 export const setupRoutes = (app: Application, controllers: InitializedControllers, apiServices: ApiServices) => {
 	const verifyJWT = createVerifyJWT(apiServices.settingsService);
@@ -39,6 +40,7 @@ export const setupRoutes = (app: Application, controllers: InitializedController
 	const diagnosticRoutes = createDiagnosticRoutes(controllers.diagnosticController, verifyJWT);
 	const incidentRoutes = createIncidentRoutes(controllers.incidentController);
 	const proxyRoutes = createProxyRoutes(controllers.proxyController);
+	const egressRoutes = createEgressRoutes(controllers.egressController);
 
 	app.use("/api/v1/auth", authApiLimiter, authRoutes);
 	app.use("/api/v1/monitors", verifyJWT, monitorRoutes);
@@ -55,4 +57,5 @@ export const setupRoutes = (app: Application, controllers: InitializedController
 	app.use("/api/v1/diagnostic", verifyJWT, diagnosticRoutes);
 	app.use("/api/v1/incidents", verifyJWT, incidentRoutes);
 	app.use("/api/v1/proxies", verifyJWT, proxyRoutes);
+	app.use("/api/v1/egress", verifyJWT, egressRoutes);
 };

--- a/server/src/config/services.api.ts
+++ b/server/src/config/services.api.ts
@@ -7,6 +7,7 @@ import { ITagsService, TagsService } from "@/domain/tags/tag.service.js";
 import { IUserService, UserService } from "@/domain/users/user.service.js";
 import { IJobScheduler } from "@/worker/worker.interface.js";
 import { ProxiesService, IProxiesService } from "@/domain/proxies/proxy.service.js";
+import { EgressStateService, IEgressStateService } from "@/domain/egress/egress-state.service.js";
 import { SharedServices } from "@/config/services.shared.js";
 
 // Third-party
@@ -24,6 +25,7 @@ export interface ApiServices extends SharedServices {
 	tagsService: ITagsService;
 	diagnosticService: IDiagnosticService;
 	proxiesService: IProxiesService;
+	egressStateService: IEgressStateService;
 }
 
 export const buildApi = (shared: SharedServices, jobScheduler: IJobScheduler): ApiServices => {
@@ -48,6 +50,7 @@ export const buildApi = (shared: SharedServices, jobScheduler: IJobScheduler): A
 		maintenanceWindowsRepository,
 		jobsRepository,
 		proxiesRepository,
+		egressStateRepository,
 	} = shared;
 
 	const userService = new UserService({
@@ -99,6 +102,7 @@ export const buildApi = (shared: SharedServices, jobScheduler: IJobScheduler): A
 	const tagsService = new TagsService(tagsRepository, monitorsRepository);
 	const diagnosticService = new DiagnosticService(db);
 	const proxiesService = new ProxiesService(proxiesRepository, monitorsRepository, settingsService);
+	const egressStateService = new EgressStateService(egressStateRepository);
 	return {
 		...shared,
 		worker: jobScheduler,
@@ -110,5 +114,6 @@ export const buildApi = (shared: SharedServices, jobScheduler: IJobScheduler): A
 		tagsService,
 		diagnosticService,
 		proxiesService,
+		egressStateService,
 	};
 };

--- a/server/src/config/services.shared.ts
+++ b/server/src/config/services.shared.ts
@@ -56,6 +56,7 @@ import { ITagsRepository } from "@/domain/tags/tag.repository.interface.js";
 import { ITeamsRepository } from "@/domain/teams/team.repository.interface.js";
 import { IUsersRepository } from "@/domain/users/user.repository.interface.js";
 import { IProxiesRepository } from "@/domain/proxies/proxy.repository.interface.js";
+import { IEgressStateRepository } from "@/domain/egress/egress-state.repository.interface.js";
 
 // Mongo repository implementations
 import MongoSettingsRepository from "@/domain/app-settings/app-settings.repository.mongo.js";
@@ -76,6 +77,7 @@ import MongoTagsRepository from "@/domain/tags/tag.repository.mongo.js";
 import MongoTeamsRepository from "@/domain/teams/team.repository.model.js";
 import MongoUsersRepository from "@/domain/users/user.repository.mongo.js";
 import MongoProxiesRepository from "@/domain/proxies/proxy.repository.mongo.js";
+import MongoEgressStateRepository from "@/domain/egress/egress-state.repository.mongo.js";
 import { IDockerLogsRepository } from "@/domain/docker/docker-log.repository.interface.js";
 
 // Shared infrastructure + business services that both the API and the worker process construct.
@@ -114,6 +116,7 @@ export interface SharedServices {
 	teamsRepository: ITeamsRepository;
 	maintenanceWindowsRepository: IMaintenanceWindowsRepository;
 	proxiesRepository: IProxiesRepository;
+	egressStateRepository: IEgressStateRepository;
 }
 
 export const buildShared = async ({
@@ -157,6 +160,7 @@ export const buildShared = async ({
 	const teamsRepository = new MongoTeamsRepository();
 	const maintenanceWindowsRepository = new MongoMaintenanceWindowsRepository();
 	const proxiesRepository = new MongoProxiesRepository();
+	const egressStateRepository = new MongoEgressStateRepository();
 
 	// Inject settings repository into settings service (now that DB is connected)
 	(settingsService as SettingsService).setRepository(settingsRepository);
@@ -246,6 +250,7 @@ export const buildShared = async ({
 		teamsRepository,
 		maintenanceWindowsRepository,
 		proxiesRepository,
+		egressStateRepository,
 	};
 	return sharedServices;
 };

--- a/server/src/config/services.worker.ts
+++ b/server/src/config/services.worker.ts
@@ -27,6 +27,7 @@ import { IncidentReactor } from "@/worker/reactors/reactor.incident.js";
 import { ReactorDispatcher } from "@/worker/reactors/reactor.dispatcher.js";
 import { DBQueueWorker } from "@/worker/worker.db-queue.js";
 import { ProxyResolver } from "@/service/network/ProxyResolver.js";
+import { IEgressService, EgressService } from "@/domain/egress/egress.service.js";
 // Network providers
 import { PingProvider } from "@/service/network/PingProvider.js";
 import { HttpProvider } from "@/service/network/HttpProvider.js";
@@ -44,6 +45,7 @@ export interface WorkerServices {
 	networkService: INetworkService;
 	bufferService: IBufferService;
 	statusService: IStatusService;
+	egressService: IEgressService;
 }
 
 export const buildWorker = async (shared: SharedServices, envSettings: EnvConfig): Promise<WorkerServices> => {
@@ -67,6 +69,7 @@ export const buildWorker = async (shared: SharedServices, envSettings: EnvConfig
 		teamsRepository,
 		maintenanceWindowsRepository,
 		proxiesRepository,
+		egressStateRepository,
 	} = shared;
 
 	// ***********************
@@ -100,6 +103,7 @@ export const buildWorker = async (shared: SharedServices, envSettings: EnvConfig
 	const bufferService = new BufferService(logger, checkService, geoChecksService, dockerLogsService, settingsService, jobsRepository);
 	const statusService = new StatusService(logger, monitorsRepository, monitorStatsRepository);
 	const monitorStatusPolicy = new MonitorStatusPolicy();
+	const egressService = new EgressService(settingsService, egressStateRepository, networkService, notificationsService, logger);
 
 	// ***********************
 	// Reactors and dispatcher
@@ -122,9 +126,10 @@ export const buildWorker = async (shared: SharedServices, envSettings: EnvConfig
 		proxyResolver,
 		bufferService,
 		dockerLogsService,
+		egressService,
 		logger
 	);
-	const checkEvaluator = new CheckEvaluator(statusService, monitorStatusPolicy);
+	const checkEvaluator = new CheckEvaluator(statusService, monitorStatusPolicy, logger);
 	const geoCheckPipeline = new GeoChecksPipeline(maintenanceWindowsRepository, geoChecksService, bufferService, logger);
 
 	// ***********************
@@ -164,5 +169,8 @@ export const buildWorker = async (shared: SharedServices, envSettings: EnvConfig
 		workerId,
 	});
 
-	return { worker, networkService, bufferService, statusService };
+	// Resume recovery polling if the instance was mid-episode when it last stopped
+	await egressService.init();
+
+	return { worker, networkService, bufferService, statusService, egressService };
 };

--- a/server/src/domain/app-settings/app-settings.model.ts
+++ b/server/src/domain/app-settings/app-settings.model.ts
@@ -1,5 +1,6 @@
 import { Schema, model, type Types } from "mongoose";
 import type { Settings, SettingsThresholds } from "@/domain/app-settings/app-settings.type.js";
+import { DEFAULT_EGRESS_POLL_INTERVAL_SECONDS, DEFAULT_EGRESS_TARGETS } from "@/domain/egress/egress.type.js";
 
 interface AppSettingsDocument extends Omit<Settings, "id" | "createdAt" | "updatedAt"> {
 	_id: Types.ObjectId;
@@ -42,6 +43,10 @@ const AppSettingsSchema = new Schema<AppSettingsDocument>(
 		globalThresholds: { type: thresholdsSchema },
 		globalProxyEnabled: { type: Boolean, default: false },
 		globalProxyId: { type: String, default: null },
+		egressCheckEnabled: { type: Boolean, default: false },
+		egressCheckTargets: { type: [String], default: () => [...DEFAULT_EGRESS_TARGETS] },
+		egressPollIntervalSeconds: { type: Number, default: DEFAULT_EGRESS_POLL_INTERVAL_SECONDS },
+		egressNotifications: { type: [String], default: () => [] }, // Notification ids, stored as strings like globalProxyId
 	},
 	{ timestamps: true }
 );

--- a/server/src/domain/app-settings/app-settings.repository.mongo.ts
+++ b/server/src/domain/app-settings/app-settings.repository.mongo.ts
@@ -3,6 +3,7 @@ import { ISettingsRepository } from "@/domain/app-settings/app-settings-reposito
 import type { Settings, SettingsUpdate } from "@/domain/app-settings/app-settings.type.js";
 import { AppSettingsModel, type AppSettingsDocument } from "@/domain/app-settings/app-settings.model.js";
 import { toStringId, toDateString } from "@/utils/mongoMappers.js";
+import { DEFAULT_EGRESS_POLL_INTERVAL_SECONDS, DEFAULT_EGRESS_TARGETS } from "@/domain/egress/egress.type.js";
 
 class MongoSettingsRepository implements ISettingsRepository {
 	private toEntity = (doc: AppSettingsDocument): Settings => {
@@ -30,6 +31,10 @@ class MongoSettingsRepository implements ISettingsRepository {
 			globalThresholds: doc.globalThresholds ?? undefined,
 			globalProxyEnabled: doc.globalProxyEnabled ?? false,
 			globalProxyId: doc.globalProxyId ?? undefined,
+			egressCheckEnabled: doc.egressCheckEnabled ?? false,
+			egressCheckTargets: doc.egressCheckTargets ?? [...DEFAULT_EGRESS_TARGETS],
+			egressPollIntervalSeconds: doc.egressPollIntervalSeconds ?? DEFAULT_EGRESS_POLL_INTERVAL_SECONDS,
+			egressNotifications: doc.egressNotifications ?? [],
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/domain/app-settings/app-settings.type.ts
+++ b/server/src/domain/app-settings/app-settings.type.ts
@@ -51,6 +51,11 @@ export interface Settings {
 	globalThresholds?: SettingsThresholds;
 	globalProxyEnabled: boolean;
 	globalProxyId?: string | null;
+	// Egress self-check (see domain/egress)
+	egressCheckEnabled: boolean;
+	egressCheckTargets: string[];
+	egressPollIntervalSeconds: number; // recovery poll cadence while degraded, not a general schedule
+	egressNotifications: string[]; // Notification ids to receive the "egress recovered" alert
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/domain/checks/check.docker.aggregation.ts
+++ b/server/src/domain/checks/check.docker.aggregation.ts
@@ -1,4 +1,4 @@
-import CheckModel from "@/domain/checks/check.model.js";
+import { CheckModel, EXCLUDE_DEGRADED_EGRESS_MATCH } from "@/domain/checks/check.model.js";
 import { DockerContainerStatsBucket, DockerStatsBucket } from "@/domain/checks/check.type.js";
 import mongoose from "mongoose";
 
@@ -9,6 +9,7 @@ export const getDockerTotalChecks = async (monitorId: string, dates: DateRange):
 		"metadata.monitorId": new mongoose.Types.ObjectId(monitorId),
 		"metadata.type": "docker",
 		createdAt: { $gte: dates.start, $lte: dates.end },
+		...EXCLUDE_DEGRADED_EGRESS_MATCH,
 	});
 
 export const getDockerUpChecks = async (monitorId: string, dates: DateRange): Promise<{ totalChecks: number }> => {

--- a/server/src/domain/checks/check.hardware.aggregations.ts
+++ b/server/src/domain/checks/check.hardware.aggregations.ts
@@ -1,4 +1,4 @@
-import { CheckModel } from "@/domain/checks/check.model.js";
+import { CheckModel, EXCLUDE_DEGRADED_EGRESS_MATCH } from "@/domain/checks/check.model.js";
 import mongoose from "mongoose";
 import type { HardwareDiskStats, HardwareNetStats } from "@/domain/checks/check.type.js";
 
@@ -70,6 +70,7 @@ export const getHardwareTotalChecks = async (monitorId: string, dates: DateRange
 		"metadata.monitorId": new mongoose.Types.ObjectId(monitorId),
 		"metadata.type": "hardware",
 		createdAt: { $gte: dates.start, $lte: dates.end },
+		...EXCLUDE_DEGRADED_EGRESS_MATCH,
 	});
 };
 

--- a/server/src/domain/checks/check.model.ts
+++ b/server/src/domain/checks/check.model.ts
@@ -1,6 +1,6 @@
 import { Schema, model, Types } from "mongoose";
 import { MonitorTypes, type MonitorType } from "@/domain/monitors/monitor.type.js";
-import { EgressStatuses } from "@/domain/egress/egress.type.js";
+import { EgressStatuses, type EgressStatus } from "@/domain/egress/egress.type.js";
 import type {
 	Check,
 	CheckAudits,
@@ -365,6 +365,10 @@ CheckSchema.index({ "metadata.teamId": 1, status: 1, createdAt: -1 });
 
 const CheckModel = model<CheckDocument>("Check", CheckSchema);
 
+// Checks recorded while the instance's own egress was down cannot be attributed to the target, so they
+// are left out of every uptime percentage and down-count. Spread this into the $match / filter of any such query.
+const EXCLUDE_DEGRADED_EGRESS_MATCH = { egressStatus: { $ne: "degraded" satisfies EgressStatus } } as const;
+
 export type { CheckDocument, CheckMetadataDocument };
-export { CheckModel, containerSummarySchema };
+export { CheckModel, containerSummarySchema, EXCLUDE_DEGRADED_EGRESS_MATCH };
 export default CheckModel;

--- a/server/src/domain/checks/check.model.ts
+++ b/server/src/domain/checks/check.model.ts
@@ -1,5 +1,6 @@
 import { Schema, model, Types } from "mongoose";
 import { MonitorTypes, type MonitorType } from "@/domain/monitors/monitor.type.js";
+import { EgressStatuses } from "@/domain/egress/egress.type.js";
 import type {
 	Check,
 	CheckAudits,
@@ -335,6 +336,11 @@ const CheckSchema = new Schema<CheckDocument>(
 		},
 		containerSummary: {
 			type: containerSummarySchema,
+			default: undefined,
+		},
+		egressStatus: {
+			type: String,
+			enum: EgressStatuses,
 			default: undefined,
 		},
 	},

--- a/server/src/domain/checks/check.repository.mongo.ts
+++ b/server/src/domain/checks/check.repository.mongo.ts
@@ -178,6 +178,7 @@ class MongoChecksRepository implements IChecksRepository {
 			audits: mapAudits(doc.audits),
 			containers: doc.containers,
 			containerSummary: doc.containerSummary,
+			...(doc.egressStatus !== undefined && { egressStatus: doc.egressStatus }),
 			createdAt: toDateString(doc.createdAt),
 			updatedAt: toDateString(doc.updatedAt),
 		};

--- a/server/src/domain/checks/check.repository.mongo.ts
+++ b/server/src/domain/checks/check.repository.mongo.ts
@@ -15,7 +15,7 @@ import type {
 	HardwareCheckStats,
 } from "@/domain/checks/check.type.js";
 import type { MonitorType } from "@/domain/monitors/monitor.type.js";
-import { CheckModel, type CheckDocument } from "@/domain/checks/check.model.js";
+import { CheckModel, EXCLUDE_DEGRADED_EGRESS_MATCH, type CheckDocument } from "@/domain/checks/check.model.js";
 import mongoose from "mongoose";
 import { getDateFormat, getDateForRange } from "@/utils/dataUtils.js";
 import { ILogger } from "@/utils/logger.js";
@@ -348,6 +348,7 @@ class MongoChecksRepository implements IChecksRepository {
 		const baseMatch = {
 			"metadata.teamId": new mongoose.Types.ObjectId(teamId),
 			createdAt: { $gte: getDateForRange(dateRange) },
+			...EXCLUDE_DEGRADED_EGRESS_MATCH,
 		};
 
 		const [totalResult, downResult] = await Promise.all([
@@ -380,6 +381,7 @@ class MongoChecksRepository implements IChecksRepository {
 				$match: {
 					"metadata.monitorId": { $in: objectIds },
 					createdAt: { $gte: windowStart },
+					...EXCLUDE_DEGRADED_EGRESS_MATCH,
 				},
 			},
 			{
@@ -467,6 +469,8 @@ class MongoChecksRepository implements IChecksRepository {
 			{
 				$facet: {
 					uptimePercentage: [
+						// Response-time series (groupedUpChecks / groupedDownChecks) deliberately keep degraded checks so they still show as failures on the graph.
+						{ $match: EXCLUDE_DEGRADED_EGRESS_MATCH },
 						{
 							$group: {
 								_id: null,

--- a/server/src/domain/checks/check.type.ts
+++ b/server/src/domain/checks/check.type.ts
@@ -1,6 +1,7 @@
 import type { MonitorType } from "@/domain/monitors/monitor.type.js";
 import { DockerContainerInfo, DockerContainerSummary } from "@/domain/docker/docker.type.js";
 import type { Response } from "got";
+import type { EgressStatus } from "@/domain/egress/egress.type.js";
 
 export const CHECK_TTL_SENTINEL = 366;
 
@@ -116,6 +117,9 @@ export interface Check {
 	seo?: number;
 	performance?: number;
 	audits?: CheckAudits;
+	// Set only on checks produced while the reliability probe ran (a failing check).
+	// "degraded" means every reliability target was unreachable, so the failure is not attributable to the monitored target.
+	egressStatus?: EgressStatus;
 	createdAt: string;
 	updatedAt: string;
 }

--- a/server/src/domain/egress/egress-state.model.ts
+++ b/server/src/domain/egress/egress-state.model.ts
@@ -1,0 +1,40 @@
+import { Schema, model, type Types } from "mongoose";
+import { EgressStatuses, type EgressProbeResult, type EgressState } from "@/domain/egress/egress.type.js";
+
+interface EgressStateDocument extends Omit<EgressState, "id" | "degradedSince" | "lastRecoveredAt" | "lastProbeAt" | "createdAt" | "updatedAt"> {
+	_id: Types.ObjectId;
+	singleton: boolean;
+	degradedSince: Date | null;
+	lastRecoveredAt: Date | null;
+	lastProbeAt: Date | null;
+	createdAt: Date;
+	updatedAt: Date;
+}
+
+const probeResultSchema = new Schema<EgressProbeResult>(
+	{
+		target: { type: String, required: true },
+		reachable: { type: Boolean, required: true },
+		responseTime: { type: Number, default: 0 },
+		message: { type: String },
+	},
+	{ _id: false }
+);
+
+const EgressStateSchema = new Schema<EgressStateDocument>(
+	{
+		singleton: { type: Boolean, required: true, unique: true, default: true },
+		status: { type: String, enum: EgressStatuses, required: true, default: "ok" },
+		degradedSince: { type: Date, default: null },
+		lastRecoveredAt: { type: Date, default: null },
+		lastProbeAt: { type: Date, default: null },
+		lastProbeResults: { type: [probeResultSchema], default: () => [] },
+	},
+	{ timestamps: true }
+);
+
+const EgressStateModel = model<EgressStateDocument>("EgressState", EgressStateSchema);
+
+export type { EgressStateDocument };
+export { EgressStateModel };
+export default EgressStateModel;

--- a/server/src/domain/egress/egress-state.repository.interface.ts
+++ b/server/src/domain/egress/egress-state.repository.interface.ts
@@ -1,0 +1,12 @@
+import type { EgressProbeResult, EgressState } from "@/domain/egress/egress.type.js";
+
+export interface IEgressStateRepository {
+	// read
+	findSingleton(): Promise<EgressState>; // creates the "ok" singleton on first call
+	// update
+	recordProbe(results: EgressProbeResult[], now: Date): Promise<EgressState>;
+	// Atomic transitions. Each returns the updated state when this caller performed the transition,
+	// or null when the state was already on the target side (another worker got there first).
+	markDegraded(results: EgressProbeResult[], now: Date): Promise<EgressState | null>;
+	markRecovered(results: EgressProbeResult[], now: Date): Promise<EgressState | null>;
+}

--- a/server/src/domain/egress/egress-state.repository.mongo.ts
+++ b/server/src/domain/egress/egress-state.repository.mongo.ts
@@ -1,0 +1,67 @@
+import { IEgressStateRepository } from "@/domain/egress/egress-state.repository.interface.js";
+import type { EgressProbeResult, EgressState } from "@/domain/egress/egress.type.js";
+import { EgressStateModel, type EgressStateDocument } from "@/domain/egress/egress-state.model.js";
+import { toStringId, toDateString } from "@/utils/mongoMappers.js";
+
+const SERVICE_NAME = "EgressStateRepository";
+
+class MongoEgressStateRepository implements IEgressStateRepository {
+	static SERVICE_NAME = SERVICE_NAME;
+
+	private toEntity = (doc: EgressStateDocument): EgressState => {
+		return {
+			id: toStringId(doc._id),
+			status: doc.status,
+			degradedSince: doc.degradedSince ? toDateString(doc.degradedSince) : null,
+			lastRecoveredAt: doc.lastRecoveredAt ? toDateString(doc.lastRecoveredAt) : null,
+			lastProbeAt: doc.lastProbeAt ? toDateString(doc.lastProbeAt) : null,
+			lastProbeResults: (doc.lastProbeResults ?? []).map((result) => ({
+				target: result.target,
+				reachable: result.reachable,
+				responseTime: result.responseTime ?? 0,
+				...(result.message !== undefined && { message: result.message }),
+			})),
+			createdAt: toDateString(doc.createdAt),
+			updatedAt: toDateString(doc.updatedAt),
+		};
+	};
+
+	findSingleton = async () => {
+		const doc = await EgressStateModel.findOneAndUpdate(
+			{ singleton: true },
+			{ $setOnInsert: { singleton: true, status: "ok" } },
+			{ upsert: true, new: true, setDefaultsOnInsert: true }
+		).lean<EgressStateDocument>();
+		return this.toEntity(doc);
+	};
+
+	recordProbe = async (results: EgressProbeResult[], now: Date) => {
+		const doc = await EgressStateModel.findOneAndUpdate(
+			{ singleton: true },
+			{ $set: { lastProbeAt: now, lastProbeResults: results }, $setOnInsert: { singleton: true, status: "ok" } },
+			{ upsert: true, new: true, setDefaultsOnInsert: true }
+		).lean<EgressStateDocument>();
+		return this.toEntity(doc);
+	};
+
+	markDegraded = async (results: EgressProbeResult[], now: Date) => {
+		// Only the caller that flips ok -> degraded sees a document back; everyone else sees null.
+		const doc = await EgressStateModel.findOneAndUpdate(
+			{ singleton: true, status: "ok" },
+			{ $set: { status: "degraded", degradedSince: now, lastProbeAt: now, lastProbeResults: results } },
+			{ new: true }
+		).lean<EgressStateDocument>();
+		return doc ? this.toEntity(doc) : null;
+	};
+
+	markRecovered = async (results: EgressProbeResult[], now: Date) => {
+		const doc = await EgressStateModel.findOneAndUpdate(
+			{ singleton: true, status: "degraded" },
+			{ $set: { status: "ok", lastRecoveredAt: now, lastProbeAt: now, lastProbeResults: results } },
+			{ new: true }
+		).lean<EgressStateDocument>();
+		return doc ? this.toEntity(doc) : null;
+	};
+}
+
+export default MongoEgressStateRepository;

--- a/server/src/domain/egress/egress-state.service.ts
+++ b/server/src/domain/egress/egress-state.service.ts
@@ -1,0 +1,20 @@
+import { IEgressStateRepository } from "@/domain/egress/egress-state.repository.interface.js";
+import type { EgressState } from "@/domain/egress/egress.type.js";
+
+export interface IEgressStateService {
+	getState(): Promise<EgressState>;
+}
+
+const SERVICE_NAME = "EgressStateService";
+
+// Read-only view of the instance-global egress state for the API process. Transitions are
+// owned by the worker (egress.service.ts); this exists so the controller never touches the repository.
+export class EgressStateService implements IEgressStateService {
+	static SERVICE_NAME = SERVICE_NAME;
+
+	constructor(private egressStateRepository: IEgressStateRepository) {}
+
+	getState = async (): Promise<EgressState> => {
+		return this.egressStateRepository.findSingleton();
+	};
+}

--- a/server/src/domain/egress/egress.service.ts
+++ b/server/src/domain/egress/egress.service.ts
@@ -1,0 +1,293 @@
+import type { Monitor } from "@/domain/monitors/monitor.type.js";
+import type { ISettingsService } from "@/domain/app-settings/app-settings.service.js";
+import type { IEgressStateRepository } from "@/domain/egress/egress-state.repository.interface.js";
+import type { INetworkService } from "@/service/networkService.js";
+import type { INotificationsService } from "@/domain/notifications/notification.service.js";
+import type { ILogger } from "@/utils/logger.js";
+import {
+	DEFAULT_EGRESS_POLL_INTERVAL_SECONDS,
+	DEFAULT_EGRESS_TARGETS,
+	type EgressProbeResult,
+	type EgressStatus,
+} from "@/domain/egress/egress.type.js";
+import { timeRequest } from "@/service/network/utils.js";
+
+const SERVICE_NAME = "EgressService";
+const PROBE_TIMEOUT_MS = 5000;
+
+// Synthetic identity stamped on the probe monitors so provider responses are recognisable in logs.
+const PROBE_MONITOR_ID = "egress-probe";
+const PROBE_TEAM_ID = "system";
+
+// "[host]:port" or "host:port" where host has no colons (so a bare IPv6 address is not mistaken for host:port).
+const HOST_PORT_PATTERN = /^(?:\[([^\]]+)\]|([^:/\s]+)):(\d{1,5})$/;
+
+export interface IEgressService {
+	probeTargets(targets: string[]): Promise<EgressProbeResult[]>;
+	assessAfterFailure(): Promise<EgressStatus | null>;
+	startRecoveryPolling(): void;
+	stop(): void;
+	init(): Promise<void>;
+}
+
+export class EgressService implements IEgressService {
+	static SERVICE_NAME = SERVICE_NAME;
+
+	private polling = false;
+	private pollTimer: NodeJS.Timeout | null = null;
+
+	constructor(
+		private settingsService: ISettingsService,
+		private egressStateRepository: IEgressStateRepository,
+		private networkService: INetworkService,
+		private notificationsService: INotificationsService,
+		private logger: ILogger
+	) {}
+
+	// ****************************
+	// Probing
+	// ****************************
+
+	// Reuses the existing ping/port/http providers by dressing each target up as a minimal monitor.
+	private toProbeMonitor = (target: string): Monitor => {
+		const base = {
+			id: PROBE_MONITOR_ID,
+			teamId: PROBE_TEAM_ID,
+			name: `Egress probe: ${target}`,
+			method: "GET",
+			useAdvancedMatching: false,
+			ignoreTlsErrors: false,
+			customUpCodes: [],
+		};
+
+		if (/^https?:\/\//i.test(target)) {
+			return { ...base, type: "http", url: target } as unknown as Monitor;
+		}
+
+		const hostPort = HOST_PORT_PATTERN.exec(target);
+		if (hostPort) {
+			const host = hostPort[1] ?? hostPort[2];
+			return { ...base, type: "port", url: host, port: Number(hostPort[3]) } as unknown as Monitor;
+		}
+
+		return { ...base, type: "ping", url: target } as unknown as Monitor;
+	};
+
+	private probeTarget = async (target: string): Promise<EgressProbeResult> => {
+		const monitor = this.toProbeMonitor(target);
+		let timer: NodeJS.Timeout | undefined;
+
+		const { response, responseTime, error } = await timeRequest(() =>
+			Promise.race([
+				this.networkService.requestStatus(monitor),
+				new Promise<never>((_, reject) => {
+					timer = setTimeout(() => reject(new Error(`Egress probe timed out after ${PROBE_TIMEOUT_MS}ms`)), PROBE_TIMEOUT_MS);
+				}),
+			]).finally(() => clearTimeout(timer))
+		);
+
+		if (error || !response) {
+			return {
+				target,
+				reachable: false,
+				responseTime,
+				message: error instanceof Error ? error.message : error ? String(error) : "No response",
+			};
+		}
+
+		return {
+			target,
+			reachable: response.status === true,
+			responseTime: response.responseTime ?? responseTime,
+			message: response.message,
+		};
+	};
+
+	probeTargets = async (targets: string[]): Promise<EgressProbeResult[]> => {
+		return await Promise.all(targets.map((target) => this.probeTarget(target)));
+	};
+
+	private resolveTargets = (configured: string[] | undefined): string[] => {
+		const targets = (configured ?? []).map((target) => target.trim()).filter((target) => target.length > 0);
+		// An empty list would make "all unreachable" vacuously true, so fall back to the defaults.
+		return targets.length > 0 ? targets : [...DEFAULT_EGRESS_TARGETS];
+	};
+
+	// ****************************
+	// Event-triggered assessment
+	// ****************************
+
+	assessAfterFailure = async (): Promise<EgressStatus | null> => {
+		try {
+			const settings = await this.settingsService.getDBSettings();
+			if (!settings.egressCheckEnabled) {
+				return null;
+			}
+
+			const state = await this.egressStateRepository.findSingleton();
+			if (state.status === "degraded") {
+				// Recovery detection belongs to the poll loop. Make sure one is running in this process in case
+				// the worker that entered the degraded state is no longer around.
+				this.startRecoveryPolling();
+				return "degraded";
+			}
+
+			const results = await this.probeTargets(this.resolveTargets(settings.egressCheckTargets));
+			const now = new Date();
+
+			if (results.some((result) => result.reachable)) {
+				await this.egressStateRepository.recordProbe(results, now);
+				return "ok";
+			}
+
+			const degraded = await this.egressStateRepository.markDegraded(results, now);
+			this.logger.warn({
+				message: degraded
+					? "Instance egress degraded: every reliability target is unreachable. Monitor failures will not be counted until it recovers"
+					: "Instance egress degraded (transition already recorded by another worker)",
+				service: SERVICE_NAME,
+				method: "assessAfterFailure",
+				details: { results },
+			});
+			this.startRecoveryPolling();
+			return "degraded";
+		} catch (error: unknown) {
+			// The egress check must never break check production; treat an internal failure as "unknown" and carry on.
+			this.logger.error({
+				message: error instanceof Error ? error.message : String(error),
+				service: SERVICE_NAME,
+				method: "assessAfterFailure",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+			return null;
+		}
+	};
+
+	// ****************************
+	// Recovery poll loop
+	// ****************************
+
+	startRecoveryPolling = () => {
+		if (this.polling) {
+			return;
+		}
+		this.polling = true;
+		this.logger.info({ message: "Starting egress recovery polling", service: SERVICE_NAME, method: "startRecoveryPolling" });
+		void this.scheduleNextTick();
+	};
+
+	stop = () => {
+		this.polling = false;
+		if (this.pollTimer) {
+			clearTimeout(this.pollTimer);
+			this.pollTimer = null;
+		}
+	};
+
+	private readPollIntervalMs = async () => {
+		try {
+			const settings = await this.settingsService.getDBSettings();
+			const seconds = settings.egressPollIntervalSeconds;
+			return (Number.isFinite(seconds) && seconds > 0 ? seconds : DEFAULT_EGRESS_POLL_INTERVAL_SECONDS) * 1000;
+		} catch (error: unknown) {
+			this.logger.warn({
+				message: `Could not read egress poll interval, using default: ${error instanceof Error ? error.message : String(error)}`,
+				service: SERVICE_NAME,
+				method: "readPollIntervalMs",
+			});
+			return DEFAULT_EGRESS_POLL_INTERVAL_SECONDS * 1000;
+		}
+	};
+
+	private scheduleNextTick = async () => {
+		if (!this.polling) {
+			return;
+		}
+		const intervalMs = await this.readPollIntervalMs();
+		if (!this.polling) {
+			return;
+		}
+		this.pollTimer = setTimeout(() => void this.tick(), intervalMs);
+		// Never hold the process open for this loop; the state is persisted and init() resumes it on restart.
+		this.pollTimer.unref();
+	};
+
+	private tick = async () => {
+		this.pollTimer = null;
+		if (!this.polling) {
+			return;
+		}
+
+		try {
+			const state = await this.egressStateRepository.findSingleton();
+			if (state.status !== "degraded") {
+				this.logger.info({ message: "Egress no longer degraded, stopping recovery polling", service: SERVICE_NAME, method: "tick" });
+				this.stop();
+				return;
+			}
+
+			const settings = await this.settingsService.getDBSettings();
+			const results = await this.probeTargets(this.resolveTargets(settings.egressCheckTargets));
+			const now = new Date();
+
+			if (!results.some((result) => result.reachable)) {
+				await this.egressStateRepository.recordProbe(results, now);
+				return;
+			}
+
+			const recovered = await this.egressStateRepository.markRecovered(results, now);
+			this.stop();
+			if (!recovered) {
+				// Another process performed the transition and owns the notification.
+				return;
+			}
+
+			this.logger.info({
+				message: `Instance egress recovered (degraded since ${recovered.degradedSince ?? "unknown"})`,
+				service: SERVICE_NAME,
+				method: "tick",
+				details: { results },
+			});
+			await this.notificationsService.sendEgressRecoveredNotification(recovered, settings.egressNotifications ?? []);
+		} catch (error: unknown) {
+			this.logger.error({
+				message: error instanceof Error ? error.message : String(error),
+				service: SERVICE_NAME,
+				method: "tick",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+		} finally {
+			// No-op once stop() has been called; otherwise keep the loop alive through errors.
+			await this.scheduleNextTick();
+		}
+	};
+
+	// ****************************
+	// Lifecycle
+	// ****************************
+
+	init = async () => {
+		try {
+			const settings = await this.settingsService.getDBSettings();
+			if (!settings.egressCheckEnabled) {
+				return;
+			}
+			const state = await this.egressStateRepository.findSingleton();
+			if (state.status === "degraded") {
+				this.logger.warn({
+					message: `Instance egress was degraded at startup (since ${state.degradedSince ?? "unknown"}), resuming recovery polling`,
+					service: SERVICE_NAME,
+					method: "init",
+				});
+				this.startRecoveryPolling();
+			}
+		} catch (error: unknown) {
+			this.logger.error({
+				message: error instanceof Error ? error.message : String(error),
+				service: SERVICE_NAME,
+				method: "init",
+				stack: error instanceof Error ? error.stack : undefined,
+			});
+		}
+	};
+}

--- a/server/src/domain/egress/egress.type.ts
+++ b/server/src/domain/egress/egress.type.ts
@@ -1,0 +1,33 @@
+// Egress self-check: detects loss of the instance's own outbound connectivity so that
+// a burst of simultaneous monitor failures is not reported as a burst of real outages.
+
+export const EgressStatuses = ["ok", "degraded"] as const;
+export type EgressStatus = (typeof EgressStatuses)[number];
+
+// Sensible defaults for a fresh install. Bare hosts are ICMP-pinged, host:port is a TCP connect,
+// http(s):// URLs are fetched. Any one target being reachable means egress is fine.
+export const DEFAULT_EGRESS_TARGETS = ["1.1.1.1", "8.8.8.8"] as const;
+export const DEFAULT_EGRESS_POLL_INTERVAL_SECONDS = 30;
+export const MIN_EGRESS_POLL_INTERVAL_SECONDS = 5;
+export const MAX_EGRESS_POLL_INTERVAL_SECONDS = 600;
+export const MAX_EGRESS_TARGETS = 10;
+
+// Instance-global singleton persisted in MongoDB so that every worker process and the API
+// process share one view of the state (the queue worker may run separately from the API).
+export interface EgressState {
+	id: string;
+	status: EgressStatus;
+	degradedSince: string | null; // ISO timestamp of the current or most recent degraded entry
+	lastRecoveredAt: string | null; // ISO timestamp of the most recent recovery
+	lastProbeAt: string | null; // ISO timestamp of the most recent reliability probe
+	lastProbeResults: EgressProbeResult[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface EgressProbeResult {
+	target: string;
+	reachable: boolean;
+	responseTime: number; // ms
+	message?: string;
+}

--- a/server/src/domain/notifications/notification.message-builder.ts
+++ b/server/src/domain/notifications/notification.message-builder.ts
@@ -1,6 +1,7 @@
 import type { Monitor } from "@/domain/monitors/monitor.type.js";
 import type { HardwareStatusPayload, MonitorStatusResponse } from "@/types/network.js";
 import type { MonitorActionDecision } from "@/worker/worker.helper.js";
+import type { EgressState } from "@/domain/egress/egress.type.js";
 import type {
 	NotificationMessage,
 	NotificationType,
@@ -17,7 +18,17 @@ export interface INotificationMessageBuilder {
 		clientHost: string
 	): NotificationMessage;
 	extractThresholdBreaches(monitor: Monitor, monitorStatusResponse: MonitorStatusResponse): ThresholdBreach[];
+	buildEgressRecoveredMessage(state: EgressState, clientHost: string): NotificationMessage;
 }
+
+// The egress recovery alert is about the instance, not a monitor. Providers all read message.monitor,
+// so it is described with a synthetic MonitorInfo rather than widening the message shape.
+export const EGRESS_MONITOR_INFO = {
+	id: "egress",
+	name: "Checkmate instance egress",
+	type: "system",
+	status: "up",
+} as const;
 
 const SERVICE_NAME = "NotificationMessageBuilder";
 
@@ -86,6 +97,7 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 				return "warning";
 			case "monitor_up":
 			case "threshold_resolved":
+			case "egress_recovered":
 				return "success";
 			case "test":
 				return "info";
@@ -172,6 +184,51 @@ export class NotificationMessageBuilder implements INotificationMessageBuilder {
 			details,
 			timestamp: new Date(),
 		};
+	}
+
+	buildEgressRecoveredMessage(state: EgressState, clientHost: string): NotificationMessage {
+		const recoveredAt = state.lastRecoveredAt ? new Date(state.lastRecoveredAt) : new Date();
+		const degradedSince = state.degradedSince ? new Date(state.degradedSince) : null;
+		const targets = state.lastProbeResults.map((result) => result.target);
+
+		const sinceText = degradedSince ? degradedSince.toISOString() : "an unknown time";
+		const duration = degradedSince ? this.formatDuration(recoveredAt.getTime() - degradedSince.getTime()) : null;
+		const summary = `The Checkmate instance lost outbound connectivity at ${sinceText} and regained it at ${recoveredAt.toISOString()}${duration ? ` (down for ${duration})` : ""}. Monitor checks that failed during this period were not counted as outages.`;
+
+		const details = [`Degraded since: ${sinceText}`, `Recovered at: ${recoveredAt.toISOString()}`];
+		if (duration) {
+			details.push(`Duration: ${duration}`);
+		}
+		details.push(`Targets probed: ${targets.length > 0 ? targets.join(", ") : "none"}`);
+
+		return {
+			type: "egress_recovered",
+			severity: this.determineSeverity("egress_recovered"),
+			monitor: { ...EGRESS_MONITOR_INFO, url: clientHost },
+			content: {
+				title: "Outbound connectivity restored",
+				summary,
+				details,
+				timestamp: recoveredAt,
+			},
+			clientHost,
+			metadata: {
+				teamId: "",
+				notificationReason: "egress_recovered",
+			},
+		};
+	}
+
+	private formatDuration(ms: number): string {
+		const totalSeconds = Math.max(0, Math.round(ms / 1000));
+		const hours = Math.floor(totalSeconds / 3600);
+		const minutes = Math.floor((totalSeconds % 3600) / 60);
+		const seconds = totalSeconds % 60;
+		const parts: string[] = [];
+		if (hours > 0) parts.push(`${hours}h`);
+		if (minutes > 0) parts.push(`${minutes}m`);
+		if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+		return parts.join(" ");
 	}
 
 	private buildDefaultContent(monitor: Monitor): NotificationContent {

--- a/server/src/domain/notifications/notification.service.ts
+++ b/server/src/domain/notifications/notification.service.ts
@@ -10,6 +10,7 @@ import type { ISettingsService } from "@/domain/app-settings/app-settings.servic
 import { ILogger } from "@/utils/logger.js";
 import type { INotificationMessageBuilder } from "@/domain/notifications/notification.message-builder.js";
 import type { NotificationChannel } from "@/domain/notifications/notification.type.js";
+import type { EgressState } from "@/domain/egress/egress.type.js";
 
 export type NotificationProviderRegistry = Record<NotificationChannel, INotificationProvider>;
 
@@ -20,6 +21,9 @@ export interface INotificationsService {
 	updateById(id: string, teamId: string, updateData: Partial<Notification>): Promise<Notification>;
 	deleteById: (id: string, teamId: string) => Promise<Notification>;
 	handleNotifications: (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => Promise<boolean>;
+
+	// Instance-level (not monitor-scoped): sent once when outbound connectivity returns after a degraded egress episode.
+	sendEgressRecoveredNotification: (state: EgressState, notificationIds: string[]) => Promise<boolean>;
 
 	sendTestNotification: (notification: Partial<Notification>) => Promise<boolean>;
 	testAllNotifications: (notificationIds: string[]) => Promise<boolean>;
@@ -60,13 +64,7 @@ export class NotificationsService implements INotificationsService {
 		this.notificationMessageBuilder = notificationMessageBuilder;
 	}
 
-	private send = async (
-		notification: Notification,
-		monitor: Monitor,
-		monitorStatusResponse: MonitorStatusResponse,
-		decision: MonitorActionDecision,
-		notificationMessage: NotificationMessage | undefined
-	): Promise<boolean> => {
+	private send = async (notification: Notification, notificationMessage: NotificationMessage | undefined): Promise<boolean> => {
 		if (!notificationMessage) {
 			this.logger.warn({
 				message: "Notification message not provided",
@@ -98,7 +96,11 @@ export class NotificationsService implements INotificationsService {
 		const clientHost = settings.clientHost || "Host not defined";
 		const notificationMessage = this.notificationMessageBuilder.buildMessage(monitor, monitorStatusResponse, decision, clientHost);
 
-		const tasks = notifications.map((notification) => this.send(notification, monitor, monitorStatusResponse, decision, notificationMessage));
+		return await this.sendToAll(notifications, notificationMessage, "sendNotifications");
+	};
+
+	private sendToAll = async (notifications: Notification[], notificationMessage: NotificationMessage | undefined, method: string) => {
+		const tasks = notifications.map((notification) => this.send(notification, notificationMessage));
 
 		const outcomes = await Promise.all(tasks);
 		const succeeded = outcomes.filter(Boolean).length;
@@ -107,11 +109,29 @@ export class NotificationsService implements INotificationsService {
 			this.logger.warn({
 				message: `Notification send completed with ${succeeded} success, ${failed} failure(s)`,
 				service: SERVICE_NAME,
-				method: "sendNotifications",
+				method,
 			});
 		}
 		// Return true if all notifications succeeded
 		return succeeded === notifications.length;
+	};
+
+	sendEgressRecoveredNotification = async (state: EgressState, notificationIds: string[]) => {
+		const notifications = await this.notificationsRepository.findNotificationsByIds(notificationIds ?? []);
+		if (notifications.length === 0) {
+			this.logger.info({
+				message: "Egress recovered but no notification channels are configured for it",
+				service: SERVICE_NAME,
+				method: "sendEgressRecoveredNotification",
+			});
+			return true;
+		}
+
+		const settings = this.settingsService.getSettings();
+		const clientHost = settings.clientHost || "Host not defined";
+		const notificationMessage = this.notificationMessageBuilder.buildEgressRecoveredMessage(state, clientHost);
+
+		return await this.sendToAll(notifications, notificationMessage, "sendEgressRecoveredNotification");
 	};
 
 	handleNotifications = async (monitor: Monitor, monitorStatusResponse: MonitorStatusResponse, decision: MonitorActionDecision) => {

--- a/server/src/domain/notifications/notification.type.ts
+++ b/server/src/domain/notifications/notification.type.ts
@@ -71,7 +71,8 @@ export interface AlertDiscordPayload {
  * Part of notification system unification effort
  */
 
-export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "test";
+// "egress_recovered" is instance-level rather than monitor-scoped: sent once when the instance regains outbound connectivity.
+export type NotificationType = "monitor_down" | "monitor_up" | "threshold_breach" | "threshold_resolved" | "egress_recovered" | "test";
 
 export type NotificationSeverity = "critical" | "warning" | "info" | "success";
 

--- a/server/src/domain/notifications/providers/email.ts
+++ b/server/src/domain/notifications/providers/email.ts
@@ -92,6 +92,8 @@ export class EmailProvider extends NotificationProvider {
 				return `Monitor ${message.monitor.name} threshold exceeded`;
 			case "threshold_resolved":
 				return `Monitor ${message.monitor.name} thresholds resolved`;
+			case "egress_recovered":
+				return "Checkmate outbound connectivity restored";
 			default:
 				return `Alert: ${message.monitor.name}`;
 		}

--- a/server/src/worker/worker.check-evaluator.ts
+++ b/server/src/worker/worker.check-evaluator.ts
@@ -4,17 +4,52 @@ import { Check } from "@/domain/checks/check.type.js";
 import { Monitor } from "@/domain/monitors/monitor.type.js";
 import { IMonitorStatusPolicy } from "@/worker/worker.monitor-status-policy.js";
 import { IStatusService } from "@/service/statusService.js";
+import { MonitorActionDecision } from "@/worker/worker.helper.js";
+import { ILogger } from "@/utils/logger.js";
 
 export interface ICheckEvaluator {
 	evaluate(status: MonitorStatusResponse, check: Check, monitor: Monitor): Promise<MonitorEvaluation>;
 }
 
+const SERVICE_NAME = "CheckEvaluator";
+
 export class CheckEvaluator implements ICheckEvaluator {
 	constructor(
 		private statusService: IStatusService,
-		private monitorStatusPolicy: IMonitorStatusPolicy
+		private monitorStatusPolicy: IMonitorStatusPolicy,
+		private logger: ILogger
 	) {}
+
+	// A check taken while the instance had no outbound connectivity says nothing about the target.
+	// It is left out of the status window, running stats and monitor status entirely, so that no incident
+	// opens for it and no spurious "resolved"/"up" fires once egress returns.
+	private skipDegradedEgressCheck = (status: MonitorStatusResponse, check: Check, monitor: Monitor): MonitorEvaluation => {
+		this.logger.debug({
+			message: `Skipping evaluation of check ${check.id} for monitor ${monitor.id}: instance egress was degraded`,
+			service: SERVICE_NAME,
+			method: "evaluate",
+		});
+		const decision: MonitorActionDecision = {
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: false,
+			incidentReason: null,
+			notificationReason: null,
+		};
+		return {
+			monitor,
+			status,
+			check,
+			statusChange: { monitor, statusChanged: false, prevStatus: monitor.status, code: status.code, timestamp: Date.now() },
+			decision,
+		};
+	};
+
 	evaluate = async (status: MonitorStatusResponse, check: Check, monitor: Monitor) => {
+		if (check.egressStatus === "degraded") {
+			return this.skipDegradedEgressCheck(status, check, monitor);
+		}
+
 		// ****************************
 		// Step 3:  Evaluate and return result to reactors
 		// ****************************

--- a/server/src/worker/worker.check-producer.ts
+++ b/server/src/worker/worker.check-producer.ts
@@ -11,6 +11,7 @@ import { IMaintenanceWindowsRepository } from "@/domain/maintenance-windows/main
 import { isWindowActive } from "@/utils/maintenanceWindow.js";
 import { IProxyResolver } from "@/service/network/ProxyResolver.js";
 import { IDockerLogsService } from "@/domain/docker/docker-log.service.js";
+import { IEgressService } from "@/domain/egress/egress.service.js";
 
 export interface ICheckProducer {
 	produce(monitor: Monitor): Promise<{ status: MonitorStatusResponse; check: Check } | null>;
@@ -27,6 +28,7 @@ export class CheckProducer implements ICheckProducer {
 		private proxyResolver: IProxyResolver,
 		private bufferService: IBufferService,
 		private dockerLogsService: IDockerLogsService,
+		private egressService: IEgressService,
 		private logger: ILogger
 	) {}
 
@@ -66,6 +68,10 @@ export class CheckProducer implements ICheckProducer {
 			throw new Error("No network response");
 		}
 
+		// Step 1c: On failure, ask whether the instance itself can reach anything before blaming the target.
+		// Null means the egress check is disabled (or failed internally) and the check is treated as usual.
+		const egressStatus = status.status === false ? await this.egressService.assessAfterFailure() : null;
+
 		// ****************************
 		// Step 2: Record
 		// ****************************
@@ -80,6 +86,9 @@ export class CheckProducer implements ICheckProducer {
 				details: { code: status.code, message: status.message },
 			});
 			return null;
+		}
+		if (egressStatus !== null) {
+			check.egressStatus = egressStatus;
 		}
 		// Step 2b: Add to buffer
 		this.bufferService.addToBuffer(check);

--- a/server/test/helpers/heartbeatTestHarness.ts
+++ b/server/test/helpers/heartbeatTestHarness.ts
@@ -129,6 +129,7 @@ export function createHeartbeatTestHarness(): HeartbeatTestHarness {
 	const maintenanceWindowsRepo = { findByMonitorId: jest.fn().mockResolvedValue([]) };
 	const proxyResolver = { resolve: jest.fn().mockResolvedValue(undefined) };
 	const dockerLogsService = { buildDockerLogs: jest.fn().mockResolvedValue([]) };
+	const egressService = { assessAfterFailure: jest.fn().mockResolvedValue(null) };
 
 	const checkProducer = new CheckProducer(
 		monitorsRepo as any,
@@ -138,9 +139,10 @@ export function createHeartbeatTestHarness(): HeartbeatTestHarness {
 		proxyResolver as any,
 		bufferStub as any,
 		dockerLogsService as any,
+		egressService as any,
 		logger
 	);
-	const checkEvaluator = new CheckEvaluator(statusService as any, new MonitorStatusPolicy());
+	const checkEvaluator = new CheckEvaluator(statusService as any, new MonitorStatusPolicy(), logger);
 
 	const notificationReactor = new NotificationReactor(notificationsService as any);
 	const incidentReactor = new IncidentReactor(incidentService as any);

--- a/server/test/unit/services/checkEvaluator.test.ts
+++ b/server/test/unit/services/checkEvaluator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, jest } from "@jest/globals";
 import { CheckEvaluator } from "../../../src/worker/worker.check-evaluator.ts";
 import { MonitorStatusPolicy } from "../../../src/worker/worker.monitor-status-policy.ts";
 import type { Monitor } from "../../../src/domain/monitors/monitor.type.ts";
+import { createMockLogger } from "../../helpers/createMockLogger.ts";
 
 const makeMonitor = (overrides?: Partial<Monitor>): Monitor =>
 	({
@@ -19,9 +20,10 @@ const createEvaluator = (overrides?: Record<string, any>) => {
 			updateMonitorStatus: jest.fn().mockResolvedValue({ monitor: makeMonitor({ status: "up" }), statusChanged: false, prevStatus: "up", code: 200 }),
 		},
 		monitorStatusPolicy: new MonitorStatusPolicy(),
+		logger: createMockLogger(),
 		...overrides,
 	};
-	const evaluator = new CheckEvaluator(defaults.statusService as any, defaults.monitorStatusPolicy as any);
+	const evaluator = new CheckEvaluator(defaults.statusService as any, defaults.monitorStatusPolicy as any, defaults.logger as any);
 	return { evaluator, defaults };
 };
 
@@ -83,5 +85,39 @@ describe("CheckEvaluator", () => {
 			shouldResolveIncident: false,
 			shouldSendNotification: false,
 		});
+	});
+
+	// ── degraded egress ───────────────────────────────────────────────────────
+
+	it("short-circuits a check flagged with degraded egress without touching monitor status", async () => {
+		const status = { monitorId: "m1", status: false, code: 500, message: "Error" } as any;
+		const check = { id: "check-1", egressStatus: "degraded" } as any;
+		const monitor = makeMonitor({ status: "up" });
+		const { evaluator, defaults } = createEvaluator();
+
+		const result = await evaluator.evaluate(status, check, monitor);
+
+		expect(defaults.statusService.updateMonitorStatus).not.toHaveBeenCalled();
+		expect(result.monitor).toBe(monitor);
+		expect(result.statusChange).toMatchObject({ monitor, statusChanged: false, prevStatus: "up", code: 500 });
+		expect(result.statusChange.timestamp).toEqual(expect.any(Number));
+		expect(result.decision).toEqual({
+			shouldCreateIncident: false,
+			shouldResolveIncident: false,
+			shouldSendNotification: false,
+			incidentReason: null,
+			notificationReason: null,
+		});
+		expect(defaults.logger.debug).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("egress was degraded") }));
+	});
+
+	it("evaluates a check flagged with egress ok as normal", async () => {
+		const status = { monitorId: "m1", status: false, code: 500, message: "Error" } as any;
+		const check = { id: "check-1", egressStatus: "ok" } as any;
+		const { evaluator, defaults } = createEvaluator();
+
+		await evaluator.evaluate(status, check, makeMonitor());
+
+		expect(defaults.statusService.updateMonitorStatus).toHaveBeenCalledWith(status, check, expect.anything());
 	});
 });

--- a/server/test/unit/services/checkProducer.test.ts
+++ b/server/test/unit/services/checkProducer.test.ts
@@ -29,6 +29,7 @@ const createProducer = (overrides?: Record<string, any>) => {
 		proxyResolver: { resolve: jest.fn().mockResolvedValue(undefined) },
 		buffer: { addToBuffer: jest.fn() },
 		dockerLogsService: { buildDockerLogs: jest.fn().mockResolvedValue([]) },
+		egressService: { assessAfterFailure: jest.fn().mockResolvedValue(null) },
 		...overrides,
 	};
 	const producer = new CheckProducer(
@@ -39,6 +40,7 @@ const createProducer = (overrides?: Record<string, any>) => {
 		defaults.proxyResolver as any,
 		defaults.buffer as any,
 		defaults.dockerLogsService as any,
+		defaults.egressService as any,
 		defaults.logger as any
 	);
 	return { producer, defaults };
@@ -167,5 +169,63 @@ describe("CheckProducer", () => {
 		await producer.produce(makeMonitor());
 
 		expect(defaults.dockerLogsService.buildDockerLogs).not.toHaveBeenCalled();
+	});
+
+	// ── egress self-check ─────────────────────────────────────────────────────
+
+	const failingStatus = { monitorId: "m1", status: false, code: 500, message: "Error" };
+
+	it("does not consult the egress service for a successful check and leaves the field unset", async () => {
+		const check: Record<string, unknown> = { id: "check-1" };
+		const { producer, defaults } = createProducer({
+			checkService: { toCheck: jest.fn().mockReturnValue(check) },
+		});
+
+		await producer.produce(makeMonitor());
+
+		expect(defaults.egressService.assessAfterFailure).not.toHaveBeenCalled();
+		expect(check).not.toHaveProperty("egressStatus");
+	});
+
+	it("flags a failing check as degraded when the egress service reports degraded egress", async () => {
+		const check: Record<string, unknown> = { id: "check-1" };
+		const { producer, defaults } = createProducer({
+			networkService: { requestStatus: jest.fn().mockResolvedValue(failingStatus) },
+			checkService: { toCheck: jest.fn().mockReturnValue(check) },
+			egressService: { assessAfterFailure: jest.fn().mockResolvedValue("degraded") },
+		});
+
+		const result = await producer.produce(makeMonitor());
+
+		expect(defaults.egressService.assessAfterFailure).toHaveBeenCalledTimes(1);
+		expect(check.egressStatus).toBe("degraded");
+		expect(defaults.buffer.addToBuffer).toHaveBeenCalledWith(expect.objectContaining({ egressStatus: "degraded" }));
+		expect(result?.check.egressStatus).toBe("degraded");
+	});
+
+	it("flags a failing check as ok when the probe found egress fine", async () => {
+		const check: Record<string, unknown> = { id: "check-1" };
+		const { producer } = createProducer({
+			networkService: { requestStatus: jest.fn().mockResolvedValue(failingStatus) },
+			checkService: { toCheck: jest.fn().mockReturnValue(check) },
+			egressService: { assessAfterFailure: jest.fn().mockResolvedValue("ok") },
+		});
+
+		await producer.produce(makeMonitor());
+
+		expect(check.egressStatus).toBe("ok");
+	});
+
+	it("leaves the field unset on a failing check when the egress check is disabled", async () => {
+		const check: Record<string, unknown> = { id: "check-1" };
+		const { producer, defaults } = createProducer({
+			networkService: { requestStatus: jest.fn().mockResolvedValue(failingStatus) },
+			checkService: { toCheck: jest.fn().mockReturnValue(check) },
+		});
+
+		await producer.produce(makeMonitor());
+
+		expect(defaults.egressService.assessAfterFailure).toHaveBeenCalledTimes(1);
+		expect(check).not.toHaveProperty("egressStatus");
 	});
 });

--- a/server/test/unit/services/egressService.test.ts
+++ b/server/test/unit/services/egressService.test.ts
@@ -1,0 +1,406 @@
+import { afterEach, describe, expect, it, jest } from "@jest/globals";
+import { EgressService } from "../../../src/domain/egress/egress.service.ts";
+import type { EgressState } from "../../../src/domain/egress/egress.type.ts";
+import { createMockLogger } from "../../helpers/createMockLogger.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeState = (overrides?: Partial<EgressState>): EgressState => ({
+	id: "egress-1",
+	status: "ok",
+	degradedSince: null,
+	lastRecoveredAt: null,
+	lastProbeAt: null,
+	lastProbeResults: [],
+	createdAt: "2026-01-01T00:00:00.000Z",
+	updatedAt: "2026-01-01T00:00:00.000Z",
+	...overrides,
+});
+
+const makeSettings = (overrides?: Record<string, unknown>) => ({
+	egressCheckEnabled: true,
+	egressCheckTargets: ["1.1.1.1", "8.8.8.8"],
+	egressPollIntervalSeconds: 30,
+	egressNotifications: ["notif-1"],
+	...overrides,
+});
+
+// requestStatus mock that answers per target url
+const statusFor = (reachableTargets: string[]) =>
+	jest.fn().mockImplementation(async (monitor: any) => ({
+		monitorId: monitor.id,
+		teamId: monitor.teamId,
+		type: monitor.type,
+		status: reachableTargets.includes(monitor.url),
+		code: reachableTargets.includes(monitor.url) ? 200 : 5000,
+		message: reachableTargets.includes(monitor.url) ? "Success" : "Ping failed",
+		responseTime: 12,
+	}));
+
+const createService = (overrides?: Record<string, any>) => {
+	const defaults = {
+		settingsService: { getDBSettings: jest.fn().mockResolvedValue(makeSettings()) },
+		egressStateRepository: {
+			findSingleton: jest.fn().mockResolvedValue(makeState()),
+			recordProbe: jest.fn().mockResolvedValue(makeState()),
+			markDegraded: jest.fn().mockResolvedValue(makeState({ status: "degraded", degradedSince: "2026-01-01T10:00:00.000Z" })),
+			markRecovered: jest.fn().mockResolvedValue(makeState({ lastRecoveredAt: "2026-01-01T10:05:00.000Z" })),
+		},
+		networkService: { requestStatus: statusFor(["1.1.1.1", "8.8.8.8"]) },
+		notificationsService: { sendEgressRecoveredNotification: jest.fn().mockResolvedValue(true) },
+		logger: createMockLogger(),
+		...overrides,
+	};
+	const service = new EgressService(
+		defaults.settingsService as any,
+		defaults.egressStateRepository as any,
+		defaults.networkService as any,
+		defaults.notificationsService as any,
+		defaults.logger as any
+	);
+	return { service, defaults };
+};
+
+// Lets the setTimeout chain in startRecoveryPolling settle (settings read, then timer armed) before advancing time.
+const runOneTick = async (intervalMs: number) => {
+	await jest.advanceTimersByTimeAsync(0);
+	await jest.advanceTimersByTimeAsync(intervalMs);
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("EgressService", () => {
+	afterEach(() => {
+		jest.useRealTimers();
+	});
+
+	// ── probeTargets ──────────────────────────────────────────────────────────
+
+	describe("probeTargets", () => {
+		it("maps a bare host to a ping monitor, host:port to a port monitor and a URL to an http monitor", async () => {
+			const { service, defaults } = createService();
+
+			await service.probeTargets(["1.1.1.1", "8.8.8.8:53", "https://example.com/health", "[2606:4700::1111]:443"]);
+
+			const monitors = (defaults.networkService.requestStatus as jest.Mock).mock.calls.map((call) => call[0] as any);
+			expect(monitors).toEqual([
+				expect.objectContaining({ type: "ping", url: "1.1.1.1" }),
+				expect.objectContaining({ type: "port", url: "8.8.8.8", port: 53 }),
+				expect.objectContaining({ type: "http", url: "https://example.com/health", method: "GET", useAdvancedMatching: false }),
+				expect.objectContaining({ type: "port", url: "2606:4700::1111", port: 443 }),
+			]);
+		});
+
+		it("reports reachable only when the provider says status is true", async () => {
+			const { service } = createService({ networkService: { requestStatus: statusFor(["1.1.1.1"]) } });
+
+			const results = await service.probeTargets(["1.1.1.1", "8.8.8.8"]);
+
+			expect(results).toEqual([
+				expect.objectContaining({ target: "1.1.1.1", reachable: true, responseTime: 12 }),
+				expect.objectContaining({ target: "8.8.8.8", reachable: false }),
+			]);
+		});
+
+		it("counts a thrown provider error as unreachable", async () => {
+			const { service } = createService({ networkService: { requestStatus: jest.fn().mockRejectedValue(new Error("ENETUNREACH")) } });
+
+			const results = await service.probeTargets(["1.1.1.1"]);
+
+			expect(results).toEqual([expect.objectContaining({ target: "1.1.1.1", reachable: false, message: "ENETUNREACH" })]);
+		});
+
+		it("counts a hung provider as unreachable once the probe timeout elapses", async () => {
+			jest.useFakeTimers();
+			const { service } = createService({ networkService: { requestStatus: jest.fn().mockReturnValue(new Promise(() => {})) } });
+
+			const pending = service.probeTargets(["1.1.1.1"]);
+			await jest.advanceTimersByTimeAsync(5000);
+			const results = await pending;
+
+			expect(results).toEqual([expect.objectContaining({ target: "1.1.1.1", reachable: false, message: expect.stringContaining("timed out") })]);
+		});
+	});
+
+	// ── assessAfterFailure ────────────────────────────────────────────────────
+
+	describe("assessAfterFailure", () => {
+		it("returns null and does not probe or record when the feature is disabled", async () => {
+			const { service, defaults } = createService({
+				settingsService: { getDBSettings: jest.fn().mockResolvedValue(makeSettings({ egressCheckEnabled: false })) },
+			});
+
+			const result = await service.assessAfterFailure();
+
+			expect(result).toBeNull();
+			expect(defaults.networkService.requestStatus).not.toHaveBeenCalled();
+			expect(defaults.egressStateRepository.findSingleton).not.toHaveBeenCalled();
+			expect(defaults.egressStateRepository.recordProbe).not.toHaveBeenCalled();
+		});
+
+		it("returns ok and records the probe when any target is reachable", async () => {
+			const { service, defaults } = createService({ networkService: { requestStatus: statusFor(["8.8.8.8"]) } });
+
+			const result = await service.assessAfterFailure();
+
+			expect(result).toBe("ok");
+			expect(defaults.egressStateRepository.recordProbe).toHaveBeenCalledWith(
+				[expect.objectContaining({ target: "1.1.1.1", reachable: false }), expect.objectContaining({ target: "8.8.8.8", reachable: true })],
+				expect.any(Date)
+			);
+			expect(defaults.egressStateRepository.markDegraded).not.toHaveBeenCalled();
+		});
+
+		it("marks degraded, warns and returns degraded when every target is unreachable", async () => {
+			jest.useFakeTimers();
+			const { service, defaults } = createService({ networkService: { requestStatus: statusFor([]) } });
+
+			const result = await service.assessAfterFailure();
+
+			expect(result).toBe("degraded");
+			expect(defaults.egressStateRepository.markDegraded).toHaveBeenCalledWith(
+				[expect.objectContaining({ target: "1.1.1.1", reachable: false }), expect.objectContaining({ target: "8.8.8.8", reachable: false })],
+				expect.any(Date)
+			);
+			expect(defaults.egressStateRepository.recordProbe).not.toHaveBeenCalled();
+			expect(defaults.logger.warn).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("egress degraded") }));
+			expect(defaults.logger.info).toHaveBeenCalledWith(expect.objectContaining({ message: "Starting egress recovery polling" }));
+			service.stop();
+		});
+
+		it("returns degraded without probing when the persisted state is already degraded", async () => {
+			jest.useFakeTimers();
+			const { service, defaults } = createService({
+				egressStateRepository: {
+					findSingleton: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					recordProbe: jest.fn(),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn(),
+				},
+			});
+
+			const result = await service.assessAfterFailure();
+
+			expect(result).toBe("degraded");
+			expect(defaults.networkService.requestStatus).not.toHaveBeenCalled();
+			expect(defaults.egressStateRepository.markDegraded).not.toHaveBeenCalled();
+			expect(defaults.egressStateRepository.recordProbe).not.toHaveBeenCalled();
+			service.stop();
+		});
+
+		it("falls back to the default targets when the configured list is empty", async () => {
+			const { service, defaults } = createService({
+				settingsService: { getDBSettings: jest.fn().mockResolvedValue(makeSettings({ egressCheckTargets: [] })) },
+			});
+
+			await service.assessAfterFailure();
+
+			const urls = (defaults.networkService.requestStatus as jest.Mock).mock.calls.map((call) => (call[0] as any).url);
+			expect(urls).toEqual(["1.1.1.1", "8.8.8.8"]);
+		});
+
+		it("returns null and logs when the assessment itself fails", async () => {
+			const { service, defaults } = createService({
+				settingsService: { getDBSettings: jest.fn().mockRejectedValue(new Error("db down")) },
+			});
+
+			const result = await service.assessAfterFailure();
+
+			expect(result).toBeNull();
+			expect(defaults.logger.error).toHaveBeenCalledWith(expect.objectContaining({ message: "db down", method: "assessAfterFailure" }));
+		});
+	});
+
+	// ── recovery polling ──────────────────────────────────────────────────────
+
+	describe("recovery polling", () => {
+		it("marks recovered and sends the notification once when a target becomes reachable", async () => {
+			jest.useFakeTimers();
+			const recovered = makeState({ lastRecoveredAt: "2026-01-01T10:05:00.000Z", degradedSince: "2026-01-01T10:00:00.000Z" });
+			const { service, defaults } = createService({
+				egressStateRepository: {
+					findSingleton: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					recordProbe: jest.fn(),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn().mockResolvedValue(recovered),
+				},
+				networkService: { requestStatus: statusFor(["1.1.1.1"]) },
+			});
+
+			service.startRecoveryPolling();
+			await runOneTick(30_000);
+
+			expect(defaults.egressStateRepository.markRecovered).toHaveBeenCalledTimes(1);
+			expect(defaults.notificationsService.sendEgressRecoveredNotification).toHaveBeenCalledTimes(1);
+			expect(defaults.notificationsService.sendEgressRecoveredNotification).toHaveBeenCalledWith(recovered, ["notif-1"]);
+
+			// Loop has stopped: a further interval produces no more work
+			await runOneTick(30_000);
+			expect(defaults.egressStateRepository.markRecovered).toHaveBeenCalledTimes(1);
+			expect(defaults.notificationsService.sendEgressRecoveredNotification).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not send a notification when another process already recorded the recovery", async () => {
+			jest.useFakeTimers();
+			const { service, defaults } = createService({
+				egressStateRepository: {
+					findSingleton: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					recordProbe: jest.fn(),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn().mockResolvedValue(null),
+				},
+				networkService: { requestStatus: statusFor(["1.1.1.1"]) },
+			});
+
+			service.startRecoveryPolling();
+			await runOneTick(30_000);
+
+			expect(defaults.egressStateRepository.markRecovered).toHaveBeenCalledTimes(1);
+			expect(defaults.notificationsService.sendEgressRecoveredNotification).not.toHaveBeenCalled();
+		});
+
+		it("records the probe and keeps polling while every target stays unreachable", async () => {
+			jest.useFakeTimers();
+			const { service, defaults } = createService({
+				egressStateRepository: {
+					findSingleton: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					recordProbe: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn(),
+				},
+				networkService: { requestStatus: statusFor([]) },
+			});
+
+			service.startRecoveryPolling();
+			await runOneTick(30_000);
+			await runOneTick(30_000);
+
+			expect(defaults.egressStateRepository.recordProbe).toHaveBeenCalledTimes(2);
+			expect(defaults.egressStateRepository.markRecovered).not.toHaveBeenCalled();
+			service.stop();
+		});
+
+		it("stops polling when the persisted state is no longer degraded", async () => {
+			jest.useFakeTimers();
+			const { service, defaults } = createService({
+				egressStateRepository: {
+					findSingleton: jest.fn().mockResolvedValue(makeState({ status: "ok" })),
+					recordProbe: jest.fn(),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn(),
+				},
+			});
+
+			service.startRecoveryPolling();
+			await runOneTick(30_000);
+
+			expect(defaults.networkService.requestStatus).not.toHaveBeenCalled();
+			await runOneTick(30_000);
+			expect(defaults.egressStateRepository.findSingleton).toHaveBeenCalledTimes(1);
+		});
+
+		it("survives a failing tick and reschedules", async () => {
+			jest.useFakeTimers();
+			const findSingleton = jest
+				.fn()
+				.mockRejectedValueOnce(new Error("db blip"))
+				.mockResolvedValue(makeState({ status: "degraded" }));
+			const { service, defaults } = createService({
+				egressStateRepository: {
+					findSingleton,
+					recordProbe: jest.fn().mockResolvedValue(makeState()),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn(),
+				},
+				networkService: { requestStatus: statusFor([]) },
+			});
+
+			service.startRecoveryPolling();
+			await runOneTick(30_000);
+			expect(defaults.logger.error).toHaveBeenCalledWith(expect.objectContaining({ message: "db blip", method: "tick" }));
+
+			await runOneTick(30_000);
+			expect(defaults.egressStateRepository.recordProbe).toHaveBeenCalledTimes(1);
+			service.stop();
+		});
+
+		it("re-reads the poll interval from settings on each tick", async () => {
+			jest.useFakeTimers();
+			const { service, defaults } = createService({
+				settingsService: { getDBSettings: jest.fn().mockResolvedValue(makeSettings({ egressPollIntervalSeconds: 5 })) },
+				egressStateRepository: {
+					findSingleton: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					recordProbe: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn(),
+				},
+				networkService: { requestStatus: statusFor([]) },
+			});
+
+			service.startRecoveryPolling();
+			await runOneTick(5_000);
+
+			expect(defaults.egressStateRepository.recordProbe).toHaveBeenCalledTimes(1);
+			service.stop();
+		});
+
+		it("is idempotent: a second start does not arm a second loop", async () => {
+			jest.useFakeTimers();
+			const { service, defaults } = createService({
+				egressStateRepository: {
+					findSingleton: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					recordProbe: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn(),
+				},
+				networkService: { requestStatus: statusFor([]) },
+			});
+
+			service.startRecoveryPolling();
+			service.startRecoveryPolling();
+			await runOneTick(30_000);
+
+			expect(defaults.egressStateRepository.recordProbe).toHaveBeenCalledTimes(1);
+			service.stop();
+		});
+	});
+
+	// ── init ──────────────────────────────────────────────────────────────────
+
+	describe("init", () => {
+		it("resumes polling when the feature is enabled and the persisted state is degraded", async () => {
+			jest.useFakeTimers();
+			const { service, defaults } = createService({
+				egressStateRepository: {
+					findSingleton: jest.fn().mockResolvedValue(makeState({ status: "degraded" })),
+					recordProbe: jest.fn(),
+					markDegraded: jest.fn(),
+					markRecovered: jest.fn().mockResolvedValue(makeState()),
+				},
+			});
+
+			await service.init();
+
+			expect(defaults.logger.info).toHaveBeenCalledWith(expect.objectContaining({ message: "Starting egress recovery polling" }));
+			service.stop();
+		});
+
+		it("does nothing when the persisted state is ok", async () => {
+			const { service, defaults } = createService();
+
+			await service.init();
+
+			expect(defaults.logger.info).not.toHaveBeenCalled();
+		});
+
+		it("does nothing when the feature is disabled", async () => {
+			const { service, defaults } = createService({
+				settingsService: { getDBSettings: jest.fn().mockResolvedValue(makeSettings({ egressCheckEnabled: false })) },
+			});
+
+			await service.init();
+
+			expect(defaults.egressStateRepository.findSingleton).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/server/test/unit/services/egressStateService.test.ts
+++ b/server/test/unit/services/egressStateService.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import { EgressStateService } from "../../../src/domain/egress/egress-state.service.ts";
+import type { EgressState } from "../../../src/domain/egress/egress.type.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const createEgressStateRepo = () => ({
+	findSingleton: jest.fn(),
+	recordProbe: jest.fn(),
+	markDegraded: jest.fn(),
+	markRecovered: jest.fn(),
+});
+
+const createService = () => {
+	const egressStateRepository = createEgressStateRepo();
+	const service = new EgressStateService(egressStateRepository as any);
+	return { service, egressStateRepository };
+};
+
+const makeState = (overrides?: Partial<EgressState>): EgressState => ({
+	id: "egress-1",
+	status: "ok",
+	degradedSince: null,
+	lastRecoveredAt: null,
+	lastProbeAt: null,
+	lastProbeResults: [],
+	createdAt: "2026-01-01T00:00:00Z",
+	updatedAt: "2026-01-01T00:00:00Z",
+	...overrides,
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("EgressStateService", () => {
+	describe("getState", () => {
+		it("returns the singleton state from the repository", async () => {
+			const { service, egressStateRepository } = createService();
+			const state = makeState({
+				status: "degraded",
+				degradedSince: "2026-01-01T00:05:00Z",
+				lastProbeAt: "2026-01-01T00:05:00Z",
+				lastProbeResults: [{ target: "1.1.1.1", reachable: false, responseTime: 0, message: "timeout" }],
+			});
+			(egressStateRepository.findSingleton as jest.Mock).mockResolvedValue(state);
+
+			const result = await service.getState();
+
+			expect(egressStateRepository.findSingleton).toHaveBeenCalledTimes(1);
+			expect(result).toEqual(state);
+		});
+
+		it("does not call any transition method", async () => {
+			const { service, egressStateRepository } = createService();
+			(egressStateRepository.findSingleton as jest.Mock).mockResolvedValue(makeState());
+
+			await service.getState();
+
+			expect(egressStateRepository.recordProbe).not.toHaveBeenCalled();
+			expect(egressStateRepository.markDegraded).not.toHaveBeenCalled();
+			expect(egressStateRepository.markRecovered).not.toHaveBeenCalled();
+		});
+
+		it("propagates repository errors", async () => {
+			const { service, egressStateRepository } = createService();
+			(egressStateRepository.findSingleton as jest.Mock).mockRejectedValue(new Error("db down"));
+
+			await expect(service.getState()).rejects.toThrow("db down");
+		});
+	});
+});

--- a/server/test/unit/services/notificationMessageBuilder.test.ts
+++ b/server/test/unit/services/notificationMessageBuilder.test.ts
@@ -3,6 +3,7 @@ import { NotificationMessageBuilder } from "../../../src/domain/notifications/no
 import type { Monitor } from "../../../src/domain/monitors/monitor.type.ts";
 import type { MonitorStatusResponse, HardwareStatusPayload } from "../../../src/types/network.ts";
 import type { MonitorActionDecision } from "../../../src/worker/worker.helper.ts";
+import type { EgressState } from "../../../src/domain/egress/egress.type.ts";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -50,6 +51,21 @@ const makeHardwarePayload = (overrides?: Partial<HardwareStatusPayload["data"]>)
 			...overrides,
 		},
 	}) as HardwareStatusPayload;
+
+const makeEgressState = (overrides?: Partial<EgressState>): EgressState => ({
+	id: "egress-1",
+	status: "ok",
+	degradedSince: "2026-01-01T10:00:00.000Z",
+	lastRecoveredAt: "2026-01-01T10:05:30.000Z",
+	lastProbeAt: "2026-01-01T10:05:30.000Z",
+	lastProbeResults: [
+		{ target: "1.1.1.1", reachable: true, responseTime: 12 },
+		{ target: "8.8.8.8", reachable: false, responseTime: 5000, message: "timed out" },
+	],
+	createdAt: "2026-01-01T00:00:00.000Z",
+	updatedAt: "2026-01-01T10:05:30.000Z",
+	...overrides,
+});
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
@@ -757,6 +773,50 @@ describe("NotificationMessageBuilder", () => {
 				expect(metrics).toContain("disk");
 				expect(metrics).toContain("temp");
 			});
+		});
+	});
+
+	// ── buildEgressRecoveredMessage ──────────────────────────────────────
+
+	describe("buildEgressRecoveredMessage", () => {
+		it("builds a success message describing the instance rather than a monitor", () => {
+			const message = builder.buildEgressRecoveredMessage(makeEgressState(), "https://app.example.com");
+
+			expect(message.type).toBe("egress_recovered");
+			expect(message.severity).toBe("success");
+			expect(message.monitor).toEqual({
+				id: "egress",
+				name: "Checkmate instance egress",
+				url: "https://app.example.com",
+				type: "system",
+				status: "up",
+			});
+			expect(message.clientHost).toBe("https://app.example.com");
+			expect(message.metadata).toEqual({ teamId: "", notificationReason: "egress_recovered" });
+		});
+
+		it("reports degraded-since, recovered-at, duration and the probed targets", () => {
+			const message = builder.buildEgressRecoveredMessage(makeEgressState(), "https://app.example.com");
+
+			expect(message.content.title).toBe("Outbound connectivity restored");
+			expect(message.content.summary).toContain("2026-01-01T10:00:00.000Z");
+			expect(message.content.summary).toContain("2026-01-01T10:05:30.000Z");
+			expect(message.content.summary).toContain("5m 30s");
+			expect(message.content.details).toEqual([
+				"Degraded since: 2026-01-01T10:00:00.000Z",
+				"Recovered at: 2026-01-01T10:05:30.000Z",
+				"Duration: 5m 30s",
+				"Targets probed: 1.1.1.1, 8.8.8.8",
+			]);
+			expect(message.content.timestamp).toEqual(new Date("2026-01-01T10:05:30.000Z"));
+		});
+
+		it("copes with a state that has no degradedSince or probe results", () => {
+			const message = builder.buildEgressRecoveredMessage(makeEgressState({ degradedSince: null, lastProbeResults: [] }), "https://app.example.com");
+
+			expect(message.content.summary).toContain("an unknown time");
+			expect(message.content.details).not.toEqual(expect.arrayContaining([expect.stringContaining("Duration")]));
+			expect(message.content.details).toContain("Targets probed: none");
 		});
 	});
 });

--- a/server/test/unit/services/notificationsService.test.ts
+++ b/server/test/unit/services/notificationsService.test.ts
@@ -5,6 +5,7 @@ import type { Monitor } from "../../../src/domain/monitors/monitor.type.ts";
 import type { Notification } from "../../../src/domain/notifications/notification.type.ts";
 import type { MonitorStatusResponse } from "../../../src/types/network.ts";
 import type { MonitorActionDecision } from "../../../src/worker/worker.helper.ts";
+import type { EgressState } from "../../../src/domain/egress/egress.type.ts";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -32,6 +33,7 @@ const createSettingsService = (clientHost = "https://app.example.com") => ({
 
 const createMessageBuilder = () => ({
 	buildMessage: jest.fn().mockReturnValue({ type: "monitor_down", content: { title: "Down" } }),
+	buildEgressRecoveredMessage: jest.fn().mockReturnValue({ type: "egress_recovered", content: { title: "Restored" } }),
 	extractThresholdBreaches: jest.fn(),
 });
 
@@ -130,6 +132,18 @@ const makeDecision = (overrides?: Partial<MonitorActionDecision>): MonitorAction
 });
 
 const makeStatusResponse = () => ({ monitorId: "mon-1", status: false, code: 500 }) as unknown as MonitorStatusResponse;
+
+const makeEgressState = (overrides?: Partial<EgressState>): EgressState => ({
+	id: "egress-1",
+	status: "ok",
+	degradedSince: "2026-01-01T10:00:00.000Z",
+	lastRecoveredAt: "2026-01-01T10:05:00.000Z",
+	lastProbeAt: "2026-01-01T10:05:00.000Z",
+	lastProbeResults: [],
+	createdAt: "2026-01-01T00:00:00.000Z",
+	updatedAt: "2026-01-01T10:05:00.000Z",
+	...overrides,
+});
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
@@ -308,6 +322,50 @@ describe("NotificationsService", () => {
 			(notificationsRepository.findNotificationsByIds as jest.Mock).mockResolvedValue([makeNotification({ type: "email" })]);
 
 			const result = await service.testAllNotifications(["notif-1"]);
+			expect(result).toBe(false);
+		});
+	});
+
+	// ── sendEgressRecoveredNotification ──────────────────────────────────────
+
+	describe("sendEgressRecoveredNotification", () => {
+		it("builds one egress message and sends it to every resolved notification", async () => {
+			const { service, notificationsRepository, emailProvider, slackProvider, notificationMessageBuilder } = createService();
+			(notificationsRepository.findNotificationsByIds as jest.Mock).mockResolvedValue([
+				makeNotification({ id: "notif-1", type: "email" }),
+				makeNotification({ id: "notif-2", type: "slack" }),
+			]);
+			const state = makeEgressState();
+
+			const result = await service.sendEgressRecoveredNotification(state, ["notif-1", "notif-2"]);
+
+			expect(result).toBe(true);
+			expect(notificationsRepository.findNotificationsByIds).toHaveBeenCalledWith(["notif-1", "notif-2"]);
+			expect(notificationMessageBuilder.buildEgressRecoveredMessage).toHaveBeenCalledTimes(1);
+			expect(notificationMessageBuilder.buildEgressRecoveredMessage).toHaveBeenCalledWith(state, "https://app.example.com");
+			const message = notificationMessageBuilder.buildEgressRecoveredMessage.mock.results[0]?.value;
+			expect(emailProvider.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ id: "notif-1" }), message);
+			expect(slackProvider.sendMessage).toHaveBeenCalledWith(expect.objectContaining({ id: "notif-2" }), message);
+		});
+
+		it("returns true without building a message when no notifications are configured", async () => {
+			const { service, notificationsRepository, notificationMessageBuilder, logger } = createService();
+			(notificationsRepository.findNotificationsByIds as jest.Mock).mockResolvedValue([]);
+
+			const result = await service.sendEgressRecoveredNotification(makeEgressState(), []);
+
+			expect(result).toBe(true);
+			expect(notificationMessageBuilder.buildEgressRecoveredMessage).not.toHaveBeenCalled();
+			expect(logger.info).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining("no notification channels") }));
+		});
+
+		it("returns false when any provider fails", async () => {
+			const { service, notificationsRepository, emailProvider } = createService();
+			emailProvider.sendMessage.mockResolvedValue(false);
+			(notificationsRepository.findNotificationsByIds as jest.Mock).mockResolvedValue([makeNotification({ type: "email" })]);
+
+			const result = await service.sendEgressRecoveredNotification(makeEgressState(), ["notif-1"]);
+
 			expect(result).toBe(false);
 		});
 	});

--- a/server/test/unit/validation/settingsValidation.test.ts
+++ b/server/test/unit/validation/settingsValidation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "@jest/globals";
+import { updateAppSettingsBodyValidation } from "../../../src/api/validation/settingsValidation.ts";
+import { MAX_EGRESS_POLL_INTERVAL_SECONDS, MAX_EGRESS_TARGETS, MIN_EGRESS_POLL_INTERVAL_SECONDS } from "../../../src/domain/egress/egress.type.ts";
+
+const validNotificationId = "64b7f0c2a1d2e3f4a5b6c7d8";
+
+describe("settingsValidation", () => {
+	describe("updateAppSettingsBodyValidation egress fields", () => {
+		it("accepts a full set of valid egress settings", () => {
+			const parsed = updateAppSettingsBodyValidation.parse({
+				egressCheckEnabled: true,
+				egressCheckTargets: ["1.1.1.1", "dns.google:53", "https://example.com/health"],
+				egressPollIntervalSeconds: 30,
+				egressNotifications: [validNotificationId],
+			});
+
+			expect(parsed.egressCheckEnabled).toBe(true);
+			expect(parsed.egressCheckTargets).toEqual(["1.1.1.1", "dns.google:53", "https://example.com/health"]);
+			expect(parsed.egressPollIntervalSeconds).toBe(30);
+			expect(parsed.egressNotifications).toEqual([validNotificationId]);
+		});
+
+		it("accepts a body with no egress fields", () => {
+			expect(() => updateAppSettingsBodyValidation.parse({ checkTTL: 30 })).not.toThrow();
+		});
+
+		it("accepts an empty target list (the worker falls back to the default targets)", () => {
+			expect(updateAppSettingsBodyValidation.parse({ egressCheckTargets: [] }).egressCheckTargets).toEqual([]);
+		});
+
+		it("rejects more targets than the maximum", () => {
+			const targets = Array.from({ length: MAX_EGRESS_TARGETS + 1 }, (_, i) => `10.0.0.${i}`);
+
+			expect(() => updateAppSettingsBodyValidation.parse({ egressCheckTargets: targets })).toThrow();
+		});
+
+		it("rejects targets that are not a host, host:port or http(s) URL", () => {
+			for (const target of ["", "   ", "ftp://example.com", "bad host", "1.1.1.1;rm"]) {
+				expect(() => updateAppSettingsBodyValidation.parse({ egressCheckTargets: [target] })).toThrow();
+			}
+		});
+
+		it("accepts the poll interval boundaries", () => {
+			expect(updateAppSettingsBodyValidation.parse({ egressPollIntervalSeconds: MIN_EGRESS_POLL_INTERVAL_SECONDS }).egressPollIntervalSeconds).toBe(
+				MIN_EGRESS_POLL_INTERVAL_SECONDS
+			);
+			expect(updateAppSettingsBodyValidation.parse({ egressPollIntervalSeconds: MAX_EGRESS_POLL_INTERVAL_SECONDS }).egressPollIntervalSeconds).toBe(
+				MAX_EGRESS_POLL_INTERVAL_SECONDS
+			);
+		});
+
+		it("rejects out-of-range and non-integer poll intervals", () => {
+			for (const interval of [MIN_EGRESS_POLL_INTERVAL_SECONDS - 1, MAX_EGRESS_POLL_INTERVAL_SECONDS + 1, 0, -5, 30.5, "30"]) {
+				expect(() => updateAppSettingsBodyValidation.parse({ egressPollIntervalSeconds: interval })).toThrow();
+			}
+		});
+
+		it("accepts an empty notification list", () => {
+			expect(updateAppSettingsBodyValidation.parse({ egressNotifications: [] }).egressNotifications).toEqual([]);
+		});
+
+		it("rejects notification ids that are not 24-character hex", () => {
+			for (const id of ["not-an-id", "64b7f0c2a1d2e3f4a5b6c7d", "zzzzzzzzzzzzzzzzzzzzzzzz", 123]) {
+				expect(() => updateAppSettingsBodyValidation.parse({ egressNotifications: [id] })).toThrow();
+			}
+		});
+
+		it("rejects a non-boolean enabled flag", () => {
+			expect(() => updateAppSettingsBodyValidation.parse({ egressCheckEnabled: "yes" })).toThrow();
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes

Adds an instance egress self-check so that a loss of outbound connectivity from the Checkmate host is not reported as an outage of every monitored target. Design and discussion are on the issue; this PR is the first implementation, opened as a draft for architecture review.

**Worker**

- When a check fails, `CheckProducer` asks `EgressService` to probe the configured targets (default `1.1.1.1`, `8.8.8.8`; bare host = ICMP, `host:port` = TCP, `http(s)://` = HTTP, via the existing `NetworkService` providers). If none are reachable the check is written with `egressStatus: "degraded"`.
- `CheckEvaluator` short-circuits on a degraded check: no status change, no incident, no notification, and the check stays out of the status window and `MonitorStats`, so monitors do not flip to down and do not fire a spurious "up" on recovery.
- Egress state is a persisted Mongo singleton (`domain/egress/egress-state.*`) with atomic ok→degraded and degraded→ok transitions, so the API and one or more worker processes see the same state and exactly one worker sends the recovery notification.
- While degraded, a dedicated unref'd timer re-probes at `egressPollIntervalSeconds` (default 30 s). On recovery it sends a single `egress_recovered` notification to the channels configured in settings.
- Degraded checks are excluded from uptime percentage aggregations (summary, daily buckets, date-range uptime, hardware and docker totals). Response-time graph series are not filtered.

**API**

- `GET /api/v1/egress` (JWT) returns the current state for the client banner. OpenAPI spec updated.
- `AppSettings` gains `egressCheckEnabled`, `egressCheckTargets`, `egressPollIntervalSeconds`, `egressNotifications`. PATCH validates the notification ids exist.

**Client**

- Admin-only "Egress self-check" card on Settings → Monitoring.
- Banner on every page while egress is degraded, polling `/egress` every 30 s.
- Checks table labels degraded checks.

**Points I'd like a view on**

- PagerDuty treats every notification as an incident, so `egress_recovered` would open one. Suppress for that provider, or leave to the user?
- Probes deliberately bypass the global proxy, on the basis that the question is "can this host reach the internet", not "can the proxy".
- `settingsController` calls `notificationsRepository` directly to verify ids exist. Happy to move that into a service if preferred.

Tested on our cluster: synthetic failure (unreachable targets) shows the banner, flags the checks, opens no incidents, clears within one poll interval of restoring the targets, and sends one Slack recovery message.

Settings card:

<img width="1071" alt="Egress self-check settings card" src="https://github.com/user-attachments/assets/e8ed1fc5-7354-4629-841e-56873219c0cd" />

Banner while degraded:

<img width="1307" alt="Degraded egress banner" src="https://github.com/user-attachments/assets/2afe6225-6c74-48e1-b213-3523272cb9ca" />

Recovery notification:

<img width="460" alt="Slack recovery notification" src="https://github.com/user-attachments/assets/ff2c4df4-52d6-43dd-805f-6c4d9bd6af68" />

## Write your issue number after "Fixes "

Fixes #3937

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [x] (Do not skip this or your PR will be closed) I deployed the application locally.
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR.
- [x] I have added i18n support to visible strings (instead of `<div>Add</div>`, use):

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed. Note: `server/openapi.json` was regenerated with `npm run build:openapi`, and the committed spec was already behind the routes, so the diff there includes some pre-existing drift as well as the new egress route. Happy to trim it to the egress change only if you'd rather.
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [x] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

