### PR TITLE
fix:improve scroll style in docker logs section

### DIFF
--- a/client/src/Pages/Docker/ContainerDetails/TabLogs.tsx
+++ b/client/src/Pages/Docker/ContainerDetails/TabLogs.tsx
@@ -38,6 +38,7 @@ interface TabLogsProps {
 
 const SCROLL_PIN_THRESHOLD_PX = 8;
 const TAIL_POLL_MS = 10_000;
+const SCROLLBAR_SIZE = 16;
 
 const isScrolledToBottom = (el: HTMLElement) =>
 	el.scrollHeight - el.scrollTop - el.clientHeight <= SCROLL_PIN_THRESHOLD_PX;
@@ -213,7 +214,25 @@ export const TabLogs = ({ monitorId, containerName, enabled }: TabLogsProps) => 
 				maxHeight="50vh"
 				overflow="auto"
 				padding={LAYOUT.MD}
-				sx={{ overflowAnchor: "none" }}
+				sx={{
+					overflowAnchor: "none",
+					scrollbarWidth: "auto",
+					scrollbarColor: "#11715b rgba(0,0,0,0.15)",
+					"&::-webkit-scrollbar": {
+						display: "block",
+						width: `${SCROLLBAR_SIZE}px`,
+						height: `${SCROLLBAR_SIZE}px`,
+					},
+					"&::-webkit-scrollbar-track": {
+						background: "rgba(0,0,0,0.15)",
+						borderRadius: "2px",
+					},
+					"&::-webkit-scrollbar-thumb": {
+						background: "#11715b",
+						borderRadius: "2px",
+					},
+					"&::-webkit-scrollbar-button": { display: "none" },
+				}}
 			>
 				{rows.length > 0 && (
 					<Stack


### PR DESCRIPTION
## Describe your changes

Styles the scrollbar in the Docker container logs view (`TabLogs`) with a custom webkit/Firefox scrollbar:

- **Color**: uses `#11715b` (project brand green) for the thumb and track background
- **Size**: `16px` width/height, controlled via a `SCROLLBAR_SIZE` constant for easy adjustment
- **No arrow buttons**: hidden to match VS Code's clean scrollbar style
- **Track**: subtle `rgba(0,0,0,0.15)` background so the scrollbar area is visible
- **Cross-browser**: uses both `scrollbarColor`/`scrollbarWidth` (Firefox) and `::-webkit-scrollbar` pseudo-elements (Chrome/Safari), with explicit `px` string values and `display: block` to ensure the width renders correctly on macOS Chrome

Note on the hardcoded color: #11715b is used directly rather than theme.palette.primary.main because the scrollbar pseudo-element selectors don't support MUI theme token interpolation at runtime — the value matches brandGreen from the project palette exactly. You may want to flag this for the reviewer.

<img width="2816" height="1324" alt="image" src="https://github.com/user-attachments/assets/da04f125-b77b-4fab-9fa1-61c314945487" />

## Please ensure all items are checked off before requesting a review.

- [x] I deployed the application locally.
- [x] I have performed a self-reviewing and testing of my code.
- [x] I have included the issue # in the PR (no issue related)
- [x] I have added i18n support to visible strings — no new user-facing strings introduced.
- [x] I have **not** included any files that are not related to my pull request.
- [x] My PR is granular and targeted to one specific feature.
- [x] I ran `npm run format` in server and client directories.
- [x] I took a screenshot or a video and attached to this PR if there is a UI change.

