### PR TITLE
validate invite token type on registration

### DIFF
--- a/server/src/api/controllers/authController.ts
+++ b/server/src/api/controllers/authController.ts
@@ -5,6 +5,7 @@ import { requireTeamId, requireUserEmail, requireUserId, requireUserRoles } from
 
 import {
 	registrationBodyValidation,
+	registerInviteTokenValidation,
 	loginValidation,
 	recoveryValidation,
 	recoveryTokenBodyValidation,
@@ -48,7 +49,7 @@ class AuthController implements IAuthController {
 
 	registerUser = catchAsync(async (req: Request, res: Response) => {
 		const newUser = req.body.user;
-		const newUserToken = req.body.token;
+		const newUserToken = registerInviteTokenValidation.parse(req.body.token);
 		if (newUser?.email) {
 			const newUserEmail = requireUserEmail(newUser.email);
 			newUser.email = newUserEmail.toLowerCase();

--- a/server/src/api/validation/authValidation.ts
+++ b/server/src/api/validation/authValidation.ts
@@ -23,6 +23,8 @@ export const registrationBodyValidation = z.object({
 	inviteToken: z.string().optional().default(""),
 });
 
+export const registerInviteTokenValidation = z.string().optional().default("");
+
 export const recoveryValidation = z.object({
 	email: z.email("Must be a valid email address"),
 });

--- a/server/test/unit/validation/authValidation.test.ts
+++ b/server/test/unit/validation/authValidation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "@jest/globals";
+import { registerInviteTokenValidation } from "../../../src/api/validation/authValidation.ts";
+
+describe("authValidation", () => {
+	describe("registerInviteTokenValidation", () => {
+		it("accepts a valid token string", () => {
+			expect(registerInviteTokenValidation.parse("a".repeat(64))).toBe("a".repeat(64));
+		});
+
+		it("defaults an absent token to an empty string", () => {
+			expect(registerInviteTokenValidation.parse(undefined)).toBe("");
+		});
+
+		it("rejects a NoSQL operator object in place of a token", () => {
+			expect(() => registerInviteTokenValidation.parse({ $ne: null })).toThrow();
+		});
+
+		it("rejects an array token", () => {
+			expect(() => registerInviteTokenValidation.parse(["a", "b"])).toThrow();
+		});
+	});
+});


### PR DESCRIPTION
## Describe your changes

### What

`AuthController.registerUser` reads the invite token from `req.body.token` and forwards it unvalidated (`server/src/api/controllers/authController.ts:51`, pre-fix state). `registrationBodyValidation.parse` only covers `req.body.user` (line 57), so the token never passed through a schema before reaching `MongoInvitesRepository.findByTokenAndDelete({ token })` (`server/src/domain/invites/invite.repository.mongo.ts:40`), where Mongoose accepts the value at face value regardless of its runtime type.

### Why

Every other place in this controller that reads a bare token or credential field validates it with a zod schema first. `loginUser` runs `loginValidation.parse(req.body)` (string `password`) before calling the service (`authController.ts:88`, service call on `:89`); `validateRecovery` and `resetPassword` run `recoveryTokenBodyValidation` / `newPasswordValidation` (`recoveryToken: z.string()`) before reading `req.body.recoveryToken` (`:136` and `:145`); `InviteController.verifyInviteToken` runs `inviteVerificationBodyValidation` (`token: z.string()`) before reading `req.body.token` (`inviteController.ts:55`). `registerUser` was the only one of these paths skipping that step for its token field, even though the same file already declares an unused `inviteToken: z.string()` inside `registrationBodyValidation`.

### How

Added `registerInviteTokenValidation` (`z.string().optional().default("")`) to `server/src/api/validation/authValidation.ts`, using the same default already applied to the neighboring `inviteToken` field. `registerUser` now runs `const newUserToken = registerInviteTokenValidation.parse(req.body.token)` before the value reaches `userService.registerUser` and `findByTokenAndDelete`, so a non-string value throws before it gets anywhere near the query layer. This mirrors the existing `registrationBodyValidation.parse(newUser)` call five lines below in the same function.

Left unchanged: the rest of `registerUser`, `userService.registerUser`, and the invite repository, since the gap was only at the controller validation boundary. Checked the other controllers under `server/src/api/controllers` for the same raw-body-into-query pattern; found none unvalidated.

### Testing

- `npx jest test/unit` (server): 80 suites, 1632 tests pass
- New `server/test/unit/validation/authValidation.test.ts`: fails against the unpatched validation module (missing export) and passes with the fix, 4/4
- `npm run build` and `npm run format-check`: clean
- `npm run lint`: one pre-existing error in `server/src/config/services.worker.ts` (unused `ISecretsRotationService` import), unrelated to this change and present identically on unmodified `develop`

### References

GHSA-75h7-m6r5-fr5p ([found during penetration test](https://www.turingpoint.de/en/security-assessments/pentests/) by [turingpoint](https://www.turingpoint.de), reported privately, unpublished at time of writing)

## Write your issue number after "Fixes "

Fixes n/a

## Please ensure all items are checked off before requesting a review. "Checked off" means you need to add an "x" character between brackets so they turn into checkmarks.

- [ ] (Do not skip this or your PR will be closed) I deployed the application locally. (not done in this pass, only `npm run build`/`test`/`lint` against the server package, no full stack with MongoDB was started; please verify before merge)
- [x] (Do not skip this or your PR will be closed) I have performed a self-reviewing and testing of my code.
- [ ] I have included the issue # in the PR. (n/a, no tracked issue)
- [ ] I have added i18n support to visible strings (instead of `<div>Add</div>`, use): (n/a, no user-facing strings changed)

```Javascript
const { t } = useTranslation();
<div>{t('add')}</div>
```

- [x] I have **not** included any files that are not related to my pull request, including package-lock and package-json if dependencies have not changed
- [x] I didn't use any hardcoded values (otherwise it will not scale, and will make it difficult to maintain consistency across the application).
- [ ] I made sure font sizes, color choices etc are all referenced from the theme. I don't have any hardcoded dimensions. (n/a, backend-only change)
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories, which automatically formats your code.
- [ ] I took a screenshot or a video and attached to this PR if there is a UI change. (n/a, no UI change)